### PR TITLE
Add bonemerge model boss ability

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -158,6 +158,25 @@ enum
 	LAST_SHARED_COLLISION_GROUP
 };
 
+// entity effects
+enum
+{
+	EF_BONEMERGE			= (1<<0),	// Performs bone merge on client side
+	EF_BRIGHTLIGHT			= (1<<1),	// DLIGHT centered at entity origin
+	EF_DIMLIGHT				= (1<<2),	// player flashlight
+	EF_NOINTERP				= (1<<3),	// don't interpolate the next frame
+	EF_NOSHADOW				= (1<<4),	// Don't cast no shadow
+	EF_NODRAW				= (1<<5),	// don't draw entity
+	EF_NORECEIVESHADOW		= (1<<6),	// Don't receive no shadow
+	EF_BONEMERGE_FASTCULL	= (1<<7),	// For use with EF_BONEMERGE. If this is set, then it places this ent's origin at its
+										// parent and uses the parent's bbox + the max extents of the aiment.
+										// Otherwise, it sets up the parent's bones every frame to figure out where to place
+										// the aiment, which is inefficient because it'll setup the parent's bones even if
+										// the parent is not in the PVS.
+	EF_ITEM_BLINK			= (1<<8),	// blink an item so that the user notices it.
+	EF_PARENT_ANIMATES		= (1<<9),	// always assume that the parent entity is animating
+};
+
 // Beam types, encoded as a byte
 enum 
 {
@@ -347,6 +366,7 @@ Handle g_hSDKEquipWearable = null;
 #include "vsh/abilities/ability_body_eat.sp"
 #include "vsh/abilities/ability_brave_jump.sp"
 #include "vsh/abilities/ability_drop_model.sp"
+#include "vsh/abilities/ability_model_override.sp"
 #include "vsh/abilities/ability_rage_bomb.sp"
 #include "vsh/abilities/ability_rage_conditions.sp"
 #include "vsh/abilities/ability_rage_ghost.sp"
@@ -542,6 +562,7 @@ public void OnPluginStart()
 	SaxtonHale_RegisterAbility("CBraveJump");
 	SaxtonHale_RegisterAbility("CDropModel");
 	SaxtonHale_RegisterAbility("CBomb");
+	SaxtonHale_RegisterAbility("CModelOverride");
 	SaxtonHale_RegisterAbility("CRageAddCond");
 	SaxtonHale_RegisterAbility("CRageGhost");
 	SaxtonHale_RegisterAbility("CLightRage");
@@ -1454,7 +1475,6 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 {
 	if (!g_bEnabled) return Plugin_Continue;
 	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
-	if (!g_bRoundStarted) return Plugin_Continue;
 
 	int iVictim = GetClientOfUserId(event.GetInt("userid"));
 	int iAttacker = GetClientOfUserId(event.GetInt("attacker"));
@@ -1491,7 +1511,7 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 			bossAttacker.CallFunction("OnPlayerKilled", event, iVictim);
 	}
 	
-	if (SaxtonHale_IsValidAttack(iVictim) && !bDeadRinger)
+	if (g_bRoundStarted && !bDeadRinger && SaxtonHale_IsValidAttack(iVictim))
 	{
 		//Victim who died is still "alive" during this event, so we subtract by 1 to not count victim
 		int iLastAlive = SaxtonHale_GetAliveAttackPlayers() - 1;
@@ -1550,7 +1570,7 @@ public Action Event_PlayerDeath(Event event, const char[] sName, bool bDontBroad
 	}
 	
 	//Reset flags
-	if (!bDeadRinger)
+	if (g_bRoundStarted && !bDeadRinger)
 	{
 		g_iClientOwner[iVictim] = 0;
 		Client_RemoveFlag(iVictim, haleClientFlags_BossTeam);

--- a/addons/sourcemod/scripting/vsh/abilities/ability_model_override.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_model_override.sp
@@ -1,0 +1,165 @@
+static bool g_bModelOverrideEnable[TF_MAXPLAYERS+1];
+static int g_iModelOverrideRef[TF_MAXPLAYERS+1][2];
+static int g_iModelOverrideSkin[TF_MAXPLAYERS+1];
+static float g_flModelOverrideScale[TF_MAXPLAYERS+1];
+static char g_sModelOverrideModel[TF_MAXPLAYERS+1][PLATFORM_MAX_PATH];
+
+methodmap CModelOverride < SaxtonHaleBase
+{
+	property bool bEnable
+	{
+		public set(bool bVal)
+		{
+			g_bModelOverrideEnable[this.iClient] = bVal;
+			
+			int iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][0]);
+			if (iModel > MaxClients)
+				SetEntityRenderMode(this.iClient, bVal ? RENDER_NORMAL : RENDER_NONE);
+			
+			iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][1]);
+			if (iModel > MaxClients)
+				SetEntityRenderMode(this.iClient, bVal ? RENDER_NORMAL : RENDER_NONE);
+		}
+		public get()
+		{
+			return g_bModelOverrideEnable[this.iClient];
+		}
+	}
+	
+	property int iSkin
+	{
+		public set(int iVal)
+		{
+			g_iModelOverrideSkin[this.iClient] = iVal;
+			
+			int iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][0]);
+			if (iModel > MaxClients)
+				SetEntProp(iModel, Prop_Send, "m_nSkin", iVal);
+			
+			iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][1]);
+			if (iModel > MaxClients)
+				SetEntProp(iModel, Prop_Send, "m_nSkin", iVal);
+		}
+		public get()
+		{
+			return g_iModelOverrideSkin[this.iClient];
+		}
+	}
+	
+	property float flScale
+	{
+		public set(float flVal)
+		{
+			g_flModelOverrideScale[this.iClient] = flVal;
+			
+			int iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][0]);
+			if (iModel > MaxClients)
+				DispatchKeyValueFloat(iModel, "modelscale", flVal);
+			
+			iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][1]);
+			if (iModel > MaxClients)
+				DispatchKeyValueFloat(iModel, "modelscale", flVal);
+		}
+		public get()
+		{
+			return g_flModelOverrideScale[this.iClient];
+		}
+	}
+	
+	public CModelOverride(CModelOverride ability)
+	{
+		ability.bEnable = true;
+		ability.iSkin = 0;
+		ability.flScale = 1.0;
+		
+		g_iModelOverrideRef[ability.iClient][0] = 0;
+		g_iModelOverrideRef[ability.iClient][1] = 0;
+	}
+	
+	public void SetModel(char[] sModel)
+	{
+		strcopy(g_sModelOverrideModel[this.iClient], sizeof(g_sModelOverrideModel[]), sModel);
+	}
+	
+	public int CreateModel()
+	{
+		int iModel = CreateEntityByName("prop_dynamic_override");
+		if (iModel > MaxClients)
+		{
+			SetEntProp(iModel, Prop_Send, "m_CollisionGroup", COLLISION_GROUP_WEAPON);
+			SetEntProp(iModel, Prop_Send, "m_fEffects", EF_BONEMERGE|EF_NOSHADOW|EF_BONEMERGE_FASTCULL|EF_PARENT_ANIMATES);
+			DispatchKeyValue(iModel, "model", g_sModelOverrideModel[this.iClient]);
+			DispatchKeyValueFloat(iModel, "modelscale", this.flScale);
+			
+			SetEntityRenderMode(iModel, this.bEnable ? RENDER_NORMAL : RENDER_NONE);
+			SetEntProp(iModel, Prop_Send, "m_nSkin", this.iSkin);
+			SetEntProp(iModel, Prop_Send, "m_hOwnerEntity", this.iClient);
+			
+			DispatchSpawn(iModel);
+			
+			return iModel;
+		}
+		
+		return -1;
+	}
+	
+	public void DeleteModel()
+	{
+		int iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][0]);
+		if (iModel > MaxClients)
+			AcceptEntityInput(iModel, "Kill");
+		
+		iModel = EntRefToEntIndex(g_iModelOverrideRef[this.iClient][1]);
+		if (iModel > MaxClients)
+			AcceptEntityInput(iModel, "Kill");
+		
+		g_iModelOverrideRef[this.iClient][0] = 0;
+		g_iModelOverrideRef[this.iClient][1] = 0;
+	}
+	
+	public void OnSpawn()
+	{
+		this.DeleteModel();
+		
+		//We need to create 2 props to make this work. iModel[0] parented to iModel[1] parented to client
+		int iModel[2];
+		iModel[0] = this.CreateModel();
+		iModel[1] = this.CreateModel();
+		
+		if (!IsValidEdict(iModel[0]) || !IsValidEdict(iModel[1]))
+			return;
+		
+		SetVariantString("!activator");
+		AcceptEntityInput(iModel[0], "SetParent", iModel[1]);
+		
+		SetVariantString("head");
+		AcceptEntityInput(iModel[0], "SetParentAttachment");
+		
+		SetVariantString("!activator");
+		AcceptEntityInput(iModel[1], "SetParent", this.iClient);
+		
+		SetVariantString("head");
+		AcceptEntityInput(iModel[1], "SetParentAttachment");
+		
+		g_iModelOverrideRef[this.iClient][0] = EntIndexToEntRef(iModel[0]);
+		g_iModelOverrideRef[this.iClient][1] = EntIndexToEntRef(iModel[1]);
+		SetEntityRenderMode(this.iClient, RENDER_NONE);
+	}
+	
+	public void OnDeath()
+	{
+		this.DeleteModel();
+		
+		if (!this.bEnable) return;
+		
+		//Just so we can get nice looking ragdoll
+		SetVariantString(g_sModelOverrideModel[this.iClient]);
+		AcceptEntityInput(this.iClient, "SetCustomModel");
+	}
+	
+	public void Destroy()
+	{
+		this.DeleteModel();
+		SetEntityRenderMode(this.iClient, RENDER_NORMAL);
+	}
+}

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -98,6 +98,11 @@ methodmap CRageGhost < SaxtonHaleBase
 		g_bGhostEnable[iClient] = true;
 		SetEntProp(iClient, Prop_Data, "m_takedamage", DAMAGE_NO);
 		
