### PR TITLE
Convert few bits to use new 1.10 features

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -269,7 +269,7 @@ methodmap CRageGhost < SaxtonHaleBase
 						if (aWeapons.Length > 0)
 						{
 							//Get random weapon/slot to change
-							SortADTArray(aWeapons, Sort_Random, Sort_Integer);
+							aWeapons.Sort(Sort_Random, Sort_Integer);
 							char sClassname[256];
 							GetEntityClassname(aWeapons.Get(0), sClassname, sizeof(sClassname));
 							FakeClientCommand(iSpooked[i], "use %s", sClassname);

--- a/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
@@ -147,7 +147,7 @@ methodmap CTeleportSwap < SaxtonHaleBase
 					return;
 				}
 				
-				SortADTArray(aClients, Sort_Random, Sort_Integer);
+				aClients.Sort(Sort_Random, Sort_Integer);
 				
 				int iClient[2];
 				

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -82,7 +82,7 @@ methodmap CSeeldier < SaxtonHaleBase
 			}
 		}
 		
-		SortADTArray(aValidMinions, Sort_Random, Sort_Integer);
+		aValidMinions.Sort(Sort_Random, Sort_Integer);
 		int iLength = aValidMinions.Length;
 		if (iLength < iTotalMinions)
 			iTotalMinions = iLength;

--- a/addons/sourcemod/scripting/vsh/cookies.sp
+++ b/addons/sourcemod/scripting/vsh/cookies.sp
@@ -1,6 +1,6 @@
-static Handle g_hCookiesPreferences;
-static Handle g_hCookiesQueue;
-static Handle g_hCookiesWinstreak;
+static Cookie g_hCookiesPreferences;
+static Cookie g_hCookiesQueue;
+static Cookie g_hCookiesWinstreak;
 
 void Cookies_Init()
 {
@@ -8,9 +8,9 @@ void Cookies_Init()
 	g_ConfigConvar.Create("vsh_cookies_queue", "1", "Should queue use cookies to store? (Disable if you want to store queue somewhere else)", _, true, 0.0, true, 1.0);
 	g_ConfigConvar.Create("vsh_cookies_winstreak", "1", "Should winstreak use cookies to store? (Disable if you want to store winstreak somewhere else)", _, true, 0.0, true, 1.0);
 	
-	g_hCookiesPreferences = RegClientCookie("vsh_preferences", "VSH Player preferences", CookieAccess_Protected);
-	g_hCookiesQueue = RegClientCookie("vsh_queue", "Amount of VSH Queue points player has", CookieAccess_Protected);
-	g_hCookiesWinstreak = RegClientCookie("vsh_winstreak", "Amount of VSH Winstreaks player has", CookieAccess_Protected);
+	g_hCookiesPreferences = new Cookie("vsh_preferences", "VSH Player preferences", CookieAccess_Protected);
+	g_hCookiesQueue = new Cookie("vsh_queue", "Amount of VSH Queue points player has", CookieAccess_Protected);
+	g_hCookiesWinstreak = new Cookie("vsh_winstreak", "Amount of VSH Winstreaks player has", CookieAccess_Protected);
 }
 
 void Cookies_Refresh()
