### PR TITLE
Fix HHH Jr. and Seeman rages not forcing third person if sv_cheats is off

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_bomb.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_bomb.sp
@@ -103,10 +103,9 @@ methodmap CBomb < SaxtonHaleBase
 		FakeClientCommand(this.iClient, "taunt");
 		SetEntityMoveType(this.iClient, MOVETYPE_NONE);
 		
-		int iFlags = GetCommandFlags("thirdperson");
-		SetCommandFlags("thirdperson", iFlags & (~FCVAR_CHEAT));
-		ClientCommand(this.iClient, "thirdperson");
-		SetCommandFlags("thirdperson", iFlags);
+		//Force thirdperson view
+		SetVariantInt(1);
+		AcceptEntityInput(this.iClient, "SetForcedTauntCam");
 	}
 	
 	public void OnThink()
@@ -149,10 +148,9 @@ methodmap CBomb < SaxtonHaleBase
 			TF2_RemoveCondition(this.iClient, TFCond_Taunting);
 			SetEntityMoveType(this.iClient, MOVETYPE_WALK);
 			
-			int iFlags = GetCommandFlags("firstperson");
-			SetCommandFlags("firstperson", iFlags & (~FCVAR_CHEAT));
-			ClientCommand(this.iClient, "firstperson");
-			SetCommandFlags("firstperson", iFlags);
+			//Set view back to first person
+			SetVariantInt(0);
+			AcceptEntityInput(this.iClient, "SetForcedTauntCam");
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -131,10 +131,8 @@ methodmap CRageGhost < SaxtonHaleBase
 		}
 		
 		//Thirdperson
-		int iFlags = GetCommandFlags("thirdperson");
-		SetCommandFlags("thirdperson", iFlags & (~FCVAR_CHEAT));
-		ClientCommand(this.iClient, "thirdperson");
-		SetCommandFlags("thirdperson", iFlags);
+		SetVariantInt(1);
+		AcceptEntityInput(this.iClient, "SetForcedTauntCam");
 	}
 	
 	public void OnThink()
@@ -323,10 +321,8 @@ methodmap CRageGhost < SaxtonHaleBase
 			}
 			
 			//Firstperson
-			int iFlags = GetCommandFlags("firstperson");
-			SetCommandFlags("firstperson", iFlags & (~FCVAR_CHEAT));
-			ClientCommand(iClient, "firstperson");
-			SetCommandFlags("firstperson", iFlags);
+			SetVariantInt(0);
+			AcceptEntityInput(this.iClient, "SetForcedTauntCam");
 		}
 	}
 	


### PR DESCRIPTION
As of now, the plugin tries to go around cheats to toggle thirdperson, but fails to do so. This PR changes the method of switching between first and thirdperson to the `SetForcedTauntCam` input, which works when cheats are off.