### PR TITLE
Fix legacy enum struct compile warning

### DIFF
--- a/addons/sourcemod/scripting/vsh/classlimit.sp
+++ b/addons/sourcemod/scripting/vsh/classlimit.sp
@@ -4,7 +4,7 @@ static TFClassType g_nSpecialRoundClass = TFClass_Unknown;	//Class for current s
 static TFClassType g_classMain[TF_MAXPLAYERS+1];
 static TFClassType g_classDesired[TF_MAXPLAYERS+1];
 
-static ConVar g_cvClassLimit[TFClassType];
+static ConVar g_cvClassLimit[view_as<int>(TFClassType)];
 
 public void ClassLimit_Init()
 {

--- a/addons/sourcemod/scripting/vsh/function.sp
+++ b/addons/sourcemod/scripting/vsh/function.sp
@@ -10,7 +10,7 @@ static any g_FunctionStackTemp[FUNCTION_CALLSTACK_MAX][FUNCTION_PARAM_MAX+1][FUN
 static StringMap g_mFunctionExecType;	//ExecType of the forward
 static StringMap g_mFunctionParamType;	//Array of ParamType of the forward from 1 to FUNCTION_PARAM_MAX, 0 for size of param
 static StringMap g_mFunctionPlugin;		//Plugin handle connected to methodmap, for calling function
-static StringMap g_mFunctionHook[SaxtonHaleHookMode];	//PrivateForward of hooks
+static StringMap g_mFunctionHook[view_as<int>(SaxtonHaleHookMode)];	//PrivateForward of hooks
 
 void Function_Init()
 {


### PR DESCRIPTION
Custom compiler doesn't use latest 1.10 version right now, but if attempted to use normal compiler, latest version added compile warning on legacy emun struct removed in 1.11.