### PR TITLE
Refactor calling function outside of CallFunction

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -45,6 +45,77 @@ enum SaxtonHaleSound
 };
 
 /**
+ * Registers a boss to be selected, use more than 1 bosses in 1 native for misc boss
+ *
+ * @note Make sure plugin unregisters boss once unloaded
+ *
+ * @param ...               Methodmap constructor of boss type.
+ * @noreturn
+ * @error                   No params passed, or constructor already exists from boss, modifiers or ability
+ */
+native void SaxtonHale_RegisterBoss(const char[] ...);
+
+/**
+ * Unregisters a boss
+ *
+ * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
+ *
+ * @param                   sBossType Methodmap constructor of boss type.
+ * @noreturn
+ */
+native void SaxtonHale_UnregisterBoss(const char[] sBossType);
+
+/**
+ * Registers a modifier to be selected
+ *
+ * @note Make sure plugin unregisters modifiers once unloaded
+ *
+ * @param sModifiersType    Methodmap constructor of modifiers type.
+ * @noreturn
+ * @error                   Constructor already exists from boss, modifiers or ability
+ */
+native void SaxtonHale_RegisterModifiers(const char[] sModifiersType);
+
+/**
+ * Unregisters a modifier
+ *
+ * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
+ *
+ * @param sModifiersType    Methodmap constructor of modifiers type.
+ * @noreturn
+ */
+native void SaxtonHale_UnregisterModifiers(const char[] sModifiersType);
+
+/**
+ * Registers an ability to have functions be called
+ *
+ * @note Make sure plugin unregisters ability once unloaded
+ *
+ * @param sAbilityType      Methodmap constructor of ability type.
+ * @noreturn
+ * @error                   Constructor already exists from boss, modifiers or ability
+ */
+native void SaxtonHale_RegisterAbility(const char[] sAbilityType);
+
+/**
+ * Unregisters an ability
+ *
+ * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
+ *
+ * @param sAbilityType      Methodmap constructor of modifiers type.
+ * @noreturn
+ */
+native void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
+
+/**
+ * Gets constructor's plugin owner
+ *
+ * @param sType             Methodmap constructor to get plugin owner.
+ * @return                  Constructor's plugin owner handle, null if constructor does not exist
+ */
+native Handle SaxtonHale_GetPlugin(const char[] sType);
+
+/**
  * Boss methodmap
  */
 methodmap SaxtonHaleBase
@@ -63,6 +134,29 @@ methodmap SaxtonHaleBase
 	// @return			    Return value of function
 	// @error               Invalid function name, too few params expected, incorrect ParamType or reached max allowed call stack.
 	public native any CallFunction(const char[] sName, any...);
+	
+	// Starts a function to specified constructor and function name, ignoring hooks
+	//
+	// @param sType         Name of constructor to call
+	// @param sFunction     Function name to call
+	// @return              True if found and function call started, false if function does not exist
+	public bool StartFunction(const char[] sType, const char[] sFunction)
+	{
+		Handle hPlugin = SaxtonHale_GetPlugin(sType);
+		if (hPlugin == null)
+			return false;
+		
+		char sBuffer[64];
+		Format(sBuffer, sizeof(sBuffer), "%s.%s", sType, sFunction);
+		
+		Function func = GetFunctionByName(hPlugin, sBuffer);
+		if (func == INVALID_FUNCTION)
+			return false;
+		
+		Call_StartFunction(hPlugin, func);
+		Call_PushCell(this);
+		return true;
+	}
 	
 	// Retrieve client index.
 	property int iClient
@@ -353,69 +447,6 @@ native void SaxtonHale_GetParamString(int iParam, char[] value, int iLength);
  * @error                   Called while not inside hook, param outside of bounds, or ParamType not String
  */
 native void SaxtonHale_SetParamString(int iParam, char[] value);
