### PR TITLE
Add config "clip" to force set clip size on spawn

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -5,6 +5,7 @@
 //tags          - List of custom attributes to weapon
 //minicrit      - Give minicrit when holding weapon
 //crit          - Give crit when holding weapon
+//clip          - Set given clip size on spawn
 //
 //List of ways to have weapon call event for various tags
 //- Drink consumed for said weapon
@@ -401,6 +402,7 @@
 		{
 			"desp"			"Loose Cannon: {negative}-50% clip size, -33% longer reload time"
 			"attrib"		"3 ; 0.5 ; 96 ; 1.33"
+			"clip"			"2"
 		}
 		"308"	//Loch-n-load
 		{

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1581,14 +1581,18 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 								TF2Attrib_SetByDefIndex(iWeapon, StringToInt(atts[j]), StringToFloat(atts[j+1]));
 
 							TF2Attrib_ClearCache(iWeapon);
-
-							//Reset max ammo after giving attribs
-							if (HasEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType") && GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType") > -1)
-							{
-								int iClip = SDK_GetMaxClip(iWeapon);
-								if (iClip > 0) SetEntProp(iWeapon, Prop_Send, "m_iClip1", iClip);
-							}
 						}
+						
+						// Set clip size to weapon in both class slot and specific index
+						int iClip = -1;
+						switch (i)
+						{
+							case 0: iClip = g_ConfigClass[nClass][iSlot].GetClip();
+							case 1: iClip = g_ConfigIndex.GetClip(iIndex);
+						}
+						
+						if (iClip > -1)
+							SetEntProp(iWeapon, Prop_Send, "m_iClip1", iClip);
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/vsh/config.sp
+++ b/addons/sourcemod/scripting/vsh/config.sp
@@ -79,6 +79,16 @@ methodmap ConfigClass < StringMap
 		
 		else return -1;
 	}
+	
+	//Return clip size class slot should have on spawn, -1 if not specified
+	public int GetClip()
+	{
+		char sValue[MAXLEN_CONFIG_VALUE];
+		if (this.GetString("clip", sValue, sizeof(sValue)))
+			return StringToInt(sValue);
+		
+		else return -1;
+	}
 };
 
 methodmap ConfigIndex < ArrayList
@@ -228,6 +238,19 @@ methodmap ConfigIndex < ArrayList
 			return StringToInt(sValue);
 		
 		return -1;
+	}
+	
+	//Return clip size weapon index should have on spawn, -1 if not specified
+	public int GetClip(int iIndex)
+	{
+		StringMap sMap = this.GetStringMap(iIndex);
+		if (sMap == null) return -1;
+		
+		char sValue[MAXLEN_CONFIG_VALUE];
+		if (sMap.GetString("clip", sValue, sizeof(sValue)))
+			return StringToInt(sValue);
+		
+		else return -1;
 	}
 };
 


### PR DESCRIPTION
Currently, clip size on spawn does not get refreshed after applying attributes from config, so `SDK_GetMaxClip` is used to get new max clip size value to set. However this is a problem to weapons that meant to start with 0 clip size (beggars bazooka, old panic attack), spawned with fully loaded weapon and forced to fire. So we use new config value "clip" to force set when needed.

We could instead check if weapon have any one of the attrib with starting clip size 0 (attrib 413, 441, 710), but there a few attribs to check, and who knows if valve updates TF2 with more weapon/attribs to break clip-size.