### PR TITLE
Rescue Ranger: Max 130 ammo hold, minor change with explosion

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1396,16 +1396,16 @@
 		
 		"997"	//Rescue Ranger
 		{
-			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}+30% damage to self"
-			"attrib"		"135 ; 1.3"
+			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}max 130 ammo hold"
+			"attrib"		"81 ; 0.65"
 			
 			"projectile"	//Called when projectile touches something
 			{
 				"Tags_Explode"
 				{
 					"target"		"projectile"
-					"damage"		"45.0"
-					"radius"		"120.0"
+					"damage"		"60.0"
+					"radius"		"50.0"
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1396,7 +1396,7 @@
 		
 		"997"	//Rescue Ranger
 		{
-			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}max 130 ammo hold"
+			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}max 130 metal hold"
 			"attrib"		"81 ; 0.65"
 			
 			"projectile"	//Called when projectile touches something

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -78,6 +78,7 @@
 //Tags_SetEntProp         - Sets a netprop to a entity
 //- type                    - Variable type to store value, either 'int' or 'float'
 //- prop                    - Netprop to change value
+//- element                 - If prop is array, which element to put
 //- math                    - How should value be changed, none to hard-set, 'add'/'multiply' from current value, 'damage' to scale from current damage dealt
 //- min                     - Min allowed value after calculating
 //- max                     - Max allowed value after calculating
@@ -1398,6 +1399,18 @@
 		{
 			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}max 130 metal hold"
 			"attrib"		"81 ; 0.65"
+			
+			"spawn"
+			{
+				"Tags_SetEntProp"	//Properly set max metal on spawn
+				{
+					"target"		"client"
+					"type"			"int"
+					"prop"			"m_iAmmo"
+					"element"		"3"			//Metal is in m_iAmmo array at element 3
+					"value"			"130"
+				}
+			}
 			
 			"projectile"	//Called when projectile touches something
 			{

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -297,6 +297,7 @@ public void Tags_SetEntProp(int iClient, int iTarget, TagsParams tParams)
 	tParams.GetString("type", sType, sizeof(sType));
 	tParams.GetString("prop", sProp, sizeof(sProp));
 	tParams.GetString("math", sMath, sizeof(sMath));
+	int iElement = tParams.GetInt("element", 0);
 	
 	if (StrEqual(sType, "int"))
 	{
@@ -313,7 +314,7 @@ public void Tags_SetEntProp(int iClient, int iTarget, TagsParams tParams)
 		if (tParams.GetIntEx("min", iMin) && iValue < iMin) iValue = iMin;
 		if (tParams.GetIntEx("max", iMax) && iValue > iMax) iValue = iMax;
 		
-		SetEntProp(iTarget, Prop_Send, sProp, iValue);
+		SetEntProp(iTarget, Prop_Send, sProp, iValue, _, iElement);
 	}
 	else if (StrEqual(sType, "float"))
 	{
@@ -330,7 +331,7 @@ public void Tags_SetEntProp(int iClient, int iTarget, TagsParams tParams)
 		if (tParams.GetFloatEx("min", flMin) && flValue < flMin) flValue = flMin;
 		if (tParams.GetFloatEx("max", flMax) && flValue > flMax) flValue = flMax;
 		
-		SetEntPropFloat(iTarget, Prop_Send, sProp, flValue);
+		SetEntPropFloat(iTarget, Prop_Send, sProp, flValue, iElement);
 	}
 }
 


### PR DESCRIPTION
Adding max 130 ammo requires engineer to either straight off build sentry with no extra metal, or build dispenser then wait for metal gain before able to build sentry. Note reducing max metal hold also reduces max metal gain from ammo packs, (small gives 26, medium gives 65). This makes it bit more harder for engineer to build sentry + dispenser early, though i'm still not sure if that's enough for a nerf.

Along with this, small change to projectile explosion. Removed +30% damage to self, increased explosion damage, and reduced radius, Really this isn't much change in-game, just making it bit more simpler with dmg self removal.