### PR TITLE
Disable Ice modifier

### DIFF
--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_ice.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_ice.sp
@@ -9,6 +9,11 @@ methodmap CModifiersIce < SaxtonHaleBase
 	{
 	}
 	
+	public bool IsModifiersHidden()
+	{
+		return true;
+	}
+	
 	public void GetModifiersName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Ice");
@@ -78,7 +83,7 @@ methodmap CModifiersIce < SaxtonHaleBase
 					g_flPlayerSpeedMultiplier[i] *= ICE_SLOWDOWN;
 					
 					//Recalculate player's speed
-					TF2_AddCondition(this.iClient, TFCond_SpeedBuffAlly, 0.01);
+					TF2_AddCondition(i, TFCond_SpeedBuffAlly, 0.01);
 					
 					CreateTimer(ICE_DURATION, Timer_ResetSpeed, EntIndexToEntRef(i));
 				}


### PR DESCRIPTION
There have been complaints about Ice modifier not being a good modifier as the upside wasn't noticeable, so people were deeming it a straight downgrade.
...well, that's because it apparently is.

The modifier's upside wouldn't work because it was modifying the victim's speed, as intended, but would try to recalculate the boss' speed instead. This has been "fixed".

That's not enough, as the function that calculates max speed uses a pre hook, rather than post. It'll always return `0.0` and make a player move at 520 hu/s if their speed multiplier is modified. 42 and I looked into this for a bit, but no matter what was done it'd crash the server, so I suggest that the modifier should be disabled for now. The modifier will still be available for server administrators to force it upon players, making it sort of a challenge modifier.