-
-/**
- * Registers a boss to be selected, use more than 1 bosses in 1 native for misc boss
- *
- * @note Make sure plugin unregisters boss once unloaded
- *
- * @param ...               Methodmap constructor of boss type.
- * @noreturn
- * @error                   No params passed, or constructor already exists from boss, modifiers or ability
- */
-native void SaxtonHale_RegisterBoss(const char[] ...);
-
-/**
- * Unregisters a boss
- *
- * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
- *
- * @param                   sBossType Methodmap constructor of boss type.
- * @noreturn
- */
-native void SaxtonHale_UnregisterBoss(const char[] sBossType);
-
-/**
- * Registers a modifier to be selected
- *
- * @note Make sure plugin unregisters modifiers once unloaded
- *
- * @param sModifiersType    Methodmap constructor of modifiers type.
- * @noreturn
- * @error                   Constructor already exists from boss, modifiers or ability
- */
-native void SaxtonHale_RegisterModifiers(const char[] sModifiersType);
-
-/**
- * Unregisters a modifier
- *
- * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
- *
- * @param sModifiersType    Methodmap constructor of modifiers type.
- * @noreturn
- */
-native void SaxtonHale_UnregisterModifiers(const char[] sModifiersType);
-
-/**
- * Registers an ability to have functions be called
- *
- * @note Make sure plugin unregisters ability once unloaded
- *
- * @param sAbilityType      Methodmap constructor of ability type.
- * @noreturn
- * @error                   Constructor already exists from boss, modifiers or ability
- */
-native void SaxtonHale_RegisterAbility(const char[] sAbilityType);
-
-/**
- * Unregisters an ability
- *
- * @note If one of misc boss is removed while other boss still here, it get auto-moved to normal boss pick.
- *
- * @param sAbilityType      Methodmap constructor of modifiers type.
- * @noreturn
- */
-native void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
 
 /**
  * Forward called when boss got telefraged

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -509,6 +509,12 @@ public void OnPluginStart()
 	TagsName_Init();
 	Winstreak_Init();
 	
+	//Add base constructor to list of plugins (dont register!)
+	Handle hPlugin = GetMyHandle();
+	Function_AddPlugin("SaxtonHaleBoss", hPlugin);
+	Function_AddPlugin("SaxtonHaleModifiers", hPlugin);
+	Function_AddPlugin("SaxtonHaleAbility", hPlugin);
+	
 	//Register normal bosses
 	SaxtonHale_RegisterBoss("CSaxtonHale");
 	SaxtonHale_RegisterBoss("CPainisCupcake");
@@ -710,22 +716,16 @@ public void OnMapStart()
 		Config_Refresh();
 
 		//Precache every bosses/abilities/modifiers registered
+		SaxtonHaleBase boss = SaxtonHaleBase(0); //client index doesn't matter
 		StringMapSnapshot snapshot = Function_GetPluginSnapshot();
+		
 		int iLength = snapshot.Length;
 		for (int i = 0; i < iLength; i++)
 		{
-			char sFunction[256];
-			snapshot.GetKey(i, sFunction, sizeof(sFunction));
-			StrCat(sFunction, sizeof(sFunction), ".Precache");	// CSaxtonHale.Precache
-			
-			Handle hPlugin = Function_GetPlugin(sFunction);
-			Function func = GetFunctionByName(hPlugin, sFunction);
-			if (func != INVALID_FUNCTION)
-			{
-				Call_StartFunction(hPlugin, func);
-				Call_PushCell(0);	//Client index, but doesn't matter when we want to just precache stuffs
+			char sType[256];
+			snapshot.GetKey(i, sType, sizeof(sType));
+			if (boss.StartFunction(sType, "Precache"))
 				Call_Finish();
-			}
 		}
 
 		delete snapshot;

--- a/addons/sourcemod/scripting/vsh/base_ability.sp
+++ b/addons/sourcemod/scripting/vsh/base_ability.sp
@@ -13,15 +13,9 @@ methodmap SaxtonHaleAbility < SaxtonHaleBase
 			{
 				strcopy(g_sAbilityType[this.iClient][i], sizeof(g_sAbilityType[][]), type);
 				
-				char sFunction[256];
-				Format(sFunction, sizeof(sFunction), "%s.%s", type, type);
-				
-				Handle hPlugin = Function_GetPlugin(type);
-				Function func = GetFunctionByName(hPlugin, sFunction);
-				if (func != INVALID_FUNCTION)
+				//Call ability's constructor function
+				if (this.StartFunction(type, type))
 				{
-					Call_StartFunction(hPlugin, func);
-					Call_PushCell(this);
 					Call_PushCell(this);
 					Call_Finish();
 				}
@@ -54,17 +48,9 @@ methodmap SaxtonHaleAbility < SaxtonHaleBase
 			{
 				Format(g_sAbilityType[this.iClient][i], sizeof(g_sAbilityType[][]), "");
 				
-				char sFunction[256];
-				Format(sFunction, sizeof(sFunction), "%s.Destroy", type);
-				
-				Handle hPlugin = Function_GetPlugin(type);
-				Function func = GetFunctionByName(hPlugin, sFunction);
-				if (func != INVALID_FUNCTION)
-				{
-					Call_StartFunction(hPlugin, func);
-					Call_PushCell(this);
+				//Call destroy function
+				if (this.StartFunction(type, "Destroy"))
 					Call_Finish();
-				}
 				
 				break;
 			}
@@ -78,7 +64,13 @@ methodmap SaxtonHaleAbility < SaxtonHaleBase
 	
 	public void Destroy()
 	{
+		//Call destroy function now, since ability type get reset before called
 		for (int i = 0; i < MAX_BOSS_ABILITY; i++)
+		{
+			if (this.StartFunction(g_sAbilityType[this.iClient][i], "Destroy"))
+				Call_Finish();
+			
 			Format(g_sAbilityType[this.iClient][i], sizeof(g_sAbilityType[][]), "");
+		}
 	}
 };

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -41,15 +41,9 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		g_flClientBossRageMusicVolume[this.iClient] = 0.0;
 		g_hClientBossRageMusicTime[this.iClient] = null;
 		
-		char sFunction[256];
-		Format(sFunction, sizeof(sFunction), "%s.%s", type, type);
-		
-		Handle hPlugin = Function_GetPlugin(type);
-		Function func = GetFunctionByName(hPlugin, sFunction);
-		if (func != INVALID_FUNCTION)
+		//Call boss's constructor function
+		if (this.StartFunction(type, type))
 		{
-			Call_StartFunction(hPlugin, func);
-			Call_PushCell(this);
 			Call_PushCell(this);
 			Call_Finish();
 		}
@@ -351,6 +345,12 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 
 	public void Destroy()
 	{
+		//Call destroy function now, since boss type get reset before called
+		if (this.StartFunction(g_sClientBossType[this.iClient], "Destroy"))
+			Call_Finish();
+		
+		Format(g_sClientBossType[this.iClient], sizeof(g_sClientBossType[]), "");
+		
 		this.bValid = false;
 		
 		SetVariantString("");

--- a/addons/sourcemod/scripting/vsh/base_modifiers.sp
+++ b/addons/sourcemod/scripting/vsh/base_modifiers.sp
@@ -7,15 +7,8 @@ methodmap SaxtonHaleModifiers < SaxtonHaleBase
 		this.bModifiers = true;
 		strcopy(g_sClientModifiersType[this.iClient], sizeof(g_sClientModifiersType[]), type);
 		
-		char sFunction[256];
-		Format(sFunction, sizeof(sFunction), "%s.%s", type, type);
-		
-		Handle hPlugin = Function_GetPlugin(type);
-		Function func = GetFunctionByName(hPlugin, sFunction);
-		if (func != INVALID_FUNCTION)
+		if (this.StartFunction(type, type))
 		{
-			Call_StartFunction(hPlugin, func);
-			Call_PushCell(this);
 			Call_PushCell(this);
 			Call_Finish();
 		}
@@ -52,8 +45,13 @@ methodmap SaxtonHaleModifiers < SaxtonHaleBase
 	
 	public void Destroy()
 	{
-		this.bModifiers = false;
+		//Call destroy function now, since modifiers type get reset before called
+		if (this.StartFunction(g_sClientModifiersType[this.iClient], "Destroy"))
+			Call_Finish();
+		
 		strcopy(g_sClientModifiersType[this.iClient], sizeof(g_sClientModifiersType[]), "");
+		
+		this.bModifiers = false;
 		SetEntityRenderColor(this.iClient, 255, 255, 255, 255);
 	}
 };

--- a/addons/sourcemod/scripting/vsh/function.sp
+++ b/addons/sourcemod/scripting/vsh/function.sp
@@ -205,19 +205,9 @@ void Function_FinishStack(int[][] value)
 
 bool Function_Call(SaxtonHaleBase boss, const char[] sClass, Action action, any &returnValue)
 {
-	//Find function
-	char sFunctionName[FUNCTION_ARRAY_MAX];
-	Format(sFunctionName, sizeof(sFunctionName), "%s.%s", sClass, g_sFunctionStackName[g_iFunctionStack]);
-	
-	Handle hPlugin = Function_GetPlugin(sClass);
-	Function func = GetFunctionByName(hPlugin, sFunctionName);
-	
-	if (func != INVALID_FUNCTION)
+	//Start function if valid
+	if (boss.StartFunction(sClass, g_sFunctionStackName[g_iFunctionStack]))
 	{
-		//Valid function, start call
-		Call_StartFunction(hPlugin, func);
-		Call_PushCell(boss);
-		
 		//Push params
 		ParamType paramType[FUNCTION_PARAM_MAX+1];
 		int iSize = Function_GetParamType(g_sFunctionStackName[g_iFunctionStack], paramType);

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -7,6 +7,14 @@ CreateNative(sBuffer, Native_Property_%2_Get);
 
 void Native_AskLoad()
 {
+	CreateNative("SaxtonHale_RegisterBoss", Native_RegisterBoss);
+	CreateNative("SaxtonHale_UnregisterBoss", Native_UnregisterBoss);
+	CreateNative("SaxtonHale_RegisterModifiers", Native_RegisterModifiers);
+	CreateNative("SaxtonHale_UnregisterModifiers", Native_UnregisterModifiers);
+	CreateNative("SaxtonHale_RegisterAbility", Native_RegisterAbility);
+	CreateNative("SaxtonHale_UnregisterAbility", Native_UnregisterAbility);
+	CreateNative("SaxtonHale_GetPlugin", Native_GetPlugin);
+	
 	CreateNative("SaxtonHaleBase.CallFunction", Native_CallFunction);
 	
 	CreateNative("SaxtonHale_InitFunction", Native_InitFunction);
@@ -20,13 +28,6 @@ void Native_AskLoad()
 	CreateNative("SaxtonHale_SetParamArray", Native_SetParamArray);
 	CreateNative("SaxtonHale_GetParamString", Native_GetParamString);
 	CreateNative("SaxtonHale_SetParamString", Native_SetParamString);
-	
-	CreateNative("SaxtonHale_RegisterBoss", Native_RegisterBoss);
-	CreateNative("SaxtonHale_UnregisterBoss", Native_UnregisterBoss);
-	CreateNative("SaxtonHale_RegisterModifiers", Native_RegisterModifiers);
-	CreateNative("SaxtonHale_UnregisterModifiers", Native_UnregisterModifiers);
-	CreateNative("SaxtonHale_RegisterAbility", Native_RegisterAbility);
-	CreateNative("SaxtonHale_UnregisterAbility", Native_UnregisterAbility);
 	
 	CreateNative("SaxtonHale_GetBossTeam", Native_GetBossTeam);
 	CreateNative("SaxtonHale_GetAttackTeam", Native_GetAttackTeam);
@@ -62,6 +63,136 @@ void Native_AskLoad()
 	NATIVE_PROPERTY_REGISTER("iRageDamage",iRageDamage)
 	NATIVE_PROPERTY_REGISTER("iMaxRageDamage",iMaxRageDamage)
 	NATIVE_PROPERTY_REGISTER("nClass",nClass)
+}
+
+//void SaxtonHale_RegisterBoss(const char[] ...);
+public any Native_RegisterBoss(Handle hPlugin, int iNumParams)
+{
+	if (iNumParams == 0)
+		ThrowNativeError(SP_ERROR_NATIVE, "No params passed");
+	
+	ArrayList aArray;
+	if (iNumParams > 1)
+		aArray = new ArrayList(MAX_TYPE_CHAR);
+	
+	for (int i = 1; i <= iNumParams; i++)
+	{
+		char sBossType[MAX_TYPE_CHAR];
+		GetNativeString(i, sBossType, sizeof(sBossType));
+		
+		if (!Function_AddPlugin(sBossType, hPlugin))
+		{
+			delete aArray;
+			ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sBossType);
+		}
+		
+		if (iNumParams == 1)
+			g_aBossesType.PushString(sBossType);
+		else
+			aArray.PushString(sBossType);
+		
+		g_aAllBossesType.PushString(sBossType);
+		MenuBoss_AddBoss(sBossType);	//Add boss to menu
+	}
+	
+	if (iNumParams > 1)
+		g_aMiscBossesType.Push(aArray);
+}
+
+//void SaxtonHale_UnregisterBoss(const char[] sBossType);
+public any Native_UnregisterBoss(Handle hPlugin, int iNumParams)
+{
+	char sBossType[MAX_TYPE_CHAR];
+	GetNativeString(1, sBossType, sizeof(sBossType));
+	
+	Function_RemovePlugin(sBossType);
+	
+	//Remove from normal boss array
+	int iIndex = g_aBossesType.FindString(sBossType);
+	if (iIndex >= 0) g_aBossesType.Erase(iIndex);
+	
+	//Remove from all boss array
+	iIndex = g_aAllBossesType.FindString(sBossType);
+	if (iIndex >= 0) g_aAllBossesType.Erase(iIndex);
+	
+	//Remove from menu
+	MenuBoss_RemoveBoss(sBossType);
+	
+	//Remove from misc boss array
+	int iLength = g_aMiscBossesType.Length;
+	for (int i = 0; i < iLength; i++)
+	{
+		ArrayList aArray = g_aMiscBossesType.Get(i);
+		
+		iIndex = aArray.PushString(sBossType);
+		if (iIndex >= 0) aArray.Erase(iIndex);
+		
+		//If only 1 exists, move to normal pick
+		if (aArray.Length == 1)
+		{
+			aArray.GetString(0, sBossType, sizeof(sBossType));
+			g_aBossesType.PushString(sBossType);
+			delete aArray;
+			g_aMiscBossesType.Erase(i);
+		}
+	}
+}
+
+//void SaxtonHale_RegisterModifiers(const char[] sModifiersType);
+public any Native_RegisterModifiers(Handle hPlugin, int iNumParams)
+{
+	char sModifiersType[MAX_TYPE_CHAR];
+	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
+	
+	if (!Function_AddPlugin(sModifiersType, hPlugin))
+		ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sModifiersType);
+	
+	g_aModifiersType.PushString(sModifiersType);
+	MenuBoss_AddModifiers(sModifiersType);	//Add modifiers to menu
+}
+
+//void SaxtonHale_UnregisterModifiers(const char[] sModifiersType);
+public any Native_UnregisterModifiers(Handle hPlugin, int iNumParams)
+{
+	char sModifiersType[MAX_TYPE_CHAR];
+	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
+	
+	Function_RemovePlugin(sModifiersType);
+	
+	//Remove from modifiers array
+	int iIndex = g_aModifiersType.FindString(sModifiersType);
+	if (iIndex >= 0) g_aModifiersType.Erase(iIndex);
+	
+	//Remove from menu
+	MenuBoss_RemoveModifiers(sModifiersType);
+}
+
+//void SaxtonHale_RegisterAbility(const char[] sAbilityType);
+public any Native_RegisterAbility(Handle hPlugin, int iNumParams)
+{
+	char sAbilityType[MAX_TYPE_CHAR];
+	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
+	
+	if (!Function_AddPlugin(sAbilityType, hPlugin))
+		ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sAbilityType);
+}
+
+//void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
+public any Native_UnregisterAbility(Handle hPlugin, int iNumParams)
+{
+	char sAbilityType[MAX_TYPE_CHAR];
+	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
+	
+	Function_RemovePlugin(sAbilityType);
+}
+
+//Handle SaxtonHale_GetPlugin(const char[] sType);
+public any Native_GetPlugin(Handle hPlugin, int iNumParams)
+{
+	char sType[MAX_TYPE_CHAR];
+	GetNativeString(1, sType, sizeof(sType));
+	
+	return Function_GetPlugin(sType);
 }
 
 //any SaxtonHaleBase.CallFunction(const char[] sName, any...);
@@ -359,127 +490,6 @@ public any Native_SetParamString(Handle hPlugin, int iNumParams)
 	char value[FUNCTION_ARRAY_MAX];
 	GetNativeString(2, value, sizeof(value));
 	Function_SetParamValue(iParam, view_as<any>(value));
-}
-
-//void SaxtonHale_RegisterBoss(const char[] ...);
-public any Native_RegisterBoss(Handle hPlugin, int iNumParams)
-{
-	if (iNumParams == 0)
-		ThrowNativeError(SP_ERROR_NATIVE, "No params passed");
-	
-	ArrayList aArray;
-	if (iNumParams > 1)
-		aArray = new ArrayList(MAX_TYPE_CHAR);
-	
-	for (int i = 1; i <= iNumParams; i++)
-	{
-		char sBossType[MAX_TYPE_CHAR];
-		GetNativeString(i, sBossType, sizeof(sBossType));
-		
-		if (!Function_AddPlugin(sBossType, hPlugin))
-		{
-			delete aArray;
-			ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sBossType);
-		}
-		
-		if (iNumParams == 1)
-			g_aBossesType.PushString(sBossType);
-		else
-			aArray.PushString(sBossType);
-		
-		g_aAllBossesType.PushString(sBossType);
-		MenuBoss_AddBoss(sBossType);	//Add boss to menu
-	}
-	
-	if (iNumParams > 1)
-		g_aMiscBossesType.Push(aArray);
-}
-
-//void SaxtonHale_UnregisterBoss(const char[] sBossType);
-public any Native_UnregisterBoss(Handle hPlugin, int iNumParams)
-{
-	char sBossType[MAX_TYPE_CHAR];
-	GetNativeString(1, sBossType, sizeof(sBossType));
-	
-	Function_RemovePlugin(sBossType);
-	
-	//Remove from normal boss array
-	int iIndex = g_aBossesType.FindString(sBossType);
-	if (iIndex >= 0) g_aBossesType.Erase(iIndex);
-	
-	//Remove from all boss array
-	iIndex = g_aAllBossesType.FindString(sBossType);
-	if (iIndex >= 0) g_aAllBossesType.Erase(iIndex);
-	
-	//Remove from menu
-	MenuBoss_RemoveBoss(sBossType);
-	
-	//Remove from misc boss array
-	int iLength = g_aMiscBossesType.Length;
-	for (int i = 0; i < iLength; i++)
-	{
-		ArrayList aArray = g_aMiscBossesType.Get(i);
-		
-		iIndex = aArray.PushString(sBossType);
-		if (iIndex >= 0) aArray.Erase(iIndex);
-		
-		//If only 1 exists, move to normal pick
-		if (aArray.Length == 1)
-		{
-			aArray.GetString(0, sBossType, sizeof(sBossType));
-			g_aBossesType.PushString(sBossType);
-			delete aArray;
-			g_aMiscBossesType.Erase(i);
-		}
-	}
-}
-
-//void SaxtonHale_RegisterModifiers(const char[] sModifiersType);
-public any Native_RegisterModifiers(Handle hPlugin, int iNumParams)
-{
-	char sModifiersType[MAX_TYPE_CHAR];
-	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
-	
-	if (!Function_AddPlugin(sModifiersType, hPlugin))
-		ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sModifiersType);
-	
-	g_aModifiersType.PushString(sModifiersType);
-	MenuBoss_AddModifiers(sModifiersType);	//Add modifiers to menu
-}
-
-//void SaxtonHale_UnregisterModifiers(const char[] sModifiersType);
-public any Native_UnregisterModifiers(Handle hPlugin, int iNumParams)
-{
-	char sModifiersType[MAX_TYPE_CHAR];
-	GetNativeString(1, sModifiersType, sizeof(sModifiersType));
-	
-	Function_RemovePlugin(sModifiersType);
-	
-	//Remove from modifiers array
-	int iIndex = g_aModifiersType.FindString(sModifiersType);
-	if (iIndex >= 0) g_aModifiersType.Erase(iIndex);
-	
-	//Remove from menu
-	MenuBoss_RemoveModifiers(sModifiersType);
-}
-
-//void SaxtonHale_RegisterAbility(const char[] sAbilityType);
-public any Native_RegisterAbility(Handle hPlugin, int iNumParams)
-{
-	char sAbilityType[MAX_TYPE_CHAR];
-	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
-	
-	if (!Function_AddPlugin(sAbilityType, hPlugin))
-		ThrowNativeError(SP_ERROR_NATIVE, "Constructor (%s) already registered", sAbilityType);
-}
-
-//void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
-public any Native_UnregisterAbility(Handle hPlugin, int iNumParams)
-{
-	char sAbilityType[MAX_TYPE_CHAR];
-	GetNativeString(1, sAbilityType, sizeof(sAbilityType));
-	
-	Function_RemovePlugin(sAbilityType);
 }
 
 //TFTeam SaxtonHale_GetBossTeam();


### PR DESCRIPTION
There currently a bug that `Destroy` function doesn't get called to some constructors, had to refactor to make it nicer and less of a pain.

This also adds 2 new natives:
`SaxtonHaleBase.StartFunction` - Starts a function to specified constructor and function, this allows to call specific function without calling every other functions from `SaxtonHaleBase.CallFunction`
`SaxtonHale_GetPlugin` - Gets constructor plugin owner handle, return null if invalid/not registered. Currently only used for `SaxtonHaleBase.StartFunction`.