### PR TITLE
Allow few natives support connecting clients

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -519,7 +519,7 @@ native bool SaxtonHale_ForceSpecialRound(int iClient = 0, TFClassType nClass = T
  * @param iClient	    	Client to set new preferences
  * @param preferences	    New preferences to set
  * @noreturn
- * @error                   Invalid client index or client not in game
+ * @error                   Invalid client index or client not connected
  */
 native void SaxtonHale_SetPreferences(int iClient, int iPreferences);
 
@@ -529,7 +529,7 @@ native void SaxtonHale_SetPreferences(int iClient, int iPreferences);
  * @param iClient        	Client to set new preferences
  * @param iQueue        	Queue points to set
  * @noreturn
- * @error                   Invalid client index or client not in game
+ * @error                   Invalid client index or client not connected
  */
 native void SaxtonHale_SetQueue(int iClient, int iQueue);
 
@@ -539,7 +539,7 @@ native void SaxtonHale_SetQueue(int iClient, int iQueue);
  * @param iClient           Client to set new winstreak
  * @param iWinstreak    	Winstreak amount to set
  * @noreturn
- * @error                   Invalid client index or client not in game
+ * @error                   Invalid client index or client not connected
  */
 native void SaxtonHale_SetWinstreak(int iClient, int iWinstreak);
 
@@ -556,7 +556,7 @@ native bool SaxtonHale_IsWinstreakEnable();
  * @param iClient        	Client to set admin status
  * @param bEnable        	True if allow to give admin command, false otherwise
  * @noreturn
- * @error                   Invalid client index or client not in game
+ * @error                   Invalid client index or client not connected
  */
 native void SaxtonHale_SetAdmin(int iClient, bool bEnable);
 
@@ -566,7 +566,7 @@ native void SaxtonHale_SetAdmin(int iClient, bool bEnable);
  * @param iClient        	Client to set punishment status
  * @param bEnable        	True if give punishment, false otherwise
  * @noreturn
- * @error                   Invalid client index or client not in game
+ * @error                   Invalid client index or client not connected
  */
 native void SaxtonHale_SetPunishment(int iClient, bool bEnable);
 

--- a/addons/sourcemod/scripting/vsh/cookies.sp
+++ b/addons/sourcemod/scripting/vsh/cookies.sp
@@ -33,6 +33,7 @@ void Cookies_OnClientJoin(int iClient)
 {
 	if (IsFakeClient(iClient))
 	{
+		//Bots dont use cookies
 		Preferences_SetAll(iClient, 0);
 		Queue_SetPlayerPoints(iClient, 0);
 		Winstreak_SetCurrent(iClient, 0);
@@ -41,18 +42,12 @@ void Cookies_OnClientJoin(int iClient)
 	
 	if (g_ConfigConvar.LookupBool("vsh_cookies_preferences"))
 		Cookies_RefreshPreferences(iClient);
-	else
-		Preferences_SetAll(iClient, -1);
 	
 	if (g_ConfigConvar.LookupBool("vsh_cookies_queue"))
 		Cookies_RefreshQueue(iClient);
-	else
-		Queue_SetPlayerPoints(iClient, -1);
 	
 	if (g_ConfigConvar.LookupBool("vsh_cookies_winstreak"))
 		Cookies_RefreshWinstreak(iClient);
-	else
-		Winstreak_SetCurrent(iClient, -1);
 }
 
 void Cookies_RefreshPreferences(int iClient)

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -561,8 +561,8 @@ public int Native_SetPreferences(Handle hPlugin, int iNumParams)
 	
 	if (iClient <= 0 || iClient > MaxClients)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is invalid", iClient);
-	if (!IsClientInGame(iClient))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
+	if (!IsClientConnected(iClient))
+		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", iClient);
 
 	Preferences_SetAll(iClient, iPreferences);
 }
@@ -575,8 +575,8 @@ public int Native_SetQueue(Handle hPlugin, int iNumParams)
 	
 	if (iClient <= 0 || iClient > MaxClients)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is invalid", iClient);
-	if (!IsClientInGame(iClient))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
+	if (!IsClientConnected(iClient))
+		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", iClient);
 
 	Queue_SetPlayerPoints(iClient, iQueue);
 }
@@ -589,8 +589,8 @@ public int Native_SetWinstreak(Handle hPlugin, int iNumParams)
 	
 	if (iClient <= 0 || iClient > MaxClients)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is invalid", iClient);
-	if (!IsClientInGame(iClient))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
+	if (!IsClientConnected(iClient))
+		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", iClient);
 
 	Winstreak_SetCurrent(iClient, iWinstreak);
 }
@@ -609,8 +609,8 @@ public int Native_SetAdmin(Handle hPlugin, int iNumParams)
 	
 	if (iClient <= 0 || iClient > MaxClients)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is invalid", iClient);
-	if (!IsClientInGame(iClient))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
+	if (!IsClientConnected(iClient))
+		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", iClient);
 
 	if (bEnable)
 		Client_AddFlag(iClient, haleClientFlags_Admin);
@@ -626,8 +626,8 @@ public int Native_SetPunishment(Handle hPlugin, int iNumParams)
 	
 	if (iClient <= 0 || iClient > MaxClients)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is invalid", iClient);
-	if (!IsClientInGame(iClient))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
+	if (!IsClientConnected(iClient))
+		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", iClient);
 
 	if (bEnable)
 		Client_AddFlag(iClient, haleClientFlags_Punishment);


### PR DESCRIPTION
Redun's subplugin had some problems trying to use natives while client is connecting, but not in game.

This PR supports the following natives for clients connecting, while not in game:
```
native void SaxtonHale_SetPreferences(int iClient, int iPreferences);
native void SaxtonHale_SetQueue(int iClient, int iQueue);
native void SaxtonHale_SetWinstreak(int iClient, int iWinstreak);
native void SaxtonHale_SetAdmin(int iClient, bool bEnable);
native void SaxtonHale_SetPunishment(int iClient, bool bEnable);
```

Also default admin check should've been in `OnClientPostAdminCheck` instead of `OnClientPutInServer`, whoops