+		//Disable prop override if have one
+		CModelOverride modelOverride = this.CallFunction("FindAbility", "CModelOverride");
+		if (modelOverride != INVALID_ABILITY)
+			modelOverride.bEnable = false;
+		
 		//Update model
 		ApplyBossModel(iClient);
 		
@@ -298,6 +303,11 @@ methodmap CRageGhost < SaxtonHaleBase
 				g_iGhostHealGainCount[iClient][iVictim] = 0;
 				Timer_EntityCleanup(null, g_iGhostParticleBeam[iClient][iVictim]);
 			}
+			
+			//Re-enable prop override if have one
+			CModelOverride modelOverride = this.CallFunction("FindAbility", "CModelOverride");
+			if (modelOverride != INVALID_ABILITY)
+				modelOverride.bEnable = true;
 			
 			//Update model
 			ApplyBossModel(this.iClient);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
@@ -99,6 +99,8 @@ methodmap CBlutarch < SaxtonHaleBase
 	
 	public void OnDeath(Event eventInfo)
 	{
+		if (!g_bRoundStarted) return;
+		
 		for (int iClient = 1; iClient <= MaxClients; iClient++)
 		{
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -75,6 +75,12 @@ methodmap CHorsemann < SaxtonHaleBase
 		boss.CallFunction("CreateAbility", "CTeleportSwap");
 		boss.CallFunction("CreateAbility", "CRageGhost");
 		
+		/*
+		CModelOverride modelOverride = boss.CallFunction("CreateAbility", "CModelOverride");
+		modelOverride.SetModel(HORSEMANN_MODEL);
+		modelOverride.flScale = 0.5;
+		*/
+		
 		boss.iBaseHealth = 700;
 		boss.iHealthPerPlayer = 650;
 		boss.nClass = TFClass_DemoMan;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -99,6 +99,8 @@ methodmap CRedmond < SaxtonHaleBase
 	
 	public void OnDeath(Event eventInfo)
 	{
+		if (!g_bRoundStarted) return;
+		
 		for (int iClient = 1; iClient <= MaxClients; iClient++)
 		{
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);

--- a/addons/sourcemod/scripting/vsh/network.sp
+++ b/addons/sourcemod/scripting/vsh/network.sp
@@ -74,7 +74,7 @@ stock bool Network_CreateEntityGlow(int iEntity, char[] sModel, int iColor[4] = 
 		
 		// Set effect flags.
 		int iFlags = GetEntProp(iGlow, Prop_Send, "m_fEffects");
-		SetEntProp(iGlow, Prop_Send, "m_fEffects", iFlags | (1 << 0)); // EF_BONEMERGE
+		SetEntProp(iGlow, Prop_Send, "m_fEffects", iFlags | EF_BONEMERGE); // EF_BONEMERGE
 		
 		SetVariantString("!activator");
 		AcceptEntityInput(iGlow, "SetParent", iEntity);


### PR DESCRIPTION
This took quite a bit of hacky and pain to get this working. Instead of using `player` entity as a model, we use `prop_dynamic_override` entity parented to player, along with `EF_BONEMERGE` where entity's model would follow player's model animation. Two `prop_dynamic_override` is needed, entity 1 parented to entity 2 parented to player. I tried to use just 1 of em, but it just doesn't work.

This is still work in progress. HHH's model need to be resided to more reasonable size, and probably broke to shit with ghost rage.

`CModelOverride` ability can also be used for Yeti (#43) and Merasmus (#51), using TF2's model without needing custom model.