### PR TITLE
New HHH Ghost Rage

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -3041,7 +3041,7 @@ stock int TF2_SpawnParticle(char[] sParticle, float vecOrigin[3] = NULL_VECTOR, 
 		AcceptEntityInput(iParticle, "Start");
 	}
 	
-	//Really only need ref of entity
+	//Return ref of entity
 	return EntIndexToEntRef(iParticle);
 }
 
@@ -3135,6 +3135,19 @@ void Frame_KillLight(int iRef)
 	int iLight = EntRefToEntIndex(iRef);
 	if (iLight > MaxClients)
 		AcceptEntityInput(iLight, "Kill");
+}
+
+stock void CreateFade(int iClient, int iDuration = 2000, int iRed = 255, int iGreen = 255, int iBlue = 255, int iAlpha = 255)
+{
+	BfWrite bf = UserMessageToBfWrite(StartMessageOne("Fade", iClient));
+	bf.WriteShort(iDuration);	//Fade duration
+	bf.WriteShort(0);
+	bf.WriteShort(0x0001);
+	bf.WriteByte(iRed);			//Red
+	bf.WriteByte(iGreen);		//Green
+	bf.WriteByte(iBlue);		//Blue
+	bf.WriteByte(iAlpha);		//Alpha
+	EndMessage();
 }
 
 stock void BroadcastSoundToTeam(int team, const char[] strSound)

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -3015,19 +3015,34 @@ stock void TF2_Explode(int iAttacker = -1, float flPos[3], float flDamage, float
 		SDKHooks_TakeDamage(iBomb, 0, iAttacker, 9999.0);
 }
 
-stock int TF2_SpawnParticle(int iClient, char[] sParticle)
+stock int TF2_SpawnParticle(char[] sParticle, float vecOrigin[3] = NULL_VECTOR, float flAngles[3] = NULL_VECTOR, bool bActivate = true, int iEntity = 0, int iControlPoint = 0)
 {
-	float vecOrigin[3];
-	GetClientAbsOrigin(iClient, vecOrigin);
-	
 	int iParticle = CreateEntityByName("info_particle_system");
-	TeleportEntity(iParticle, vecOrigin, NULL_VECTOR, NULL_VECTOR);
+	TeleportEntity(iParticle, vecOrigin, flAngles, NULL_VECTOR);
 	DispatchKeyValue(iParticle, "effect_name", sParticle);
 	DispatchSpawn(iParticle);
-	ActivateEntity(iParticle);
-	AcceptEntityInput(iParticle, "Start");
 	
-	return iParticle;
+	if (0 < iEntity && IsValidEntity(iEntity))
+	{
+		SetVariantString("!activator");
+		AcceptEntityInput(iParticle, "SetParent", iEntity);
+	}
+	
+	if (0 < iControlPoint && IsValidEntity(iControlPoint))
+	{
+		//Array netprop, but really only need element 0 anyway
+		SetEntPropEnt(iParticle, Prop_Send, "m_hControlPointEnts", iControlPoint, 0);
+		SetEntProp(iParticle, Prop_Send, "m_iControlPointParents", iControlPoint, _, 0);
+	}
+	
+	if (bActivate)
+	{
+		ActivateEntity(iParticle);
+		AcceptEntityInput(iParticle, "Start");
+	}
+	
+	//Really only need ref of entity
+	return EntIndexToEntRef(iParticle);
 }
 
 stock void TF2_TeleportSwap(int iClient[2])
@@ -3048,8 +3063,7 @@ stock void TF2_TeleportSwap(int iClient[2])
 		GetEntPropVector(iClient[i], Prop_Data, "m_vecVelocity", vecVel[i]);
 		
 		//Create particle
-		int iParticle = TF2_SpawnParticle(iClient[i], PARTICLE_GHOST);
-		CreateTimer(3.0, Timer_EntityCleanup, EntIndexToEntRef(iParticle));
+		CreateTimer(3.0, Timer_EntityCleanup, TF2_SpawnParticle(PARTICLE_GHOST, vecOrigin[i], vecAngles[i]));
 	}
 	
 	for (int i = 0; i <= 1; i++)

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -232,9 +232,9 @@ methodmap CRageGhost < SaxtonHaleBase
 					CreateFade(iSpooked[i], _, 255, 0, 255, 160);
 					
 					char sSound[PLATFORM_MAX_PATH];
-					this.CallFunction("GetSoundAbility", "CRageGhost", sSound, sizeof(sSound));
+					this.CallFunction("GetSoundAbility", sSound, sizeof(sSound), "CRageGhost");
 					if (!StrEmpty(sSound))
