### PR TITLE
Fix rage_view tag not working

### DIFF
--- a/addons/sourcemod/scripting/vsh/hud.sp
+++ b/addons/sourcemod/scripting/vsh/hud.sp
@@ -30,7 +30,7 @@ public void Hud_Think(int iClient)
 		{
 			for (int iBoss = 1; iBoss <= MaxClients; iBoss++)
 			{
-				SaxtonHaleBase boss = SaxtonHaleBase(iClient);
+				SaxtonHaleBase boss = SaxtonHaleBase(iBoss);
 				if (IsClientInGame(iBoss) && IsPlayerAlive(iBoss) && boss.bValid && !boss.bMinion)
 				{
 					int iRage = RoundToFloor(float(boss.iRageDamage) / float(boss.iMaxRageDamage) * 100.0);


### PR DESCRIPTION
It's checking client itself for valid boss, rather than looping every bosses in server.
Thanks to @Blazephlozard for finding this bug.