@@ -54,7 +54,7 @@ void Cookies_RefreshPreferences(int iClient)
 {
 	int iVal;
 	char sVal[16];
-	GetClientCookie(iClient, g_hCookiesPreferences, sVal, sizeof(sVal));
+	g_hCookiesPreferences.Get(iClient, sVal, sizeof(sVal));
 	
 	if (StringToIntEx(sVal, iVal) > 0)
 		Preferences_SetAll(iClient, iVal);
@@ -66,7 +66,7 @@ void Cookies_RefreshQueue(int iClient)
 {
 	int iVal;
 	char sVal[16];
-	GetClientCookie(iClient, g_hCookiesQueue, sVal, sizeof(sVal));
+	g_hCookiesQueue.Get(iClient, sVal, sizeof(sVal));
 	
 	if (StringToIntEx(sVal, iVal) > 0)
 		Queue_SetPlayerPoints(iClient, iVal);
@@ -78,7 +78,7 @@ void Cookies_RefreshWinstreak(int iClient)
 {
 	int iVal;
 	char sVal[16];
-	GetClientCookie(iClient, g_hCookiesWinstreak, sVal, sizeof(sVal));
+	g_hCookiesWinstreak.Get(iClient, sVal, sizeof(sVal));
 	
 	if (StringToIntEx(sVal, iVal) > 0)
 		Winstreak_SetCurrent(iClient, iVal);
@@ -95,7 +95,7 @@ void Cookies_SavePreferences(int iClient, int iValue)
 	{
 		char sVal[16];
 		IntToString(iValue, sVal, sizeof(sVal));
-		SetClientCookie(iClient, g_hCookiesPreferences, sVal);
+		g_hCookiesPreferences.Set(iClient, sVal);
 	}
 	
 	Forward_UpdatePreferences(iClient, iValue);
@@ -110,7 +110,7 @@ void Cookies_SaveQueue(int iClient, int iValue)
 	{
 		char sVal[16];
 		IntToString(iValue, sVal, sizeof(sVal));
-		SetClientCookie(iClient, g_hCookiesQueue, sVal);
+		g_hCookiesQueue.Set(iClient, sVal);
 	}
 	
 	Forward_UpdateQueue(iClient, iValue);
@@ -125,7 +125,7 @@ void Cookies_SaveWinstreak(int iClient, int iValue)
 	{
 		char sVal[16];
 		IntToString(iValue, sVal, sizeof(sVal));
-		SetClientCookie(iClient, g_hCookiesWinstreak, sVal);
+		g_hCookiesWinstreak.Set(iClient, sVal);
 	}
 	
 	Forward_UpdateWinstreak(iClient, iValue);

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -188,7 +188,7 @@ void Dome_PlayerDeath(int iPlayerCount)
 	}
 }
 
-void Dome_Frame_Start(int i = 0)
+public void Dome_Frame_Start()
 {
 	if (!g_ConfigConvar.LookupBool("vsh_dome_enable") || g_flDomeEnableTime == 0.0 || g_flDomeStart != 0.0) return;
 

--- a/addons/sourcemod/scripting/vsh/forward.sp
+++ b/addons/sourcemod/scripting/vsh/forward.sp
@@ -1,20 +1,20 @@
-static Handle g_hForwardBossWin;
-static Handle g_hForwardBossLose;
-static Handle g_hForwardTeleportDamage;
-static Handle g_hForwardChainStabs;
-static Handle g_hForwardUpdatePreferences;
-static Handle g_hForwardUpdateQueue;
-static Handle g_hForwardUpdateWinstreak;
+static GlobalForward g_hForwardBossWin;
+static GlobalForward g_hForwardBossLose;
+static GlobalForward g_hForwardTeleportDamage;
+static GlobalForward g_hForwardChainStabs;
+static GlobalForward g_hForwardUpdatePreferences;
+static GlobalForward g_hForwardUpdateQueue;
+static GlobalForward g_hForwardUpdateWinstreak;
 
 void Forward_AskLoad()
 {
-	g_hForwardBossWin = CreateGlobalForward("SaxtonHale_OnBossWin", ET_Ignore, Param_Cell);
-	g_hForwardBossLose = CreateGlobalForward("SaxtonHale_OnBossLose", ET_Ignore, Param_Cell);
-	g_hForwardTeleportDamage = CreateGlobalForward("SaxtonHale_OnTeleportDamage", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
-	g_hForwardChainStabs = CreateGlobalForward("SaxtonHale_OnChainStabs", ET_Ignore, Param_Cell, Param_Cell);
-	g_hForwardUpdatePreferences = CreateGlobalForward("SaxtonHale_OnUpdatePreferences", ET_Ignore, Param_Cell, Param_Cell);
-	g_hForwardUpdateQueue = CreateGlobalForward("SaxtonHale_OnUpdateQueue", ET_Ignore, Param_Cell, Param_Cell);
-	g_hForwardUpdateWinstreak = CreateGlobalForward("SaxtonHale_OnUpdateWinstreak", ET_Ignore, Param_Cell, Param_Cell);
+	g_hForwardBossWin = new GlobalForward("SaxtonHale_OnBossWin", ET_Ignore, Param_Cell);
+	g_hForwardBossLose = new GlobalForward("SaxtonHale_OnBossLose", ET_Ignore, Param_Cell);
+	g_hForwardTeleportDamage = new GlobalForward("SaxtonHale_OnTeleportDamage", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
+	g_hForwardChainStabs = new GlobalForward("SaxtonHale_OnChainStabs", ET_Ignore, Param_Cell, Param_Cell);
+	g_hForwardUpdatePreferences = new GlobalForward("SaxtonHale_OnUpdatePreferences", ET_Ignore, Param_Cell, Param_Cell);
+	g_hForwardUpdateQueue = new GlobalForward("SaxtonHale_OnUpdateQueue", ET_Ignore, Param_Cell, Param_Cell);
+	g_hForwardUpdateWinstreak = new GlobalForward("SaxtonHale_OnUpdateWinstreak", ET_Ignore, Param_Cell, Param_Cell);
 }
 
 void Forward_BossWin(int iTeam)

--- a/addons/sourcemod/scripting/vsh/menu/menu_boss.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_boss.sp
@@ -406,6 +406,8 @@ public int MenuBoss_SelectNextClient(Menu hMenu, MenuAction action, int iClient,
 		int iPlayer = GetClientOfUserId(iUserId);
 		if (0 < iPlayer <= MaxClients && IsClientInGame(iPlayer))
 			g_nextMenuSelectBoss[iClient].iUserId = iUserId;
+		else
+			g_nextMenuSelectBoss[iClient].iUserId = 0;
 		
 		MenuBoss_DisplayNextBoss(iClient);
 	}
@@ -428,7 +430,11 @@ public int MenuBoss_SelectNextBoss(Menu hMenu, MenuAction action, int iClient, i
 		MenuBoss_DisplayNextClient(iClient);
 		return;
 	}
-	else if (!StrEqual(sSelect, "random"))
+	else if (StrEqual(sSelect, "random"))
+	{
+		Format(g_nextMenuSelectBoss[iClient].sBoss, sizeof(g_nextMenuSelectBoss[].sBoss), "");
+	}
+	else
 	{
 		Format(g_nextMenuSelectBoss[iClient].sBoss, sizeof(g_nextMenuSelectBoss[].sBoss), sSelect);
 	}
@@ -453,7 +459,11 @@ public int MenuBoss_SelectNextModifiers(Menu hMenu, MenuAction action, int iClie
 		MenuBoss_DisplayNextBoss(iClient);
 		return;
 	}
-	else if (!StrEqual(sSelect, "random"))
+	else if (StrEqual(sSelect, "random"))
+	{
+		Format(g_nextMenuSelectBoss[iClient].sModifiers, sizeof(g_nextMenuSelectBoss[].sModifiers), "");
+	}
+	else
 	{
 		Format(g_nextMenuSelectBoss[iClient].sModifiers, sizeof(g_nextMenuSelectBoss[].sModifiers), sSelect);
 	}

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -65,7 +65,7 @@ void Native_AskLoad()
 }
 
 //any SaxtonHaleBase.CallFunction(const char[] sName, any...);
-public int Native_CallFunction(Handle hPlugin, int iNumParams)
+public any Native_CallFunction(Handle hPlugin, int iNumParams)
 {
 	SaxtonHaleBase boss = view_as<SaxtonHaleBase>(GetNativeCell(1));
 	
@@ -144,7 +144,7 @@ public int Native_CallFunction(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_InitFunction(const char[] sName, ExecType type, ParamType ...);
-public int Native_InitFunction(Handle hPlugin, int iNumParams)
+public any Native_InitFunction(Handle hPlugin, int iNumParams)
 {
 	iNumParams -= 2;
 	
@@ -184,7 +184,7 @@ public int Native_InitFunction(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_HookFunction(const char[] sName, SaxtonHaleHookCallback callback, SaxtonHaleHookType = VSHHookType_Post);
-public int Native_HookFunction(Handle hPlugin, int iNumParams)
+public any Native_HookFunction(Handle hPlugin, int iNumParams)
 {
 	char sName[FUNCTION_ARRAY_MAX];
 	GetNativeString(1, sName, sizeof(sName));
@@ -195,7 +195,7 @@ public int Native_HookFunction(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_UnhookFunction(const char[] sName, SaxtonHaleHookCallback callback, SaxtonHaleHookType = VSHHookType_Post);
-public int Native_UnhookFunction(Handle hPlugin, int iNumParams)
+public any Native_UnhookFunction(Handle hPlugin, int iNumParams)
 {
 	char sName[FUNCTION_ARRAY_MAX];
 	GetNativeString(1, sName, sizeof(sName));
@@ -226,7 +226,7 @@ int Native_GetParamEx(char[] sName, int iLength, ParamType &buffer)
 }
 
 //any SaxtonHale_GetParam(int iParam);
-public int Native_GetParam(Handle hPlugin, int iNumParams)
+public any Native_GetParam(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -251,7 +251,7 @@ public int Native_GetParam(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_SetParam(int iParam, any value);
-public int Native_SetParam(Handle hPlugin, int iNumParams)
+public any Native_SetParam(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -273,7 +273,7 @@ public int Native_SetParam(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_GetParamArray(int iParam, any[] value);
-public int Native_GetParamArray(Handle hPlugin, int iNumParams)
+public any Native_GetParamArray(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -295,7 +295,7 @@ public int Native_GetParamArray(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_SetParamArray(int iParam, any[] value);
-public int Native_SetParamArray(Handle hPlugin, int iNumParams)
+public any Native_SetParamArray(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -317,7 +317,7 @@ public int Native_SetParamArray(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_GetParamString(int iParam, char[] value);
-public int Native_GetParamString(Handle hPlugin, int iNumParams)
+public any Native_GetParamString(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -340,7 +340,7 @@ public int Native_GetParamString(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_SetParamString(int iParam, char[] value);
-public int Native_SetParamString(Handle hPlugin, int iNumParams)
+public any Native_SetParamString(Handle hPlugin, int iNumParams)
 {
 	//Get param + checks
 	char sName[FUNCTION_ARRAY_MAX];
@@ -362,7 +362,7 @@ public int Native_SetParamString(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_RegisterBoss(const char[] ...);
-public int Native_RegisterBoss(Handle hPlugin, int iNumParams)
+public any Native_RegisterBoss(Handle hPlugin, int iNumParams)
 {
 	if (iNumParams == 0)
 		ThrowNativeError(SP_ERROR_NATIVE, "No params passed");
@@ -396,7 +396,7 @@ public int Native_RegisterBoss(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_UnregisterBoss(const char[] sBossType);
-public int Native_UnregisterBoss(Handle hPlugin, int iNumParams)
+public any Native_UnregisterBoss(Handle hPlugin, int iNumParams)
 {
 	char sBossType[MAX_TYPE_CHAR];
 	GetNativeString(1, sBossType, sizeof(sBossType));
@@ -435,7 +435,7 @@ public int Native_UnregisterBoss(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_RegisterModifiers(const char[] sModifiersType);
-public int Native_RegisterModifiers(Handle hPlugin, int iNumParams)
+public any Native_RegisterModifiers(Handle hPlugin, int iNumParams)
 {
 	char sModifiersType[MAX_TYPE_CHAR];
 	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
@@ -448,7 +448,7 @@ public int Native_RegisterModifiers(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_UnregisterModifiers(const char[] sModifiersType);
-public int Native_UnregisterModifiers(Handle hPlugin, int iNumParams)
+public any Native_UnregisterModifiers(Handle hPlugin, int iNumParams)
 {
 	char sModifiersType[MAX_TYPE_CHAR];
 	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
@@ -464,7 +464,7 @@ public int Native_UnregisterModifiers(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_RegisterAbility(const char[] sAbilityType);
-public int Native_RegisterAbility(Handle hPlugin, int iNumParams)
+public any Native_RegisterAbility(Handle hPlugin, int iNumParams)
 {
 	char sAbilityType[MAX_TYPE_CHAR];
 	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
@@ -474,7 +474,7 @@ public int Native_RegisterAbility(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
-public int Native_UnregisterAbility(Handle hPlugin, int iNumParams)
+public any Native_UnregisterAbility(Handle hPlugin, int iNumParams)
 {
 	char sAbilityType[MAX_TYPE_CHAR];
 	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
@@ -483,19 +483,19 @@ public int Native_UnregisterAbility(Handle hPlugin, int iNumParams)
 }
 
 //TFTeam SaxtonHale_GetBossTeam();
-public int Native_GetBossTeam(Handle hPlugin, int iNumParams)
+public any Native_GetBossTeam(Handle hPlugin, int iNumParams)
 {
 	return BOSS_TEAM;
 }
 
 //TFTeam SaxtonHale_GetAttackTeam();
-public int Native_GetAttackTeam(Handle hPlugin, int iNumParams)
+public any Native_GetAttackTeam(Handle hPlugin, int iNumParams)
 {
 	return ATTACK_TEAM;
 }
 
 //TFClassType SaxtonHale_GetMainClass(int iClient);
-public int Native_GetMainClass(Handle hPlugin, int iNumParams)
+public any Native_GetMainClass(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	if (iClient <= 0 || iClient > MaxClients)
@@ -503,11 +503,11 @@ public int Native_GetMainClass(Handle hPlugin, int iNumParams)
 	if (!IsClientInGame(iClient))
 		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
 	
-	return view_as<int>(ClassLimit_GetMainClass(iClient));
+	return ClassLimit_GetMainClass(iClient);
 }
 
 //int SaxtonHale_GetDamage(int iClient);
-public int Native_GetDamage(Handle hPlugin, int iNumParams)
+public any Native_GetDamage(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	if (iClient <= 0 || iClient > MaxClients)
@@ -519,7 +519,7 @@ public int Native_GetDamage(Handle hPlugin, int iNumParams)
 }
 
 //int SaxtonHale_GetAssistDamage(int iClient);
-public int Native_GetAssistDamage(Handle hPlugin, int iNumParams)
+public any Native_GetAssistDamage(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	if (iClient <= 0 || iClient > MaxClients)
@@ -531,7 +531,7 @@ public int Native_GetAssistDamage(Handle hPlugin, int iNumParams)
 }
 
 //bool SaxtonHale_ForceSpecialRound(int iClient=0, TFClassType nClass=TFClass_Unknown);
-public int Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
+public any Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	TFClassType nClass = GetNativeCell(2);
@@ -554,7 +554,7 @@ public int Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
 }
 
 //void SaxtonHale_SetPreferences(int iClient, int iPreferences);
-public int Native_SetPreferences(Handle hPlugin, int iNumParams)
+public any Native_SetPreferences(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	int iPreferences = GetNativeCell(2);
@@ -568,7 +568,7 @@ public int Native_SetPreferences(Handle hPlugin, int iNumParams)
 }
 
 //SaxtonHale_SetQueue(int iClient, int iQueue);
-public int Native_SetQueue(Handle hPlugin, int iNumParams)
+public any Native_SetQueue(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	int iQueue = GetNativeCell(2);
@@ -582,7 +582,7 @@ public int Native_SetQueue(Handle hPlugin, int iNumParams)
 }
 
 //SaxtonHale_SetWinstreak(int iClient, int iWinstreak);
-public int Native_SetWinstreak(Handle hPlugin, int iNumParams)
+public any Native_SetWinstreak(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	int iWinstreak = GetNativeCell(2);
@@ -596,13 +596,13 @@ public int Native_SetWinstreak(Handle hPlugin, int iNumParams)
 }
 
 //bool SaxtonHale_IsWinstreakEnable();
-public int Native_IsWinstreakEnable(Handle hPlugin, int iNumParams)
+public any Native_IsWinstreakEnable(Handle hPlugin, int iNumParams)
 {
 	return Winstreak_IsEnabled();
 }
 
 //SaxtonHale_SetAdmin(int iClient, bool bEnable);
-public int Native_SetAdmin(Handle hPlugin, int iNumParams)
+public any Native_SetAdmin(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	bool bEnable = GetNativeCell(2);
@@ -619,7 +619,7 @@ public int Native_SetAdmin(Handle hPlugin, int iNumParams)
 }
 
 //SaxtonHale_SetPunishment(int iClient, bool bEnable);
-public int Native_SetPunishment(Handle hPlugin, int iNumParams)
+public any Native_SetPunishment(Handle hPlugin, int iNumParams)
 {
 	int iClient = GetNativeCell(1);
 	bool bEnable = GetNativeCell(2);
@@ -638,13 +638,13 @@ public int Native_SetPunishment(Handle hPlugin, int iNumParams)
 //Macro to setup natives for every properties
 #define NATIVE_PROPERTY(%1,%2) \
 static %2 g_clientBoss%1[TF_MAXPLAYERS+1]; \
-public int Native_Property_%1_Set(Handle hPlugin, int iNumParams) \
+public any Native_Property_%1_Set(Handle hPlugin, int iNumParams) \
 { \
 	g_clientBoss%1[GetNativeCell(1)] = GetNativeCell(2); \
 } \
-public int Native_Property_%1_Get(Handle hPlugin, int iNumParams) \
+public any Native_Property_%1_Get(Handle hPlugin, int iNumParams) \
 { \
-	return view_as<int>(g_clientBoss%1[GetNativeCell(1)]); \
+	return g_clientBoss%1[GetNativeCell(1)]; \
 }
 
 NATIVE_PROPERTY(bValid, bool)

--- a/addons/sourcemod/scripting/vsh/queue.sp
+++ b/addons/sourcemod/scripting/vsh/queue.sp
@@ -19,7 +19,7 @@ int Queue_GetPlayerFromRank(int iRank)
 		return 0;
 	
 	aQueue.Resize(iLength);
-	SortADTArray(aQueue, Sort_Descending, Sort_Integer);
+	aQueue.Sort(Sort_Descending, Sort_Integer);
 	int iClient = aQueue.Get(iRank-1, 1);
 	delete aQueue;
 	


### PR DESCRIPTION
New features used from 1.10 to make coding style bit more nicer:
- enum struct instead of StringMap handle to pass around with next boss
- `GameData` methodmap
- `Cookie` methodmap
- `GlobalForward` methodmap
- `PrivateForward` methodmap
- `ArrayList.Sort` instead of `SortADTArray`
- `any` variable instead of `int` in native callbacks 
- `RequestFrameCallback` no longer needing data param for starting dome function
- `ArrayList` instead of legacy `Handle` in `MultiTargetFilter` callback