### PR TITLE
Eyelander: +15 max health on every hit, no speed bonus

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -82,6 +82,11 @@
 //- min                     - Min allowed value after calculating
 //- max                     - Max allowed value after calculating
 //
+//Tags_SetAttrib          - Add an attribute to an entity
+//- index                   - Attribute index
+//- value                   - Value to apply index
+//- math                    - How should value be changed, none to hard-set, 'add'/'multiply' from current value, 'damage' to scale from current damage dealt
+//
 //Tags_AddAttrib          - Add an attribute to an entity
 //- index                   - Attribute index
 //- value                   - Value to apply index
@@ -1110,8 +1115,8 @@
 		
 		"132"	//Eyelander
 		{
-			"desp"			"Eyelander: {positive}+1 head on every hit, {negative}-10% movement speed"
-			"attrib"		"54 ; 0.9"
+			"desp"			"Eyelander: {positive}+15 max health on every hit, {negative}no speed bonus"
+			"attrib"		"26 ; 0.0 ; 219 ; 0.0"
 			
 			"attackdamage"
 			{
@@ -1125,15 +1130,18 @@
 					"value"			"1"
 				}
 				
+				"Tags_SetAttrib"
+				{
+					"target"		"melee"		//Melee weapon
+					"index"			"26"		//Max health on wearer
+					
+					"math"			"add"		//Add value everytime this is called
+					"value"			"15"		//15 max health on every hit
+				}
+				
 				"Tags_AddHealth"	//Add 15 health
 				{
 					"amount"		"15"
-				}
-				
-				"Tags_AddCond"
-				{
-					"cond"			"32"	//Speed boost
-					"duration"		"0.0"	//No duration, really just to recalculate speed
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -2770,9 +2770,9 @@ stock int TF2_CreateGlow(int iEnt, int iColor[4])
 	return ent;
 }
 
-stock bool TF2_FindAttribute(int iClient, int iAttrib, float &flVal)
+stock bool TF2_FindAttribute(int iEntity, int iAttrib, float &flVal)
 {
-	Address addAttrib = TF2Attrib_GetByDefIndex(iClient, iAttrib);
+	Address addAttrib = TF2Attrib_GetByDefIndex(iEntity, iAttrib);
 	if (addAttrib != Address_Null)
 	{
 		flVal = TF2Attrib_GetValue(addAttrib);


### PR DESCRIPTION
With the upcoming of PR #59, i'm in fear of demoboots + eyelander speed combo, so lets rework eyelander.

New eyelander now simply no longer gain extra speed, but instead unlimited max health gained on hit, rather than limited to 4 heads. Meaning 10 hits would gain you +150 max health, while almost every bosses deal 182 melee damage anyway.

~~Watch this weapon very powerful from medic combo~~