### PR TITLE
Mark native SaxtonHale_GetPlugin as optional

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -706,6 +706,14 @@ public SharedPlugin __pl_saxtonhale =
 #if !defined REQUIRE_PLUGIN
 public __pl_saxtonhale_SetNTVOptional()
 {
+	MarkNativeAsOptional("SaxtonHale_RegisterBoss");
+	MarkNativeAsOptional("SaxtonHale_UnregisterBoss");
+	MarkNativeAsOptional("SaxtonHale_RegisterModifiers");
+	MarkNativeAsOptional("SaxtonHale_UnregisterModifiers");
+	MarkNativeAsOptional("SaxtonHale_RegisterAbility");
+	MarkNativeAsOptional("SaxtonHale_UnregisterAbility");
+	MarkNativeAsOptional("SaxtonHale_GetPlugin");
+	
 	MarkNativeAsOptional("SaxtonHaleBase.CallFunction");
 	
 	MarkNativeAsOptional("SaxtonHaleBase.bValid.get");
@@ -758,13 +766,6 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHale_SetParamArray");
 	MarkNativeAsOptional("SaxtonHale_GetParamString");
 	MarkNativeAsOptional("SaxtonHale_SetParamString");
-	
-	MarkNativeAsOptional("SaxtonHale_RegisterBoss");
-	MarkNativeAsOptional("SaxtonHale_UnregisterBoss");
-	MarkNativeAsOptional("SaxtonHale_RegisterModifiers");
-	MarkNativeAsOptional("SaxtonHale_UnregisterModifiers");
-	MarkNativeAsOptional("SaxtonHale_RegisterAbility");
-	MarkNativeAsOptional("SaxtonHale_UnregisterAbility");
 	
 	MarkNativeAsOptional("SaxtonHale_GetBossTeam");
 	MarkNativeAsOptional("SaxtonHale_GetAttackTeam");


### PR DESCRIPTION
Missed that from PR #67, caused optional plugin to not load because `SaxtonHale_GetPlugin` native was required to load