### PR TITLE
Buff Bonk Boy Ball and increase movement speed

### DIFF
--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -77,6 +77,16 @@
 				"linux"		"323"
 				"windows"	"317"
 			}
+			"CTFStunBall::ApplyBallImpactEffectOnVictim"
+			{
+				"linux"		"260"
+				"windows"	"259"
+			}
+			"CTFStunBall::ShouldBallTouch"
+			{
+				"linux"		"262"
+				"windows"	"261"
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -351,6 +351,7 @@ ConVar tf_arena_preround_time;
 #include "vsh/abilities/ability_rage_scare.sp"
 #include "vsh/abilities/ability_teleport_swap.sp"
 #include "vsh/abilities/ability_wallclimb.sp"
+#include "vsh/abilities/ability_weapon_ball.sp"
 #include "vsh/abilities/ability_weapon_charge.sp"
 #include "vsh/abilities/ability_weapon_fists.sp"
 #include "vsh/abilities/ability_weapon_spells.sp"
@@ -539,6 +540,7 @@ public void OnPluginStart()
 	SaxtonHale_RegisterAbility("CScareRage");
 	SaxtonHale_RegisterAbility("CTeleportSwap");
 	SaxtonHale_RegisterAbility("CWallClimb");
+	SaxtonHale_RegisterAbility("CWeaponBall");
 	SaxtonHale_RegisterAbility("CWeaponCharge");
 	SaxtonHale_RegisterAbility("CWeaponFists");
 	SaxtonHale_RegisterAbility("CWeaponSpells");

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_scare.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_scare.sp
@@ -146,18 +146,8 @@ methodmap CScareRage < SaxtonHaleBase
 				
 				GetEntPropVector(iEntity, Prop_Send, "m_vecOrigin", vecTargetPos);
 				if (GetVectorDistance(vecTargetPos, vecPos) <= flRadius)
-				{
-					SetEntProp(iEntity, Prop_Send, "m_bDisabled", true);
-					CreateTimer(flDuration, Timer_ScareEnableSentry, EntIndexToEntRef(iEntity));
-				}
+					TF2_StunBuilding(iEntity, flDuration);
 			}
 		}
 	}
 };
