### PR TITLE
Fix stacking tags function delay from refreshing loadout

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -496,6 +496,7 @@ public void OnPluginStart()
 	Function_Init();
 	Menu_Init();
 	NextBoss_Init();
+	TagsCall_Init();
 	TagsCore_Init();
 	TagsName_Init();
 	Winstreak_Init();

--- a/addons/sourcemod/scripting/vsh/config.sp
+++ b/addons/sourcemod/scripting/vsh/config.sp
@@ -440,7 +440,7 @@ void Config_Refresh()
 	delete kv;
 	
 	TagsName_Load();
-	for (int iClient = 0; iClient <= MaxClients; iClient++)
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
 		TagsCore_RefreshClient(iClient);
 	
 	ClassLimit_Refresh();

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -607,8 +607,8 @@ public void Tags_KillWeapon(int iClient, int iTarget, TagsParams tParams)
 			//Kill em
 			TF2_RemoveItemInSlot(iClient, iSlot);
 			
-			//Refresh tags stuff now that weapon is crabbed
-			TagsCore_RefreshClient(iClient);
+			//Refresh tags stuff now that weapon is crabbed, without clearing any pending function timers
+			TagsCore_RefreshClient(iClient, false);
 			return;
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/tags/tags_core.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_core.sp
@@ -93,12 +93,16 @@ void TagsCore_Clear()
 	g_tFunctions.Clear();
 }
 
-void TagsCore_RefreshClient(int iClient)
+void TagsCore_RefreshClient(int iClient, bool bClearTimer = true)
 {
 	//Delet existing arrays before creating new ones
 	for (TagsCall nCall; nCall < TagsCall; nCall++)
 		for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 			delete g_aTagsClient[iClient][nCall][iSlot];
+	
+	//Clear any pending function timers
+	if (bClearTimer)
+		TagsCall_ClearTimer(iClient);
 	
 	if (!SaxtonHale_IsValidAttack(iClient))
 		return;

--- a/addons/sourcemod/scripting/vsh/tags/tags_function.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_function.sp
@@ -121,19 +121,9 @@ methodmap TagsFunction < ArrayList
 		
 		float flDelay = tParams.flDelay;
 		if (flDelay >= 0.0)
-		{
-			//Create delay timer
-			DataPack data;
-			CreateDataTimer(flDelay, TagsCall_TimerDelay, data);
-			data.WriteFunction(functionStruct.func);
-			data.WriteCell(EntIndexToEntRef(iClient));
-			data.WriteCell(tParams);
-			data.WriteCell(tParams.iCall);
-		}
+			TagsCall_CallDelay(functionStruct.func, iClient, tParams, tParams.iCall, flDelay);
 		else
-		{
 			TagsCall_Call(functionStruct.func, iClient, tParams, tParams.iCall);
-		}
 	}
 	
 	public void Delete(int iPos)


### PR DESCRIPTION
It was possible to call delay tags function while playing as boss, or stacking functions together.
Prevent any pending delay functions called when refreshing client's loadout.

Thanks to @woisalreadytaken on finding this bug, boss able to gain minicrit from demoshield's delay minicrit function.