### PR TITLE
Update bonk boy balances

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -1,3 +1,5 @@
+#define ATTRIB_FIRE_RATE	6
+
 static int g_iBonkBoyModelHelmet;
 static int g_iBonkBoyModelMask;
 static int g_iBonkBoyModelShirt;
@@ -64,8 +66,9 @@ methodmap CBonkBoy < SaxtonHaleBase
 		
 		CRageAddCond rageCond = boss.CallFunction("CreateAbility", "CRageAddCond");
 		rageCond.flRageCondDuration = 5.0;
-		rageCond.AddCond(TFCond_CritHype);
-		rageCond.AddCond(TFCond_SpeedBuffAlly);
+		rageCond.AddCond(TFCond_HalloweenSpeedBoost);	//Unlimited jumps
+		rageCond.AddCond(TFCond_CritHype);				//Pink weapon effect
+		rageCond.AddCond(TFCond_SpeedBuffAlly);			//Speed boost effect
 		
 		boss.flSpeed = 400.0;
 		boss.iBaseHealth = 700;
@@ -97,25 +100,20 @@ methodmap CBonkBoy < SaxtonHaleBase
 		StrCat(sInfo, length, "\n- Medium range ball stuns player and building, moonshot instakills");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
-		StrCat(sInfo, length, "\n- Soda Popper jumps and faster speed movement for 5 seconds");
-		StrCat(sInfo, length, "\n- 200%% Rage: Extends duration to 10 seconds");
+		StrCat(sInfo, length, "\n- Unlimited and greater mobility jumps");
+		StrCat(sInfo, length, "\n- Faster movement speed");
+		StrCat(sInfo, length, "\n- Unlimited ball");
+		StrCat(sInfo, length, "\n- 200%% Rage: Extends duration from 5 to 10 seconds");
 	}
 	
 	public void OnSpawn()
 	{
 		char attribs[256];
-		Format(attribs, sizeof(attribs), "2 ; 2.80 ; 252 ; 0.5 ; 259 ; 1.0 ; 38 ; 1.0 ; 278 ; 0.33 ; 279 ; 3.0 ; 524 ; 1.2 ; 551 ; 1.0");
+		Format(attribs, sizeof(attribs), "2 ; 3.54 ; 252 ; 0.5 ; 259 ; 1.0 ; 38 ; 1.0 ; 278 ; 0.33 ; 524 ; 1.2 ; 551 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 44, "tf_weapon_bat_wood", 1, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
-		{
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
-			
-			//Correctly set ammo to 3
-			int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
-			if (iAmmoType > -1)
-				SetEntProp(this.iClient, Prop_Send, "m_iAmmo", 3, 4, iAmmoType);
-		}
-
+		
 		/*
 		Sandman attributes:
 		
@@ -125,7 +123,6 @@ methodmap CBonkBoy < SaxtonHaleBase
 		
 		38: Launches a ball that slows opponents
 		278: increase in recharge rate
-		279: max misc ammo on wearer
 		524: greater jump height when active
 		551: special_taunt
 		*/
@@ -156,6 +153,14 @@ methodmap CBonkBoy < SaxtonHaleBase
 		
 		this.flSpeed *= 1.5;
 		g_bBonkBoyRage[this.iClient] = true;
+		SetEntityMoveType(this.iClient, MOVETYPE_ISOMETRIC);
+		
+		int iMelee = TF2_GetItemInSlot(this.iClient, WeaponSlot_Melee);
+		if (iMelee > MaxClients)
+		{
+			TF2Attrib_SetByDefIndex(iMelee, ATTRIB_FIRE_RATE, 0.4);	//firing speed
+			TF2Attrib_ClearCache(iMelee);
+		}
 	}
 	
 	public void OnThink()
@@ -164,6 +169,14 @@ methodmap CBonkBoy < SaxtonHaleBase
 		{
 			g_bBonkBoyRage[this.iClient] = false;
 			this.flSpeed /= 1.5;
+			SetEntityMoveType(this.iClient, MOVETYPE_WALK);
+			
+			int iMelee = TF2_GetItemInSlot(this.iClient, WeaponSlot_Melee);
+			if (iMelee > MaxClients)
+			{
+				TF2Attrib_RemoveByDefIndex(iMelee, ATTRIB_FIRE_RATE);	//firing speed
+				TF2Attrib_ClearCache(iMelee);
+			}
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -272,6 +272,30 @@ stock void TF2_RemoveItemInSlot(int client, int slot)
 	}
 }
 
+stock int TF2_GetAmmo(int iClient, int iSlot)
+{
+	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
+	if (iWeapon > MaxClients)
+	{
+		int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
+		if (iAmmoType > -1)
+			return GetEntProp(iClient, Prop_Send, "m_iAmmo", _, iAmmoType);
+	}
+	
+	return -1;
+}
+
+stock void TF2_SetAmmo(int iClient, int iSlot, int iAmmo)
+{
+	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
+	if (iWeapon > MaxClients)
+	{
+		int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
+		if (iAmmoType > -1)
+			SetEntProp(iClient, Prop_Send, "m_iAmmo", iAmmo, _, iAmmoType);
+	}
+}
+
 stock int TF2_GetPatient(int iClient)
 {
 	if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient) || !IsPlayerAlive(iClient))


### PR DESCRIPTION
- Increase melee damage from 98 to 124
- Rage now gives unlimited jumps and much greater mobility while jumping in air (MOVETYPE_ISOMETRIC)
- Increase sandman fire rate during rage by +60% (* 0.4)
- Unlimited ball spam during rage

Also added 2 stocks, `TF2_GetAmmo` and `TF2_SetAmmo`. Can be used for whatever other bosses out there