-
-public Action Timer_ScareEnableSentry(Handle timer, int iRef)
-{
-	int iEntity = EntRefToEntIndex(iRef);
-	if (iEntity > MaxClients)
-		SetEntProp(iEntity, Prop_Send, "m_bDisabled", false);
-}

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
@@ -1,0 +1,152 @@
+static int g_iWeaponBallStunType;
+
+static float g_flWeaponBallStunTime[TF_MAXPLAYERS+1];
+static int g_iWeaponBallThrower[TF_MAXPLAYERS+1];
+
+methodmap CWeaponBall < SaxtonHaleBase
+{
+	public CWeaponBall(CWeaponBall ability)
+	{
+	}
+	
+	public void OnEntityCreated(int iEntity, const char[] sClassname)
+	{
+		if (strcmp(sClassname, "tf_projectile_stun_ball") == 0)
+		{
+			SDK_HookBallImpact(iEntity, WeaponBall_BallImpact);	//To hook when ball impacts player
+			SDK_HookBallTouch(iEntity, WeaponBall_BallTouch);	//To hook when ball impacts building
+		}
+	}
+	
+	public void Precache()
+	{
+		g_iWeaponBallStunType = FindSendPropInfo("CTFStunBall", "m_iType");
+	}
+};
+
+public MRESReturn WeaponBall_BallImpact(int iEntity, Handle hParams)
+{
+	//Get victim whos stunned from ball
+	int iVictim = DHookGetParam(hParams, 1);
+	if (iVictim <= 0 || iVictim > MaxClients || !IsClientInGame(iVictim))
+		return;
+	
+	//Check if valid ball from Bonk Boy
+	int iThrower;
+	float flTime;
+	if (!WeaponBall_IsValidBall(iEntity, iThrower, flTime))
+		return;
+	
+	g_flWeaponBallStunTime[iVictim] = flTime;
+	g_iWeaponBallThrower[iVictim] = iThrower;
+	
+	SDKHook(iVictim, SDKHook_OnTakeDamage, WeaponBall_OnTakeDamage);
+	HookEvent("player_death", WeaponBall_PlayerDeath, EventHookMode_Pre);
+	RequestFrame(WeaponBall_UnhookBallDamage, GetClientUserId(iVictim));
+}
+
+public MRESReturn WeaponBall_BallTouch(int iEntity, Handle hReturn, Handle hParams)
+{
+	if (GetEntProp(iEntity, Prop_Send, "m_bTouched"))
+		return;
+	
+	//Check if toucher is building
+	int iBuilding = DHookGetParam(hParams, 1);
+	if (iBuilding <= MaxClients)
+		return;
+	
+	char sClassname[256];
+	GetEntityClassname(iBuilding, sClassname, sizeof(sClassname));
+	if (StrContains(sClassname, "obj_") != 0)
+		return;
+	
+	//Check if valid ball from Bonk Boy
+	int iThrower;
+	float flTime;
+	if (!WeaponBall_IsValidBall(iEntity, iThrower, flTime))
+		return;
+	
+	//Team check
+	if (GetEntProp(iBuilding, Prop_Send, "m_iTeamNum") == GetClientTeam(iThrower))
+		return;
+	
+	//Deal damage
+	SDKHooks_TakeDamage(iBuilding, iThrower, iThrower, flTime * 120.0);
+	
+	//Stun building
+	TF2_StunBuilding(iBuilding, flTime * 8.0);
+	
+	//Mark ball as touched
+	SetEntProp(iEntity, Prop_Send, "m_bTouched", true);
+}
+
+bool WeaponBall_IsValidBall(int iEntity, int &iThrower = 0, float &flTime = 0.0)
+{
+	//Check if ball came from owner with ability
+	int iOwner = GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity");
+	if (!SaxtonHale_IsValidBoss(iOwner))
+		return false;
+	
+	SaxtonHaleBase boss = SaxtonHaleBase(iOwner);
+	if (boss.CallFunction("FindAbility", "CWeaponBall") == INVALID_ABILITY)
+		return false;
+	
+	//Get whoever threw the ball, either from bonk boy, or from deflected pyro
+	iThrower = GetEntPropEnt(iEntity, Prop_Send, "m_hThrower");
+	if (iThrower <= 0 || iThrower > MaxClients || !IsClientInGame(iThrower))
+		return false;
+	
+	//Sandman init time is stored in m_iType + 4 offset
+	flTime = GetGameTime() - GetEntDataFloat(iEntity, g_iWeaponBallStunType + 0x04);
+	return true;
+}
+
+public Action WeaponBall_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	Action action = Plugin_Continue;
+	
+	if (damagecustom == TF_CUSTOM_BASEBALL && g_flWeaponBallStunTime[victim] > 0.0)
+	{
+		attacker = g_iWeaponBallThrower[victim];
+		g_iWeaponBallThrower[victim] = 0;
+		action = Plugin_Changed;
+		
+		if (g_flWeaponBallStunTime[victim] > 0.85)
+		{
+			//Home run baby
+			damagetype |= DMG_CRIT;
+			damage = 1337.0 / 3.0;
+			
+			TF2_StunPlayer(victim, 10.0, _, TF_STUNFLAGS_BIGBONK, attacker);
+		}
+		else if (g_flWeaponBallStunTime[victim] > 0.10)
+		{
+			//Not so home run
+			damage *= g_flWeaponBallStunTime[victim] * 8.0;
+			TF2_StunPlayer(victim, g_flWeaponBallStunTime[victim] * 8.0, _, TF_STUNFLAGS_SMALLBONK, attacker);
+		}
+		
+		g_flWeaponBallStunTime[victim] = 0.0;
+	}
+	
+	return action;
+}
+
+public Action WeaponBall_PlayerDeath(Event event, const char[] sName, bool bDontBroadcast)
+{
+	if (event.GetInt("customkill") == TF_CUSTOM_BASEBALL && event.GetInt("stun_flags") == TF_STUNFLAGS_BIGBONK)
+	{
+		event.SetInt("customkill", TF_CUSTOM_TAUNT_GRAND_SLAM);
+		event.SetString("weapon", "taunt_scout");
+		event.SetString("weapon_logclassname", "taunt_scout");
+	}
+}
+
+public void WeaponBall_UnhookBallDamage(int iUserId)
+{
+	int iClient = GetClientOfUserId(iUserId);
+	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
+		SDKUnhook(iClient, SDKHook_OnTakeDamage, WeaponBall_OnTakeDamage);
+	
+	UnhookEvent("player_death", WeaponBall_PlayerDeath, EventHookMode_Pre);
+}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -3,11 +3,7 @@ static int g_iBonkBoyModelMask;
 static int g_iBonkBoyModelShirt;
 static int g_iBonkBoyModelBag;
 
-static int g_iBonkBoyStunType;
-
 static bool g_bBonkBoyRage[TF_MAXPLAYERS+1];
