### PR TITLE
Panic Attack: +30% faster firing speed, hold fire required to load shells

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -228,6 +228,12 @@
 	{
 		// MULTI CLASS
 
+		"1153"	//Panic Attack
+		{
+			"desp"			"Panic Attack: {positive}+30% faster firing speed, {negative}hold fire required to load shells"
+			"attrib"		"6 ; 0.7 ; 710 ; 1.0"
+			"clip"			"0"
+		}
 		"357"	//Half-Zatoichi
 		{
 			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, {negative}marked-for-death while active"


### PR DESCRIPTION
This new stat somewhat brings back old panic attack, but still have all of TF2 stats.
New panic attack now requires you to load up to 6 shells, and fire +30% faster.
`+30% faster firing speed` could be replaced to `Fire rate increases as health decreases`, but in VSH you likely to be 1-2 shot killed so that doesn't help much.

Requires PR #11 to fix having 6 clip size on spawn, when it meant to be 0