### PR TITLE
Remove crouch as a valid ability button

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -104,7 +104,7 @@ methodmap CBraveJump < SaxtonHaleBase
 		if (this.iJumpCharge > 0)
 			Format(sMessage, sizeof(sMessage), "Jump charge: %0.2f%%. Look up and stand up to use super-jump.", (float(this.iJumpCharge)/float(this.iMaxJumpCharge))*100.0);
 		else
-			Format(sMessage, sizeof(sMessage), "Hold right click or crouch to use your super-jump!");
+			Format(sMessage, sizeof(sMessage), "Hold right click to use your super-jump!");
 		
 		if (g_flJumpCooldownWait[this.iClient] != 0.0 && g_flJumpCooldownWait[this.iClient] > GetGameTime())
 		{
@@ -127,13 +127,13 @@ methodmap CBraveJump < SaxtonHaleBase
 	
 	public void OnButtonHold(int button)
 	{
-		if ((button == IN_DUCK) || (button == IN_ATTACK2))
+		if (button == IN_ATTACK2)
 			g_bBraveJumpHoldingChargeButton[this.iClient] = true;
 	}
 	
 	public void OnButtonRelease(int button)
 	{
-		if ((button == IN_DUCK) || (button == IN_ATTACK2))
+		if (button == IN_ATTACK2)
 		{
 			if (TF2_IsPlayerInCondition(this.iClient, TFCond_Dazed))//Can't jump if stunned
 				return;

--- a/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
@@ -88,9 +88,9 @@ methodmap CTeleportSwap < SaxtonHaleBase
 		
 		char sMessage[255];
 		if (this.iCharge > 0)
-			Format(sMessage, sizeof(sMessage), "Jump charge: %0.2f%%. Look up and stand up to use teleport-swap.", (float(this.iCharge)/float(this.iMaxCharge))*100.0);
+			Format(sMessage, sizeof(sMessage), "Teleport-swap: %0.2f%%. Look up and stand up to use teleport-swap.", (float(this.iCharge)/float(this.iMaxCharge))*100.0);
 		else
-			Format(sMessage, sizeof(sMessage), "Hold right click or crouch to use your super-jump!");
+			Format(sMessage, sizeof(sMessage), "Hold right click to use your teleport-swap!");
 		
 		if (g_flTeleportSwapCooldownWait[this.iClient] != 0.0 && g_flTeleportSwapCooldownWait[this.iClient] > GetGameTime())
 		{
@@ -113,13 +113,13 @@ methodmap CTeleportSwap < SaxtonHaleBase
 	
 	public void OnButtonHold(int button)
 	{
-		if ((button == IN_DUCK) || (button == IN_ATTACK2))
+		if (button == IN_ATTACK2)
 			g_bTeleportSwapHoldingChargeButton[this.iClient] = true;
 	}
 	
 	public void OnButtonRelease(int button)
 	{
-		if ((button == IN_DUCK) || (button == IN_ATTACK2))
+		if (button == IN_ATTACK2)
 		{
 			if (TF2_IsPlayerInCondition(this.iClient, TFCond_Dazed))//Can't teleport-swap if stunned
 				return;


### PR DESCRIPTION
Both right click and crouch can be used for super-jump and teleport-swap ability, but we all know right click is much better than crouch. As crouch makes you, crouch and cant really walk much. Really only here for legacy reasons.

Now if we remove crouch as a valid ability button, this may help new players learn to use right click instead of crouch, but do they know right click is a thing? Hud already tells you to use right click for ability, but would they read?

Only super-jump and teleport-swap uses crouch as a ability button. Also fix lazy copy-paste with teleport-swap using super-jump words