### PR TITLE
Make Demopan's charge instakill

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
@@ -130,17 +130,14 @@ methodmap CWeaponCharge < SaxtonHaleBase
 	public Action OnPlayerKilled(Event event, int iVictim)
 	{
 		//Because SDKHooks_TakeDamage doesnt even set damage sources from chargin targe properly
-		int iInflictor = event.GetInt("inflictor_entindex");
-		if (iInflictor > MaxClients && IsValidEdict(iInflictor))
+		char sWeapon[256];
+		event.GetString("weapon", sWeapon, sizeof(sWeapon));
+		
+		if (StrEqual(sWeapon, "tf_wearable_demoshield"))
 		{
-			char sClassname[256];
-			GetEntityClassname(iInflictor, sClassname, sizeof(sClassname));
-			if (StrEqual(sClassname, "tf_wearable_demoshield"))
-			{
-				event.SetString("weapon_logclassname", "demoshield");
-				event.SetString("weapon", "demoshield");
-				event.SetInt("customkill", TF_CUSTOM_CHARGE_IMPACT);
-			}
+			event.SetString("weapon_logclassname", "demoshield");
+			event.SetString("weapon", "demoshield");
+			event.SetInt("customkill", TF_CUSTOM_CHARGE_IMPACT);
 		}
 	}
 	
@@ -152,26 +149,59 @@ methodmap CWeaponCharge < SaxtonHaleBase
 
 public void Charge_StartTouch(int iClient, int iToucher)
 {
-	if (0 < iToucher <= MaxClients && TF2_IsPlayerInCondition(iClient, TFCond_Charging) && GetClientTeam(iClient) != GetClientTeam(iToucher) && GetClientTeam(iToucher) > 1)
+	if (TF2_IsPlayerInCondition(iClient, TFCond_Charging))
 	{
-		//Deal damage a frame later, otherwise possible crash
-		DataPack data = new DataPack();
-		data.WriteCell(iClient);
-		data.WriteCell(iToucher);
-		
-		RequestFrame(Charge_BashDamage, data);
+		if (0 < iToucher <= MaxClients && GetClientTeam(iClient) != GetClientTeam(iToucher) && GetClientTeam(iToucher) > 1)
+		{
+			//Deal damage a frame later, otherwise possible crash
+			DataPack data = new DataPack();
+			data.WriteCell(EntIndexToEntRef(iClient));
+			data.WriteCell(EntIndexToEntRef(iToucher));
+			
+			RequestFrame(Charge_BashDamage, data);
+		}
+		else if (iToucher > MaxClients && IsValidEdict(iToucher))
+		{
+			//Check if building, and deal damage
+			char sClassname[256];
+			GetEntityClassname(iToucher, sClassname, sizeof(sClassname));
+			if (StrEqual(sClassname, "obj_sentrygun") || StrEqual(sClassname, "obj_dispenser") || StrEqual(sClassname, "obj_teleporter"))
+			{
+				int iTeam = GetEntProp(iToucher, Prop_Send, "m_iTeamNum");
+				if (iTeam != GetClientTeam(iClient) && iTeam > 1)
+				{
+					DataPack data = new DataPack();
+					data.WriteCell(EntIndexToEntRef(iClient));
+					data.WriteCell(EntIndexToEntRef(iToucher));
+					
+					RequestFrame(Charge_BashDamage, data);
+				}
+			}
+		}
 	}
 }
 
 public void Charge_BashDamage(DataPack data)
 {
 	data.Reset();
-	int iClient = data.ReadCell();
-	int iToucher = data.ReadCell();
+	int iClient = EntRefToEntIndex(data.ReadCell());
+	int iToucher = EntRefToEntIndex(data.ReadCell());
 	delete data;
 	
-	if (IsClientInGame(iClient) && IsPlayerAlive(iClient) && IsClientInGame(iToucher) && IsPlayerAlive(iToucher))
+	//Client check
+	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient) || !IsPlayerAlive(iClient))
+		return;
+	
+	if (0 < iToucher <= MaxClients && IsClientInGame(iToucher) && IsPlayerAlive(iToucher))
 	{
+		//Player damage
+		int iWeapon = TF2_GetItemInSlot(iClient, WeaponSlot_Secondary);
+		if (iWeapon > MaxClients && IsValidEdict(iWeapon))
+			SDKHooks_TakeDamage(iToucher, iWeapon, iClient, 500.0, DMG_CLUB, iWeapon);
+	}
+	else if (iToucher > MaxClients && IsValidEdict(iToucher))
+	{
+		//Building damage
 		int iWeapon = TF2_GetItemInSlot(iClient, WeaponSlot_Secondary);
 		if (iWeapon > MaxClients && IsValidEdict(iWeapon))
 			SDKHooks_TakeDamage(iToucher, iWeapon, iClient, 500.0, DMG_CLUB, iWeapon);

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
@@ -143,7 +143,7 @@ methodmap CWeaponCharge < SaxtonHaleBase
 	
 	public void Destroy()
 	{
-		SDKUnhook(this.iClient, SDKHook_StartTouch, Charge_StartTouch);
+		SDKUnhook(this.iClient, SDKHook_StartTouchPost, Charge_StartTouch);
 	}
 };
 


### PR DESCRIPTION
Because Demopan's rage will still suck after PR #21 

This is quite of a hacky workaround inorder to make this work, because demoshield only deal damage if charge ends, while rage force charge even after bash.

Whenever demopan touches enemy player, call `SDKHooks_TakeDamage` a frame later to prevent possible crash, and update `player_death` event to make kill icon etc look like a charge kill.