### PR TITLE
Fix class weapon menu's back button not working

### DIFF
--- a/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
@@ -133,7 +133,10 @@ public int MenuWeapon_SelectMain(Menu hMenu, MenuAction action, int iClient, int
 	hMenu.GetItem(iSelect, sSelect, sizeof(sSelect));
 	
 	if (StrEqual(sSelect, "back"))
+	{
 		Menu_DisplayMain(iClient);
+		return;
+	}
 	
 	TFClassType nClass = view_as<TFClassType>(StringToInt(sSelect));
 	MenuWeapon_DisplayClass(iClient, nClass);


### PR DESCRIPTION
The class part of the weapon menu would get stuck if you tried to press the back button on it, as it was missing a `return`.