### PR TITLE
Don't remove and re-equip boss's toolbox weapon

### DIFF
--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -181,7 +181,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 					AcceptEntityInput(iEntity, "Kill");
 		}
 		
-		for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+		for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)	//Don't remove toolbox weapon
 			TF2_RemoveItemInSlot(this.iClient, iSlot);
 		
 		int iHealth = this.CallFunction("CalculateMaxHealth");

--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -65,11 +65,6 @@ methodmap CVagineer < SaxtonHaleBase
 		g_flVagineerSentryHealthDecay[boss.iClient] = 0.0;
 	}
 	
-	public bool IsBossHidden()
-	{
-		return true;
-	}
-	
 	public void GetBossName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Vagineer");
@@ -92,13 +87,10 @@ methodmap CVagineer < SaxtonHaleBase
 	{
 		SetEntProp(this.iClient, Prop_Send, "m_iAmmo", 0, 4, 3);
 		this.CallFunction("CreateWeapon", 25, "tf_weapon_pda_engineer_build", 100, TFQual_Unusual, "");
-		int iWeapon = this.CallFunction("CreateWeapon", 28, "tf_weapon_builder", 100, TFQual_Unusual, "");
-		if (iWeapon > MaxClients)
-			SetEntProp(iWeapon, Prop_Send, "m_aBuildableObjectTypes", 1, _, view_as<int>(TFObject_Sentry));	//Allow sentry to actually be built
 		
 		char attribs[256];
 		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65 ; 93 ; 0.0 ; 95 ; 0.0 ; 343 ; 0.5 ; 353 ; 1.0 ; 436 ; 1.0 ; 464 ; 10.0 ; 2043 ; 0.0");
-		iWeapon = this.CallFunction("CreateWeapon", 7, "tf_weapon_wrench", 100, TFQual_Collectors, attribs);
+		int iWeapon = this.CallFunction("CreateWeapon", 7, "tf_weapon_wrench", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
 		/*


### PR DESCRIPTION
Attempting to give toolbox weapon `tf_weapon_builder` cause crashes. Why? We dont know.
So instead, we allow all engineer boss keep `tf_weapon_builder` weapon from TF2 loadout. This should still be fine when adding new Engineer boss without buildings, as `OnBuild` function blocks build by default.