### PR TITLE
Fix error from trying to add an attribute instead of condition

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1074,7 +1074,7 @@
 					"damagetype"	"knockback"	//...enable full knockback...
 				}
 				
-				"Tags_AddAttrib"
+				"Tags_AddCond"
 				{
 					"target"		"victim"
 					"cond"			"127"	//...and give the airblast air control penalty to the boss...


### PR DESCRIPTION
I did a word and it got overlooked, things got a bit jumbled up when the config got tested in VR Lab rather than my local server.