-static float g_flBonkBoyStunTime[TF_MAXPLAYERS+1];
-static int g_iBonkBoyBallThrower[TF_MAXPLAYERS+1];
 
 static char g_strBonkBoyRoundStart[][] = {
 	"vo/scout_sf12_goodmagic07.mp3",
@@ -64,6 +60,7 @@ methodmap CBonkBoy < SaxtonHaleBase
 	public CBonkBoy(CBonkBoy boss)
 	{
 		boss.CallFunction("CreateAbility", "CDashJump");
+		boss.CallFunction("CreateAbility", "CWeaponBall");
 		
 		CRageAddCond rageCond = boss.CallFunction("CreateAbility", "CRageAddCond");
 		rageCond.flRageCondDuration = 5.0;
@@ -170,15 +167,6 @@ methodmap CBonkBoy < SaxtonHaleBase
 		}
 	}
 	
-	public void OnEntityCreated(int iEntity, const char[] sClassname)
-	{
-		if (strcmp(sClassname, "tf_projectile_stun_ball") == 0)
-		{
-			SDK_HookBallImpact(iEntity, BonkBoy_BallImpact);	//To hook when ball impacts player
-			SDK_HookBallTouch(iEntity, BonkBoy_BallTouch);		//To hook when ball impacts building
-		}
-	}
-	
 	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
 	{
 		switch (iSoundType)
@@ -199,8 +187,6 @@ methodmap CBonkBoy < SaxtonHaleBase
 	
 	public void Precache()
 	{
-		g_iBonkBoyStunType = FindSendPropInfo("CTFStunBall", "m_iType");
-		
 		g_iBonkBoyModelHelmet = PrecacheModel("models/player/items/scout/bonk_helmet.mdl");
 		g_iBonkBoyModelMask = PrecacheModel("models/workshop/player/items/scout/bonk_mask/bonk_mask.mdl");
 		g_iBonkBoyModelShirt = PrecacheModel("models/workshop/player/items/scout/hwn2015_death_racer_jacket/hwn2015_death_racer_jacket.mdl");
@@ -215,132 +201,3 @@ methodmap CBonkBoy < SaxtonHaleBase
 		for (int i = 0; i < sizeof(g_strBonkBoyBackStabbed); i++) PrecacheSound(g_strBonkBoyBackStabbed[i]);
 	}
 };
