### PR TITLE
Airblast: Replace ammo cost to damage requirement

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -200,7 +200,7 @@
 			"Primary"
 			{
 				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}replace airblast ammo cost to 500 damage requirement"
-				"attrib"	"71 ; 3.0 ; 170 ; 0.0"
+				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"
 				{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -206,6 +206,8 @@
 				{
 					"Tags_Airblast"
 					{
+						"name"			"pyro-primary-airblast"
+						
 						"target"		"primary"
 						"damage"		"500"
 					}
@@ -841,6 +843,11 @@
 		{
 			"desp"			"Phlogistinator: {negative}No afterburn damage bonus"
 			"attrib"		"71 ; 1.0"
+			
+			"spawn"
+			{
+				"block"				"pyro-primary-airblast"	//Phlogistinator don't have airblast
+			}
 		}
 		
 		"1179"	//Thermal Thruster

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -199,7 +199,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}replace airblast ammo cost to 500 damage requirement"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}replace airblast ammo cost to 400 damage requirement"
 				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"
@@ -209,7 +209,7 @@
 						"name"			"pyro-primary-airblast"
 						
 						"target"		"primary"
-						"damage"		"500"
+						"damage"		"400"	//400 dmg required
 					}
 				}
 			}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -136,6 +136,9 @@
 //Tags_AddHealersUber     - Add uber to every healers healing target
 //- amount                  - Max uber to evenly split give every healers
 //
+//Tags_Airblast           - Set weapon to require damage inorder to able to airblast
+//- damage                  - Damage requirement to able to use airblast
+//
 //Tags_Explode            - Creates explosion at target
 //- damage                  - Explosion damage
 //- radius                  - Radius of explosion
@@ -196,8 +199,17 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}+250% airblast cost"
-				"attrib"	"71 ; 3.0 ; 170 ; 3.5"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}replace airblast ammo cost to 500 damage requirement"
+				"attrib"	"71 ; 3.0 ; 170 ; 0.0"
+				
+				"spawn"
+				{
+					"Tags_Airblast"
+					{
+						"target"		"primary"
+						"damage"		"500"
+					}
+				}
 			}
 			
 			"Melee"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -137,6 +137,7 @@
 //- amount                  - Max uber to evenly split give every healers
 //
 //Tags_Airblast           - Set weapon to require damage inorder to able to airblast
+//- start                   - Damage meter to start
 //- damage                  - Damage requirement to able to use airblast
 //
 //Tags_Explode            - Creates explosion at target
@@ -209,6 +210,7 @@
 						"name"			"pyro-primary-airblast"
 						
 						"target"		"primary"