-						EmitSoundToClient(iClient, sSound, _, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+						EmitSoundToClient(iSpooked[i], sSound);
 				}
 				
 				//Random teleports

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -229,7 +229,7 @@ methodmap CRageGhost < SaxtonHaleBase
 				//Visual/Sound effects
 				for (int i = 0; i < iLength; i++)
 				{
-					CreateFade(iSpooked[i], _, 255, 0, 255, 160);
+					CreateFade(iSpooked[i], 1000, 160, 56, 204, 160);
 					
 					char sSound[PLATFORM_MAX_PATH];
 					this.CallFunction("GetSoundAbility", sSound, sizeof(sSound), "CRageGhost");

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -229,15 +229,7 @@ methodmap CRageGhost < SaxtonHaleBase
 				//Visual/Sound effects
 				for (int i = 0; i < iLength; i++)
 				{
-					BfWrite bf = UserMessageToBfWrite(StartMessageOne("Fade", iSpooked[i]));
-					bf.WriteShort(2000);	//Fade duration
-					bf.WriteShort(0);
-					bf.WriteShort(0x0001);
-					bf.WriteByte(255);		//Red
-					bf.WriteByte(0);		//Green
-					bf.WriteByte(255);		//Blue
-					bf.WriteByte(160);		//Alpha
-					EndMessage();
+					CreateFade(iSpooked[i], _, 255, 0, 255, 160);
 					
 					char sSound[PLATFORM_MAX_PATH];
 					this.CallFunction("GetSoundAbility", "CRageGhost", sSound, sizeof(sSound));

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -117,16 +117,24 @@ methodmap CRageGhost < SaxtonHaleBase
 		vecOrigin[2] += 42.0;
 		g_iGhostParticleCentre[iClient] = TF2_SpawnParticle("", vecOrigin, vecAngles, false, iClient);
 		
-		//Stun
+		//Stun and Fly
 		float flDuration = this.flDuration * (this.bSuperRage ? 2 : 1);
-		TF2_StunPlayer(iClient, flDuration, 0.0, TF_STUNFLAGS_GHOSTSCARE|TF_STUNFLAG_NOSOUNDOREFFECT, 0);
-		/*
+		TF2_StunPlayer(iClient, flDuration, 0.0, TF_STUNFLAG_GHOSTEFFECT|TF_STUNFLAG_NOSOUNDOREFFECT, 0);
+		TF2_AddCondition(iClient, TFCond_SwimmingNoEffects, flDuration);
+		
+		//Get active weapon and dont render
+		int iWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
+		if (IsValidEdict(iWeapon))
+		{
+			SetEntityRenderMode(iWeapon, RENDER_TRANSCOLOR);
+			SetEntityRenderColor(iWeapon, _, _, _, 0);
+		}
+		
 		//Thirdperson
 		int iFlags = GetCommandFlags("thirdperson");
 		SetCommandFlags("thirdperson", iFlags & (~FCVAR_CHEAT));
 		ClientCommand(this.iClient, "thirdperson");
 		SetCommandFlags("thirdperson", iFlags);
-		*/
 	}
 	
 	public void OnThink()
@@ -313,14 +321,28 @@ methodmap CRageGhost < SaxtonHaleBase
 			float vecOrigin[3];
 			GetClientAbsOrigin(iClient, vecOrigin);
 			CreateTimer(3.0, Timer_EntityCleanup, TF2_SpawnParticle(PARTICLE_GHOST, vecOrigin));
-			/*
+			
+			//Get active weapon and make it visible again
+			int iWeapon = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
+			if (IsValidEdict(iWeapon))
+			{
+				SetEntityRenderMode(iWeapon, RENDER_NORMAL);
+				SetEntityRenderColor(iWeapon, _, _, _, 255);
+			}
+			
 			//Firstperson
 			int iFlags = GetCommandFlags("firstperson");
 			SetCommandFlags("firstperson", iFlags & (~FCVAR_CHEAT));
 			ClientCommand(iClient, "firstperson");
 			SetCommandFlags("firstperson", iFlags);
-			*/
 		}
+	}
+	
+	public void OnButton(int &buttons)
+	{
+		//Don't allow him to attack during rage
+		if (g_bGhostEnable[this.iClient] && buttons & IN_ATTACK)
+			buttons &= ~IN_ATTACK;
 	}
 	
 	public void Destroy()

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -123,7 +123,7 @@ methodmap CHorsemann < SaxtonHaleBase
 		}
 	}
 	