-
-public MRESReturn BonkBoy_BallImpact(int iEntity, Handle hParams)
-{
-	//Get victim whos stunned from ball
-	int iVictim = DHookGetParam(hParams, 1);
-	if (iVictim <= 0 || iVictim > MaxClients || !IsClientInGame(iVictim))
-		return;
-	
-	//Check if valid ball from Bonk Boy
-	int iThrower;
-	float flTime;
-	if (!BonkBoy_IsValidBall(iEntity, iThrower, flTime))
-		return;
-	
-	g_flBonkBoyStunTime[iVictim] = flTime;
-	g_iBonkBoyBallThrower[iVictim] = iThrower;
-	
-	SDKHook(iVictim, SDKHook_OnTakeDamage, BonkBoy_OnTakeDamage);
-	HookEvent("player_death", BonkBoy_PlayerDeath, EventHookMode_Pre);
-	RequestFrame(BonkBoy_UnhookBallDamage, GetClientUserId(iVictim));
-}
-
-public MRESReturn BonkBoy_BallTouch(int iEntity, Handle hReturn, Handle hParams)
-{
-	if (GetEntProp(iEntity, Prop_Send, "m_bTouched"))
-		return;
-	
-	//Check if toucher is building
-	int iBuilding = DHookGetParam(hParams, 1);
-	if (iBuilding <= MaxClients)
-		return;
-	
-	char sClassname[256];
-	GetEntityClassname(iBuilding, sClassname, sizeof(sClassname));
-	if (StrContains(sClassname, "obj_") != 0)
-		return;
-	
-	//Check if valid ball from Bonk Boy
-	int iThrower;
-	float flTime;
-	if (!BonkBoy_IsValidBall(iEntity, iThrower, flTime))
-		return;
-	
-	//Team check
-	if (GetEntProp(iBuilding, Prop_Send, "m_iTeamNum") == GetClientTeam(iThrower))
-		return;
-	
-	//Deal damage
-	SDKHooks_TakeDamage(iBuilding, iThrower, iThrower, flTime * 120.0);
-	
-	//Stun building
-	TF2_StunBuilding(iBuilding, flTime * 8.0);
-	
-	//Mark ball as touched
-	SetEntProp(iEntity, Prop_Send, "m_bTouched", true);
-}
-
-bool BonkBoy_IsValidBall(int iEntity, int &iThrower = 0, float &flTime = 0.0)
-{
-	//Check if ball originally came from bonk boy
-	int iOwner = GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity");
-	if (!SaxtonHale_IsValidBoss(iOwner))
-		return false;
-	
-	SaxtonHaleBase boss = SaxtonHaleBase(iOwner);
-	char sBossType[MAX_TYPE_CHAR];
-	boss.CallFunction("GetBossType", sBossType, sizeof(sBossType));
-	if (!StrEqual(sBossType, "CBonkBoy"))
-		return false;
-	
-	//Get whoever threw the ball, either from bonk boy, or from deflected pyro
-	iThrower = GetEntPropEnt(iEntity, Prop_Send, "m_hThrower");
-	if (iThrower <= 0 || iThrower > MaxClients || !IsClientInGame(iThrower))
-		return false;
-	
-	//Sandman init time is stored in m_iType + 4 offset
-	flTime = GetGameTime() - GetEntDataFloat(iEntity, g_iBonkBoyStunType + 0x04);
-	return true;
-}
-
-public Action BonkBoy_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
-{
-	Action action = Plugin_Continue;
-	
-	if (damagecustom == TF_CUSTOM_BASEBALL && g_flBonkBoyStunTime[victim] > 0.0)
-	{
-		attacker = g_iBonkBoyBallThrower[victim];
-		g_iBonkBoyBallThrower[victim] = 0;
-		action = Plugin_Changed;
-		
-		if (g_flBonkBoyStunTime[victim] > 0.85)
-		{
-			//Home run baby
-			damagetype |= DMG_CRIT;
-			damage = 1337.0 / 3.0;
-			
-			TF2_StunPlayer(victim, 10.0, _, TF_STUNFLAGS_BIGBONK, attacker);
-		}
-		else if (g_flBonkBoyStunTime[victim] > 0.10)
-		{
-			//Not so home run
-			damage *= g_flBonkBoyStunTime[victim] * 8.0;
-			TF2_StunPlayer(victim, g_flBonkBoyStunTime[victim] * 8.0, _, TF_STUNFLAGS_SMALLBONK, attacker);
-		}
-		
-		g_flBonkBoyStunTime[victim] = 0.0;
-	}
-	
-	return action;
-}
-
-public Action BonkBoy_PlayerDeath(Event event, const char[] sName, bool bDontBroadcast)
-{
-	if (event.GetInt("customkill") == TF_CUSTOM_BASEBALL && event.GetInt("stun_flags") == TF_STUNFLAGS_BIGBONK)
-	{
-		event.SetInt("customkill", TF_CUSTOM_TAUNT_GRAND_SLAM);
-		event.SetString("weapon", "taunt_scout");
-		event.SetString("weapon_logclassname", "taunt_scout");
-	}
-}
-
-public void BonkBoy_UnhookBallDamage(int iUserId)
-{
-	int iClient = GetClientOfUserId(iUserId);
-	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
-		SDKUnhook(iClient, SDKHook_OnTakeDamage, BonkBoy_OnTakeDamage);
-	
-	UnhookEvent("player_death", BonkBoy_PlayerDeath, EventHookMode_Pre);
-}

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -283,6 +283,19 @@ stock int TF2_GetBuilding(int iClient, TFObjectType nType, TFObjectMode nMode = 
 	return -1;
 }
 
+stock void TF2_StunBuilding(int iBuilding, float flDuration)
+{
+	SetEntProp(iBuilding, Prop_Send, "m_bDisabled", true);
+	CreateTimer(flDuration, Timer_EnableBuilding, EntIndexToEntRef(iBuilding));
+}
+
+public Action Timer_EnableBuilding(Handle timer, int iRef)
+{
+	int iBuilding = EntRefToEntIndex(iRef);
+	if (iBuilding > MaxClients)
+		SetEntProp(iBuilding, Prop_Send, "m_bDisabled", false);
+}
+
 stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTemp = NULL_STRING, int iLevel = 0, TFQuality iQuality = TFQual_Normal, char[] sAttrib = NULL_STRING, bool bAttrib = false)
 {
 	char sClassname[256];


### PR DESCRIPTION
- Increase starting movement speed from 370 to 400
- Increase stun duration multiplier from 5 to 8 (now lasts between 1 to 7 seconds, scaled by how long ball in air)
- Increase ball damage (between ~15 to ~100 damage, scaled by how long ball in air)
- Ball now damage and stuns building, damage and duration matches about the same to player

Into the technical side, `SDKHook_StartTouch` is not so reliable/accurate and usually misses shot. Instead, 2 hooks were made from dhook:
- `CTFStunBall::ApplyBallImpactEffectOnVictim` called the moment when ball is about to damage and stun player
- `CTFStunBall::ShouldBallTouch` called when ball collides with world or entity, mainly only used to stun and damage buildings