### PR TITLE
Fix high environmental damage teleporting bosses once per valid spawn point and add the stun animation to it

### DIFF
--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -327,7 +327,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 							float vecNoVel[3];
 							TeleportEntity(this.iClient, vecPos, NULL_VECTOR, vecNoVel);
 							damage = (damagetype & DMG_ACID) ? this.flEnvDamageCap/3.0 : this.flEnvDamageCap;
-							TF2_StunPlayer(this.iClient, 2.0, 1.0, 257, 0);
+							TF2_StunPlayer(this.iClient, 2.0, _, TF_STUNFLAGS_NORMALBONK, 0);
 							bTeleported = true;
 							action = Plugin_Changed;
 						}

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -316,22 +316,25 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 				{
 					int iBossSpawn = MaxClients+1;
 					int iTeam = GetClientTeam(this.iClient);
-					bool bTeleported = false;
+					ArrayList aSpawnPoints = new ArrayList();
 					
-					while((iBossSpawn = FindEntityByClassname(iBossSpawn, "info_player_teamspawn")) > MaxClients && !bTeleported)
-					{
+					while ((iBossSpawn = FindEntityByClassname(iBossSpawn, "info_player_teamspawn")) > MaxClients)
 						if (GetEntProp(iBossSpawn, Prop_Send, "m_iTeamNum") == iTeam)
-						{
-							float vecPos[3];
-							GetEntPropVector(iBossSpawn, Prop_Data, "m_vecAbsOrigin", vecPos);
-							float vecNoVel[3];
-							TeleportEntity(this.iClient, vecPos, NULL_VECTOR, vecNoVel);
-							damage = (damagetype & DMG_ACID) ? this.flEnvDamageCap/3.0 : this.flEnvDamageCap;
-							TF2_StunPlayer(this.iClient, 2.0, _, TF_STUNFLAGS_NORMALBONK, 0);
-							bTeleported = true;
-							action = Plugin_Changed;
-						}
+							aSpawnPoints.Push(iBossSpawn);
+					
+					if (aSpawnPoints.Length > 0)
+					{
+						aSpawnPoints.Sort(Sort_Random, Sort_Integer);
+						float vecPos[3];
+						GetEntPropVector(aSpawnPoints.Get(0), Prop_Data, "m_vecAbsOrigin", vecPos);
+						float vecNoVel[3];
+						TeleportEntity(this.iClient, vecPos, NULL_VECTOR, vecNoVel);
+						TF2_StunPlayer(this.iClient, 2.0, _, TF_STUNFLAGS_NORMALBONK, 0);
 					}
+					
+					delete aSpawnPoints;
+					damage = (damagetype & DMG_ACID) ? this.flEnvDamageCap/3.0 : this.flEnvDamageCap;
+					action = Plugin_Changed;
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -316,7 +316,9 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 				{
 					int iBossSpawn = MaxClients+1;
 					int iTeam = GetClientTeam(this.iClient);
-					while((iBossSpawn = FindEntityByClassname(iBossSpawn, "info_player_teamspawn")) > MaxClients)
+					bool bTeleported = false;
+					
+					while((iBossSpawn = FindEntityByClassname(iBossSpawn, "info_player_teamspawn")) > MaxClients && !bTeleported)
 					{
 						if (GetEntProp(iBossSpawn, Prop_Send, "m_iTeamNum") == iTeam)
 						{
@@ -326,6 +328,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 							TeleportEntity(this.iClient, vecPos, NULL_VECTOR, vecNoVel);
 							damage = (damagetype & DMG_ACID) ? this.flEnvDamageCap/3.0 : this.flEnvDamageCap;
 							TF2_StunPlayer(this.iClient, 2.0, 1.0, 257, 0);
+							bTeleported = true;
 							action = Plugin_Changed;
 						}
 					}


### PR DESCRIPTION
High environmental damage has been stunning bosses for a while but it just doesn't let bosses move instead of showing them they're actually stunned, so I changed that to give better visual feedback to them.
On the way, I found out that bosses get teleported and stunned multiple times if there's more than one spawn point for their team, so I added a check to stop the plugin from doing so if they were already teleported (and to also stop it from fucking destroying people's eardrums with the new stun sound).