-	public void GetAbilitySound(char[] sSound, int length, const char[] sType)
+	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
 	{
 		if (strcmp(sType, "CRageGhost") == 0)
 			strcopy(sSound, length, g_strHorsemannGhost[GetRandomInt(0,sizeof(g_strHorsemannGhost)-1)]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -61,10 +61,10 @@ methodmap CHorsemann < SaxtonHaleBase
 		boss.CallFunction("CreateAbility", "CTeleportSwap");
 		boss.CallFunction("CreateAbility", "CRageGhost");
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iBaseHealth = 700;
+		boss.iHealthPerPlayer = 650;
 		boss.nClass = TFClass_DemoMan;
-		boss.iMaxRageDamage = 2500;
+		boss.iMaxRageDamage = 3000;
 	}
 	
 	public void GetBossName(char[] sName, int length)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -59,9 +59,7 @@ methodmap CHorsemann < SaxtonHaleBase
 	{
 		boss.CallFunction("CreateAbility", "CWallClimb");
 		boss.CallFunction("CreateAbility", "CTeleportSwap");
-		CScareRage scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
-		scareAbility.flRadius = 800.0;
-		//boss.CallFunction("CreateAbility", "CRageGhost");
+		boss.CallFunction("CreateAbility", "CRageGhost");
 		
 		boss.iBaseHealth = 800;
 		boss.iHealthPerPlayer = 800;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -74,15 +74,16 @@ methodmap CHorsemann < SaxtonHaleBase
 	
 	public void GetBossInfo(char[] sInfo, int length)
 	{
-		StrCat(sInfo, length, "\nHealth: Medium");
+		StrCat(sInfo, length, "\nHealth: Low");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nAbilities");
 		StrCat(sInfo, length, "\n- Wall Climb");
 		StrCat(sInfo, length, "\n- Teleport Swap");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
-		StrCat(sInfo, length, "\n- Scares players at medium range for 5 seconds");
-		StrCat(sInfo, length, "\n- 200%% Rage: Larger range and extends duration to 7.5 seconds");
+		StrCat(sInfo, length, "\n- Becomes ghost to fly, immute to damage, and unable to attack for 5 seconds");
+		StrCat(sInfo, length, "\n- Steals health from nearby players with random spooky effects");
+		StrCat(sInfo, length, "\n- 200%% Rage: Extends duration to 10 seconds");
 	}
 	
 	public void OnSpawn()

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -306,7 +306,7 @@ void Dome_Frame_Prepare(int iRef)
 					else
 						flAlpha = (flDistanceMultiplier - DOME_FADE_START_MULTIPLIER) * (1.0/(1.0-DOME_FADE_START_MULTIPLIER)) * DOME_FADE_ALPHA_MAX * (flRender/255.0);
 					
-					Dome_Fade(i, RoundToNearest(flAlpha));
+					CreateFade(i, _, g_vecColor[0], g_vecColor[1], g_vecColor[2], RoundToNearest(flAlpha));
 				}
 			}
 		}
@@ -377,7 +377,7 @@ void Dome_Frame_Shrink(int iRef)
 				else
 					flAlpha = (flDistanceMultiplier - DOME_FADE_START_MULTIPLIER) * (1.0/(1.0-DOME_FADE_START_MULTIPLIER)) * DOME_FADE_ALPHA_MAX;
 				
-				Dome_Fade(i, RoundToNearest(flAlpha));
+				CreateFade(i, _, g_vecColor[0], g_vecColor[1], g_vecColor[2], RoundToNearest(flAlpha));
 			}
 		}
 	}
@@ -450,19 +450,6 @@ void Dome_Building_Damage(int iEntity)
 	
 	SetVariantInt(15);
 	AcceptEntityInput(iEntity, "RemoveHealth");
-}
-
-void Dome_Fade(int iClient, int iAlpha)
-{
-	Handle hFade = StartMessageOne("Fade", iClient);
-	BfWriteShort(hFade, 2000);				//Fade duration
-	BfWriteShort(hFade, 0);
-	BfWriteShort(hFade, 0x0001);
-	BfWriteByte(hFade, g_vecColor[0]);	//Red
-	BfWriteByte(hFade, g_vecColor[1]);	//Green
-	BfWriteByte(hFade, g_vecColor[2]);	//Blue
-	BfWriteByte(hFade, iAlpha);				//Alpha
-	EndMessage();
 }
 
 void Dome_UpdateRadius()


### PR DESCRIPTION
This is something i meant to finish a while ago, but here it is, replaces default scare rage.

When rage is used, HHH turns into a ghost for 5 seconds (10 for super rage), can't take any damage and can fly, but can't attack.
When nearby players, medigun beam particle effect appears from victim to ghost, and steals health. Steals 20hp per sec while gains 40hp per sec, which is doubled of stolen health. Because of health gain, HHH's base health is reduced to same as Gentle Spy, and rage requirement is increased from 2500dmg to 3000dmg.

Along with this, nearby players also get "spooky" effects at random, this includes:
- Purple fade with thunder noises
- Teleport-swap to another nearby player
- Force switched to random weapon
- Eye angle view force changed to random direction