### PR TITLE
Use private forwards to call boss function hooks

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -274,8 +274,6 @@ typeset SaxtonHaleHookCallback
 /**
  * Hook a boss function to use when function get called. Also allows to override return and params before returning real value
  *
- * @note Make sure plugin unhooks a function once unloaded
- *
  * @param sName             Name of function to hook.
  * @param callback          Callback when function get called.
  * @param hookType          Type of hook, pre to call before functions get called, or post to call after functions get called. Overriding return and params work on both pre and post.
@@ -285,6 +283,8 @@ native void SaxtonHale_HookFunction(const char[] sName, SaxtonHaleHookCallback c
 
 /**
  * Unhook a boss function
+ *
+ * @note It is not necessary to unhook a function on plugin end
  *
  * @param sName             Name of function to unhook.
  * @param callback          Callback when function get called.


### PR DESCRIPTION
Using `Call_StartFunction` to call each hooks with `ArrayList` and `DataPack` isn't really the best way to call hook functions, and requires unhooking from sub-plugins so it doesn't error out.

Now using private forward `Call_StartForward` would call all same hooks at once. SM also automatically unhooks a function on plugin unload, not requiring `SaxtonHale_UnhookFunction` to unhook.