### PR TITLE
Increase HHH ghost rage duration from 5 to 8 seconds

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -80,7 +80,7 @@ methodmap CRageGhost < SaxtonHaleBase
 	{
 		//Default values, these can be changed if needed
 		ability.flRadius = 400.0;
-		ability.flDuration = 5.0;
+		ability.flDuration = 8.0;
 		ability.flHealSteal = 20.0;	//Steals hp per second
 		ability.flHealGain = 40.0;	//Gains hp per second
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -81,9 +81,9 @@ methodmap CHorsemann < SaxtonHaleBase
 		StrCat(sInfo, length, "\n- Teleport Swap");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
-		StrCat(sInfo, length, "\n- Becomes ghost to fly, immute to damage, and unable to attack for 5 seconds");
+		StrCat(sInfo, length, "\n- Becomes ghost to fly, immute to damage, and unable to attack for 8 seconds");
 		StrCat(sInfo, length, "\n- Steals health from nearby players with random spooky effects");
-		StrCat(sInfo, length, "\n- 200%% Rage: Extends duration to 10 seconds");
+		StrCat(sInfo, length, "\n- 200%% Rage: Extends duration to 16 seconds");
 	}
 	
 	public void OnSpawn()


### PR DESCRIPTION
Not that helpful right now, increasing duration from 5 to 8 allows HHH to steal more health, from 100 to 160. Enough to kill 125hp class, but not quite enough to medic when passive health regen can live long enough.