+						"start"			"400"	//Start with 100% meter
 						"damage"		"400"	//400 dmg required
 					}
 				}

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -921,7 +921,6 @@ public Action Event_RoundStart(Event event, const char[] sName, bool bDontBroadc
 
 	g_iTotalAttackCount = SaxtonHale_GetAliveAttackPlayers();	//Update amount of attack players
 
-	Tags_RoundStart();
 	Winstreak_RoundStart();
 
 	RequestFrame(Frame_InitVshPreRoundTimer, tf_arena_preround_time.IntValue);
@@ -1617,9 +1616,8 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 
 	if (g_iTotalRoundPlayed <= 0) return;
 	
+	Tags_ResetClient(iClient);
 	TagsCore_RefreshClient(iClient);
-	
-	Hud_SetRageView(iClient, false);
 	
 	if (SaxtonHale_IsValidAttack(iClient))
 		TagsCore_CallAll(iClient, TagsCall_Spawn);
@@ -1640,6 +1638,7 @@ public Action Event_PlayerHurt(Event event, const char[] sName, bool bDontBroadc
 	{
 		int iAttacker = GetClientOfUserId(event.GetInt("attacker"));
 		int iDamageAmount = event.GetInt("damageamount");
+		Tags_OnPlayerHurt(iClient, iAttacker, iDamageAmount);
 		
 		if (0 < iAttacker <= MaxClients && IsClientInGame(iAttacker) && iClient != iAttacker)
 		{

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -113,6 +113,14 @@ enum
 	LifeState_Dead = 2
 };
 
+enum FlamethrowerState
+{
+	FlamethrowerState_Idle = 0,
+	FlamethrowerState_StartFiring,
+	FlamethrowerState_Firing,
+	FlamethrowerState_Airblast,
+};
+
 enum MinigunState
 {
 	MinigunState_Idle = 0,

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -50,6 +50,7 @@
 #define ITEM_ROCK_PAPER_SCISSORS	1110
 
 #define SOUND_ALERT			"ui/system_message_alert.wav"
+#define SOUND_METERFULL		"player/recharged.wav"
 #define SOUND_BACKSTAB		"player/spy_shield_break.wav"
 #define SOUND_DOUBLEDONK	"player/doubledonk.wav"
 
@@ -726,6 +727,7 @@ public void OnMapStart()
 		PrecacheParticleSystem(PARTICLE_GHOST);
 
 		PrecacheSound(SOUND_ALERT);
+		PrecacheSound(SOUND_METERFULL);
 		PrecacheSound(SOUND_BACKSTAB);
 		PrecacheSound(SOUND_DOUBLEDONK);
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -101,7 +101,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 		117: Attrib_Dmg_Falloff_Increased	//Doesnt even work thanks valve
 		*/
 		
-		Format(attribs, sizeof(attribs), "2 ; 4.55 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 4.55 ; 252 ; 0.5 ; 259 ; 1.0");
 		iWeapon = this.CallFunction("CreateWeapon", 194, "tf_weapon_knife", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -111,7 +111,6 @@ methodmap CAnnouncer < SaxtonHaleBase
 		2: Damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
@@ -84,7 +84,7 @@ methodmap CBlutarch < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 574, "tf_weapon_knife", 100, TFQual_Haunted, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -94,7 +94,6 @@ methodmap CBlutarch < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -133,7 +133,7 @@ methodmap CBrutalSniper < SaxtonHaleBase
 		*/
 		
 		g_iBrutalSniperWeaponCooldown[this.iClient][0] = BRUTALSNIPER_MAXWEAPONS - 2;	//Kukri
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0");
 		iWeapon = this.CallFunction("CreateWeapon", ITEM_KUKRI, "tf_weapon_club", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -143,7 +143,6 @@ methodmap CBrutalSniper < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
@@ -97,7 +97,7 @@ methodmap CDemoPan < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 264, "tf_weapon_bottle", 100, TFQual_Collectors, attribs);	//Frying Pan Index, classname doesnt like saxxy
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -107,7 +107,6 @@ methodmap CDemoPan < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 		
 		//Not really a weapon but still works lul

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -112,7 +112,7 @@ methodmap CDemoRobot < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65 ; 436 ; 1.0 ; 264 ; 0.73");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 436 ; 1.0 ; 264 ; 0.73");
 		int iWeapon = this.CallFunction("CreateWeapon", 132, "tf_weapon_sword", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -122,7 +122,7 @@ methodmap CDemoRobot < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
+		
 		436: ragdolls_plasma_effect
 		264: melee range multiplier (tf_weapon_sword have 37% extra range)
 		*/

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -132,7 +132,7 @@ methodmap CGentleSpy < SaxtonHaleBase
 		221: Attrib_DecloakRate
 		*/
 		
-		Format(attribs, sizeof(attribs), "2 ; 4.55 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 4.55 ; 252 ; 0.5 ; 259 ; 1.0");
 		iWeapon = this.CallFunction("CreateWeapon", 194, "tf_weapon_knife", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -142,7 +142,6 @@ methodmap CGentleSpy < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
@@ -131,7 +131,7 @@ methodmap CSaxtonHale < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65 ; 214 ; %d", GetRandomInt(9999, 99999));
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 214 ; %d", GetRandomInt(9999, 99999));
 		int iWeapon = this.CallFunction("CreateWeapon", 195, "tf_weapon_shovel", 100, TFQual_Strange, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -141,7 +141,6 @@ methodmap CSaxtonHale < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		214: kill_eater
 		*/
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -103,7 +103,7 @@ methodmap CHorsemann < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65 ; 264 ; 0.73 ; 551 ; 1");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 264 ; 0.73 ; 551 ; 1");
 		int iWeapon = this.CallFunction("CreateWeapon", 266, "tf_weapon_sword", 100, TFQual_Unusual, attribs);
 
 		if (iWeapon > MaxClients)
@@ -117,7 +117,6 @@ methodmap CHorsemann < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		436: ragdolls_plasma_effect
 		264: melee range multiplier (tf_weapon_sword have 37% extra range)
 		551: special taunt

--- a/addons/sourcemod/scripting/vsh/bosses/boss_painiscupcakes.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_painiscupcakes.sp
@@ -146,7 +146,7 @@ methodmap CPainisCupcake < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 195, "tf_weapon_shovel", 100, TFQual_Strange, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -156,7 +156,6 @@ methodmap CPainisCupcake < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -84,7 +84,7 @@ methodmap CRedmond < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 574, "tf_weapon_knife", 100, TFQual_Haunted, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -94,7 +94,6 @@ methodmap CRedmond < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -37,7 +37,7 @@ methodmap CSeeldier < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 1.9 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 1.9 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 195, "tf_weapon_shovel", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -47,7 +47,6 @@ methodmap CSeeldier < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
@@ -62,7 +62,7 @@ methodmap CSeeMan < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 1.9 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65");
+		Format(attribs, sizeof(attribs), "2 ; 1.9 ; 252 ; 0.5 ; 259 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 195, "tf_weapon_bottle", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -72,7 +72,6 @@ methodmap CSeeMan < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		*/
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -89,7 +89,7 @@ methodmap CVagineer < SaxtonHaleBase
 		this.CallFunction("CreateWeapon", 25, "tf_weapon_pda_engineer_build", 100, TFQual_Unusual, "");
 		
 		char attribs[256];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 329 ; 0.65 ; 93 ; 0.0 ; 95 ; 0.0 ; 343 ; 0.5 ; 353 ; 1.0 ; 436 ; 1.0 ; 464 ; 10.0 ; 2043 ; 0.0");
+		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 93 ; 0.0 ; 95 ; 0.0 ; 343 ; 0.5 ; 353 ; 1.0 ; 436 ; 1.0 ; 464 ; 10.0 ; 2043 ; 0.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 7, "tf_weapon_wrench", 100, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -99,7 +99,6 @@ methodmap CVagineer < SaxtonHaleBase
 		2: damage bonus
 		252: reduction in push force taken from damage
 		259: Deals 3x falling damage to the player you land on
-		329: reduction in airblast vulnerability
 		
 		93: Construction hit speed boost decreased
 		95: Slower repair speed

--- a/addons/sourcemod/scripting/vsh/hud.sp
+++ b/addons/sourcemod/scripting/vsh/hud.sp
@@ -55,9 +55,9 @@ void Hud_Think(int iClient)
 
 		Hud_AddText(iClient, sMessage);
 
-		//If dead, display whoever client is spectating and damage
 		if (!IsPlayerAlive(iClient))
 		{
+			//If dead, display whoever client is spectating and damage
 			int iOberserTarget = GetEntPropEnt(iClient, Prop_Send, "m_hObserverTarget");
 			if (iOberserTarget != iClient && 0 < iOberserTarget <= MaxClients && IsClientInGame(iOberserTarget) && !SaxtonHaleBase(iOberserTarget).bValid)
 			{
@@ -66,6 +66,16 @@ void Hud_Think(int iClient)
 				else
 					Format(sMessage, sizeof(sMessage), "%N's Damage: %i Assist: %i", iOberserTarget, g_iPlayerDamage[iOberserTarget], g_iPlayerAssistDamage[iOberserTarget]);
 				
+				Hud_AddText(iClient, sMessage);
+			}
+		}
+		else
+		{
+			//Display airblast percentage
+			float flPercentage = Tags_GetAirblastPercentage(iClient);
+			if (flPercentage >= 0.0)
+			{
+				Format(sMessage, sizeof(sMessage), "Airblast: %i%%", RoundToFloor(flPercentage * 100.0));
 				Hud_AddText(iClient, sMessage);
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -90,15 +90,21 @@ void Tags_OnPlayerHurt(int iVictim, int iAttacker, int iDamage)
 	{
 		if (g_iTagsAirblastRequirement[iAttacker] >= 0)
 		{
+			bool bFull = (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker]);
 			g_iTagsAirblastDamage[iAttacker] += iDamage;
 			
 			if (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker])
 			{
 				g_iTagsAirblastDamage[iAttacker] = g_iTagsAirblastRequirement[iAttacker];
 				
-				int iPrimary = TF2_GetItemInSlot(iAttacker, WeaponSlot_Primary);
-				if (iPrimary > MaxClients)
-					SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 0.0);	//Allow airblast to be used
+				if (!bFull)
+				{
+					EmitSoundToClient(iAttacker, SOUND_METERFULL);	//Alert player meter is fully
+					
+					int iPrimary = TF2_GetItemInSlot(iAttacker, WeaponSlot_Primary);
+					if (iPrimary > MaxClients)
+						SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 0.0);	//Allow airblast to be used
+				}
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -41,7 +41,7 @@ void Tags_OnThink(int iClient)
 	if (GetEntityFlags(iClient) & FL_ONGROUND)
 		g_iClimbAmount[iClient] = 0;
 	
-	if (g_iTagsAirblastRequirement[iClient] >= 0 && g_iTagsAirblastDamage[iClient] >= g_iTagsAirblastRequirement[iClient])
+	if (g_iTagsAirblastRequirement[iClient] > 0 && g_iTagsAirblastDamage[iClient] >= g_iTagsAirblastRequirement[iClient])
 	{
 		//Detect if airblast is used, and reset if so
 		int iPrimary = TF2_GetItemInSlot(iClient, WeaponSlot_Primary);
@@ -88,7 +88,7 @@ void Tags_OnPlayerHurt(int iVictim, int iAttacker, int iDamage)
 {
 	if (SaxtonHale_IsValidBoss(iVictim) && SaxtonHale_IsValidAttack(iAttacker))
 	{
-		if (g_iTagsAirblastRequirement[iAttacker] >= 0)
+		if (g_iTagsAirblastRequirement[iAttacker] > 0)
 		{
 			bool bFull = (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker]);
 			g_iTagsAirblastDamage[iAttacker] += iDamage;
@@ -769,7 +769,7 @@ stock int Tags_GetBackstabCount(int iClient, int iVictim)
 
 stock float Tags_GetAirblastPercentage(int iClient)
 {
-	if (g_iTagsAirblastRequirement[iClient] < 0)
+	if (g_iTagsAirblastRequirement[iClient] <= 0)
 		return -1.0;
 	
 	return float(g_iTagsAirblastDamage[iClient]) / float(g_iTagsAirblastRequirement[iClient]);

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -6,6 +6,7 @@ static bool g_bTagsLunchbox[TF_MAXPLAYERS+1];
 
 static int g_iTagsAirblastRequirement[TF_MAXPLAYERS+1];
 static int g_iTagsAirblastDamage[TF_MAXPLAYERS+1];
+static FlamethrowerState g_nTagsAirblastState[TF_MAXPLAYERS+1];
 
 static ArrayList g_aAttrib;	//Arrays of active attribs to be removed later
 
@@ -40,17 +41,20 @@ void Tags_OnThink(int iClient)
 	if (GetEntityFlags(iClient) & FL_ONGROUND)
 		g_iClimbAmount[iClient] = 0;
 	
-	if (g_iTagsAirblastRequirement[iClient] >= 0)
+	if (g_iTagsAirblastRequirement[iClient] >= 0 && g_iTagsAirblastDamage[iClient] >= g_iTagsAirblastRequirement[iClient])
 	{
-		//Detect if airblast is used
+		//Detect if airblast is used, and reset if so
 		int iPrimary = TF2_GetItemInSlot(iClient, WeaponSlot_Primary);
 		if (iPrimary > MaxClients)
 		{
-			if (g_iTagsAirblastDamage[iClient] >= g_iTagsAirblastRequirement[iClient] && GetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack") > GetGameTime())
+			FlamethrowerState nState = view_as<FlamethrowerState>(GetEntProp(iPrimary, Prop_Send, "m_iWeaponState"));
+			if (nState != g_nTagsAirblastState[iClient] && nState == FlamethrowerState_Airblast)
 			{
 				g_iTagsAirblastDamage[iClient] = 0;	//Reset damage
 				SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 31536000.0+GetGameTime());	//3 years
 			}
+			
+			g_nTagsAirblastState[iClient] = nState;
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -4,6 +4,9 @@ static int g_iZombieUsed[TF_MAXPLAYERS+1];
 
 static bool g_bTagsLunchbox[TF_MAXPLAYERS+1];
 
+static int g_iTagsAirblastRequirement[TF_MAXPLAYERS+1];
+static int g_iTagsAirblastDamage[TF_MAXPLAYERS+1];
+
 static ArrayList g_aAttrib;	//Arrays of active attribs to be removed later
 
 enum
@@ -14,19 +17,20 @@ enum
 	TagsAttrib_MAX,
 }
 
-void Tags_RoundStart()
+void Tags_ResetClient(int iClient)
 {
 	if (g_aAttrib == null)
 		g_aAttrib = new ArrayList(TagsAttrib_MAX);
 	
-	for (int iClient = 1; iClient <= MaxClients; iClient++)
-	{
-		g_iClimbAmount[iClient] = 0;
-		g_iZombieUsed[iClient] = 0;
-		
-		for (int iVictim = 1; iVictim <= MaxClients; iVictim++)
-			g_iBackstabCount[iClient][iVictim] = 0;
-	}
+	g_iClimbAmount[iClient] = 0;
+	g_iZombieUsed[iClient] = 0;
+	g_iTagsAirblastRequirement[iClient] = -1;
+	g_iTagsAirblastDamage[iClient] = 0;
+	
+	for (int iVictim = 1; iVictim <= MaxClients; iVictim++)
+		g_iBackstabCount[iClient][iVictim] = 0;
+	
+	Hud_SetRageView(iClient, false);
 }
 
 void Tags_OnThink(int iClient)
@@ -35,6 +39,20 @@ void Tags_OnThink(int iClient)
 	
 	if (GetEntityFlags(iClient) & FL_ONGROUND)
 		g_iClimbAmount[iClient] = 0;
+	
+	if (g_iTagsAirblastRequirement[iClient] >= 0)
+	{
+		//Detect if airblast is used
+		int iPrimary = TF2_GetItemInSlot(iClient, WeaponSlot_Primary);
+		if (iPrimary > MaxClients)
+		{
+			if (g_iTagsAirblastDamage[iClient] >= g_iTagsAirblastRequirement[iClient] && GetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack") > GetGameTime())
+			{
+				g_iTagsAirblastDamage[iClient] = 0;	//Reset damage
+				SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 31536000.0+GetGameTime());	//3 years
+			}
+		}
+	}
 	
 	int iSecondary = TF2_GetItemInSlot(iClient, WeaponSlot_Secondary);
 	if (iSecondary > MaxClients)
@@ -57,6 +75,26 @@ void Tags_OnThink(int iClient)
 					g_bTagsLunchbox[iClient] = true;
 					TagsCore_CallAll(iClient, TagsCall_Lunchbox);
 				}
+			}
+		}
+	}
+}
+
+void Tags_OnPlayerHurt(int iVictim, int iAttacker, int iDamage)
+{
+	if (SaxtonHale_IsValidBoss(iVictim) && SaxtonHale_IsValidAttack(iAttacker))
+	{
+		if (g_iTagsAirblastRequirement[iAttacker] >= 0)
+		{
+			g_iTagsAirblastDamage[iAttacker] += iDamage;
+			
+			if (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker])
+			{
+				g_iTagsAirblastDamage[iAttacker] = g_iTagsAirblastRequirement[iAttacker];
+				
+				int iPrimary = TF2_GetItemInSlot(iAttacker, WeaponSlot_Primary);
+				if (iPrimary > MaxClients)
+					SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 0.0);	//Allow airblast to be used
 			}
 		}
 	}
@@ -582,6 +620,12 @@ public void Tags_AddHealersUber(int iClient, int iTarget, TagsParams tParams)
 	}
 }
 
+public void Tags_Airblast(int iClient, int iTarget, TagsParams tParams)
+{
+	g_iTagsAirblastRequirement[iClient] = tParams.GetInt("damage", -1);
+	SetEntPropFloat(iTarget, Prop_Send, "m_flNextSecondaryAttack", 31536000.0+GetGameTime());	//3 years
+}
+
 public void Tags_Explode(int iClient, int iTarget, TagsParams tParams)
 {
 	if (iTarget <= 0 || !IsValidEdict(iTarget))
@@ -706,4 +750,12 @@ public Action Timer_ResetAttrib(Handle hTimer, DataPack data)
 stock int Tags_GetBackstabCount(int iClient, int iVictim)
 {
 	return g_iBackstabCount[iClient][iVictim];
+}
+
+stock float Tags_GetAirblastPercentage(int iClient)
+{
+	if (g_iTagsAirblastRequirement[iClient] < 0)
+		return -1.0;
+	
+	return float(g_iTagsAirblastDamage[iClient]) / float(g_iTagsAirblastRequirement[iClient]);
 }

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -633,7 +633,12 @@ public void Tags_AddHealersUber(int iClient, int iTarget, TagsParams tParams)
 public void Tags_Airblast(int iClient, int iTarget, TagsParams tParams)
 {
 	g_iTagsAirblastRequirement[iClient] = tParams.GetInt("damage", -1);
-	SetEntPropFloat(iTarget, Prop_Send, "m_flNextSecondaryAttack", 31536000.0+GetGameTime());	//3 years
+	g_iTagsAirblastDamage[iClient] = tParams.GetInt("start", 0);
+	
+	if (g_iTagsAirblastRequirement[iClient] > g_iTagsAirblastDamage[iClient])
+		SetEntPropFloat(iTarget, Prop_Send, "m_flNextSecondaryAttack", 31536000.0+GetGameTime());	//3 years
+	else
+		SetEntPropFloat(iTarget, Prop_Send, "m_flNextSecondaryAttack", 0.0);
 }
 
 public void Tags_Explode(int iClient, int iTarget, TagsParams tParams)


### PR DESCRIPTION
VSH with airblast issue will never end.

Currently, 70 ammo cost for airblast still isn't enough to help prevent spam, because of dispenser able to keep feeding ammo endless amount, along with ammo packs around the map. Thermal Thruster also stacks up annoyance with escaping and landing to dispenser/ammo pack to keep up the annoyance.

Instead of using ammo as a cost, 500 damage is required everytime airblast is used, with no ammo cost. Hud will display percentage progress on when able to use airblast from damage dealt. Boss's airblast reduction in airblast vulnerability has been removed along with that.

Hopefully this should make airblast feels more rewarding.