### PR TITLE
Post-post-playtest Über Ranger update

### DIFF
--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -81,7 +81,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		int iEnemy = 0;
 		for (int i = 1; i <= MaxClients; i++)
 		{
-			if (IsClientInGame(i))
+			if (IsClientInGame(i) && IsPlayerAlive(i))
 			{
 				int iTargetTeam = GetClientTeam(i);
 				if (iTargetTeam > 1 && iTargetTeam != iTeam)

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -77,19 +77,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 
 	public int CalculateMaxHealth()
 	{
-		int iTeam = GetClientTeam(this.iClient);
-		int iEnemy = 0;
-		for (int i = 1; i <= MaxClients; i++)
-		{
-			if (IsClientInGame(i) && IsPlayerAlive(i))
-			{
-				int iTargetTeam = GetClientTeam(i);
-				if (iTargetTeam > 1 && iTargetTeam != iTeam)
-					iEnemy++;
-			}
-		}
-
-		return RoundToNearest((this.iBaseHealth + this.iHealthPerPlayer*iEnemy) * this.flHealthMultiplier);
+		return RoundToNearest((this.iBaseHealth + this.iHealthPerPlayer * SaxtonHale_GetAliveAttackPlayers()) * this.flHealthMultiplier);
 	}
 	
 	public void GetBossName(char[] sName, int length)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -60,8 +60,7 @@ methodmap CSeeldier < SaxtonHaleBase
 		int iTotalMinions = 3;
 		if (this.bSuperRage) iTotalMinions *= 2;
 		
-		ArrayList aValidMinions = new ArrayList();
-		GetValidSummonableClients(aValidMinions);
+		ArrayList aValidMinions = GetValidSummonableClients();
 		
 		int iLength = aValidMinions.Length;
 		if (iLength < iTotalMinions)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -55,8 +55,8 @@ methodmap CUberRanger < SaxtonHaleBase
 		abilityJump.iJumpChargeBuild = 1;
 		
 		CRageAddCond rageCond = boss.CallFunction("CreateAbility", "CRageAddCond");
-		rageCond.flRageCondDuration = 6.0;
-		rageCond.flRageCondSuperRageMultiplier = 1.333;	//This is 7.998 seconds, close enough
+		rageCond.flRageCondDuration = 5.0;
+		rageCond.flRageCondSuperRageMultiplier = 1.6;	// 8 seconds
 		rageCond.AddCond(TFCond_UberchargedCanteen);
 		
 		boss.iBaseHealth = 650;
@@ -68,7 +68,7 @@ methodmap CUberRanger < SaxtonHaleBase
 		for (int i = 1; i <= MaxClients; i++)
 			g_bUberRangerPlayerWasSummoned[i] = false;
 			
-		UberRangerResetColorList();
+		UberRanger_ResetColorList();
 	}
 	
 	public void GetBossName(char[] sName, int length)
@@ -85,7 +85,7 @@ methodmap CUberRanger < SaxtonHaleBase
 		StrCat(sInfo, length, "\n- Equipped with a Medi Gun");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
-		StrCat(sInfo, length, "\n- Übercharge for 6 seconds");
+		StrCat(sInfo, length, "\n- Übercharge for 5 seconds");
 		StrCat(sInfo, length, "\n- Summons a fellow Über Ranger");
 		StrCat(sInfo, length, "\n- Über Rangers are allowed to heal and über each other");
 		StrCat(sInfo, length, "\n- 200%% Rage: extends über duration to 8 seconds and summons 3 Über Rangers");
@@ -198,8 +198,9 @@ methodmap CUberRanger < SaxtonHaleBase
 				
 				boss.CallFunction("CreateBoss", "CMinionRanger");
 				TF2_RespawnPlayer(iClient);
-				
 				TF2_TeleportToClient(iClient, this.iClient);
+				
+				
 				TF2_AddCondition(iClient, TFCond_Ubercharged, 2.0);
 				
 				aValidMinions.Erase(iBestClientIndex);
@@ -282,8 +283,12 @@ methodmap CMinionRanger < SaxtonHaleBase
 {
 	public CMinionRanger(CMinionRanger boss)
 	{
-		boss.iBaseHealth = 600;
-		boss.iHealthPerPlayer = 0;
+		CBraveJump abilityJump = boss.CallFunction("CreateAbility", "CBraveJump");
+		abilityJump.iJumpChargeBuild = 1;
+		abilityJump.flMaxHeigth = 650.0;
+		
+		boss.iBaseHealth = 400;
+		boss.iHealthPerPlayer = 40;
 		boss.nClass = TFClass_Medic;
 		boss.iMaxRageDamage = -1;
 		boss.flWeighDownTimer = -1.0;
@@ -330,7 +335,7 @@ methodmap CMinionRanger < SaxtonHaleBase
 		
 		//Checking if the list is there at all or has been emptied
 		if (g_aUberRangerColorList == null || g_aUberRangerColorList.Length <= 0)
-			UberRangerResetColorList();
+			UberRanger_ResetColorList();
 			
 		//Assign color
 		int iColor[4];
@@ -367,6 +372,12 @@ methodmap CMinionRanger < SaxtonHaleBase
 		strcopy(sModel, length, RANGER_MODEL);
 	}
 	
+	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
+	{
+		if (strcmp(sType, "CBraveJump") == 0)
+			strcopy(sSound, length, g_strUberRangerJump[GetRandomInt(0,sizeof(g_strUberRangerJump)-1)]);
+	}
+	
 	public void OnThink()
 	{
 		Hud_AddText(this.iClient, "Use your Medigun to heal your companions!");
@@ -378,7 +389,7 @@ methodmap CMinionRanger < SaxtonHaleBase
 	}
 };
 
-public void UberRangerResetColorList()
+public void UberRanger_ResetColorList()
 {
 	if (g_aUberRangerColorList == null)
 		g_aUberRangerColorList = new ArrayList(3);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -200,6 +200,8 @@ methodmap CUberRanger < SaxtonHaleBase
 	
 	public void OnThink()
 	{
+		if (!IsPlayerAlive(this.iClient)) return;
+		
 		Hud_AddText(this.iClient, "Use your Medigun to heal your companions!");
 	}
 	
@@ -374,14 +376,16 @@ methodmap CMinionRanger < SaxtonHaleBase
 	
 	public void OnThink()
 	{
+		if (!IsPlayerAlive(this.iClient)) return;
+		
+		char sMessage[64];
+		
 		if (!g_bUberRangerMinionHasMoved[this.iClient])
-		{
-			char sAFKWarning[64];
-			Format(sAFKWarning, sizeof(sAFKWarning), "You have %d second%s to move before getting replaced!", g_iUberRangerMinionAFKTimeLeft[this.iClient], g_iUberRangerMinionAFKTimeLeft[this.iClient] != 1 ? "s" : "");
-			Hud_AddText(this.iClient, sAFKWarning);
-		}
+			Format(sMessage, sizeof(sMessage), "You have %d second%s to move before getting replaced!", g_iUberRangerMinionAFKTimeLeft[this.iClient], g_iUberRangerMinionAFKTimeLeft[this.iClient] != 1 ? "s" : "");
 		else
-			Hud_AddText(this.iClient, "Use your Medigun to heal your companions!");
+			Format(sMessage, sizeof(sMessage), "Use your Medigun to heal your companions!");
+			
+		Hud_AddText(this.iClient, sMessage);
 	}
 	
 	public void OnDeath()

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -252,8 +252,8 @@ methodmap CMinionRanger < SaxtonHaleBase
 	public CMinionRanger(CMinionRanger boss)
 	{
 		CBraveJump abilityJump = boss.CallFunction("CreateAbility", "CBraveJump");
-		abilityJump.iJumpChargeBuild /= 4;						//4x slower jump charge rate
-		abilityJump.flMaxHeigth /= 2;							//Half max height for super jumps
+		abilityJump.iJumpChargeBuild /= 4;	//4x slower jump charge rate
+		abilityJump.flMaxHeigth /= 2;		//Half max height for super jumps
 		
 		boss.iBaseHealth = 400;
 		boss.iHealthPerPlayer = 40;

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -68,8 +68,10 @@ stock int GetMainBoss()
 	return iBoss;
 }
 
-stock ArrayList GetValidSummonableClients(ArrayList aClients, bool bAllowBoss = false)
+stock ArrayList GetValidSummonableClients(bool bAllowBoss = false)
 {
+	ArrayList aClients = new ArrayList();
+	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
 		if (IsClientInGame(iClient)

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -650,8 +650,7 @@ public void Tags_SummonZombie(int iClient, int iTarget, TagsParams tParams)
 		iMaxCount = iMin;
 	
 	//Collect list of valid players
-	ArrayList aDeadPlayers = new ArrayList();
-	GetValidSummonableClients(aDeadPlayers);
+	ArrayList aDeadPlayers = GetValidSummonableClients();
 	int iLength = aDeadPlayers.Length;
 	
 	if (iMaxCount > iLength)


### PR DESCRIPTION
This is where the balance changes come in. Mini rangers seem to be too weak, and that's fair, I didn't take any time thinking about how much health they should have besides "being tankier than Seeldier minions." This update makes ranger companions more unique compared to the other types of summons, essentially actual minibosses.

**Changes:**
Companions:
- Instead of a flat 600 base health, they now get 400 hp + 40 per player (on the enemy team and alive)
- They now can super jump, with weaker strength (half of an average jump's height)
- They're übered until 3 seconds after they make their first move on spawn (more details on this later)
- They get an outline for a short amount of time after spawning so players can tell which one is the boss

Boss:
- 100% Rage now lasts for 5 seconds instead of 6, and 200% lasts for 8 seconds instead of 7.998

Going into the technical side, with summoned players being the most important part of a boss' ability, it's important that the boss doesn't get fucked by their (lack of) action, so AFK players will be replaced accordingly as follows:
- When a player spawns, they'll have a 6 second countdown until they start moving
    - Only directional keys are considered. Jumping/looking/attacking/etc in place will be ignored
    - The moment they start moving, it goes away
    - If it ends and they haven't moved yet, the next best miniboss candidate will take their place
    - If there are no other candidates, that's very unfortunate. The spawn protection will go away but the AFK player won't go anywhere

Note that this just aims to catch legit AFK players without punishment, if people are purposefully suiciding or similar, usage of the punishment feature should be considered.

Known issue:
- The super jump text in the hud doesn't go away when you die, though this is a general issue rather than this boss's and should be done in a separate PR.