### PR TITLE
Change certain on-screen text behavior

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
@@ -71,4 +71,9 @@ methodmap CWallClimb < SaxtonHaleBase
 		fVelocity[2] = this.flMaxHeight;
 		TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, fVelocity);
 	}
+	
+	public void OnThink()
+	{
+		Hud_AddText(this.iClient, "Climb walls by hitting them with your melee weapon!");
+	}
 };

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -116,7 +116,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 			g_flClientBossWeighDownTimer[this.iClient] = GetGameTime();
 		}
 		
-		if (g_bRoundStarted && this.iMaxRageDamage != -1)
+		if (g_bRoundStarted && IsPlayerAlive(this.iClient) && this.iMaxRageDamage != -1)
 		{
 			float flRage = (float(this.iRageDamage) / float(this.iMaxRageDamage)) * 100.0;
 			

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -202,9 +202,7 @@ methodmap CUberRanger < SaxtonHaleBase
 	}
 	
 	public void OnThink()
-	{
-		if (!IsPlayerAlive(this.iClient)) return;
-		
+	{		
 		Hud_AddText(this.iClient, "Use your Medigun to heal your companions!");
 	}
 	
@@ -372,16 +370,13 @@ methodmap CMinionRanger < SaxtonHaleBase
 	
 	public void OnThink()
 	{
-		if (IsPlayerAlive(this.iClient))
-		{
-			char sMessage[64];
-			if (!g_bUberRangerMinionHasMoved[this.iClient])
-				Format(sMessage, sizeof(sMessage), "You have %d second%s to move before getting replaced!", g_iUberRangerMinionAFKTimeLeft[this.iClient], g_iUberRangerMinionAFKTimeLeft[this.iClient] != 1 ? "s" : "");
-			else
-				Format(sMessage, sizeof(sMessage), "Use your Medigun to heal your companions!");
-				
-			Hud_AddText(this.iClient, sMessage);
-		}
+		char sMessage[64];
+		if (!g_bUberRangerMinionHasMoved[this.iClient])
+			Format(sMessage, sizeof(sMessage), "You have %d second%s to move before getting replaced!", g_iUberRangerMinionAFKTimeLeft[this.iClient], g_iUberRangerMinionAFKTimeLeft[this.iClient] != 1 ? "s" : "");
+		else
+			Format(sMessage, sizeof(sMessage), "Use your Medigun to heal your companions!");
+			
+		Hud_AddText(this.iClient, sMessage);
 	}
 	
 	public void OnDeath()

--- a/addons/sourcemod/scripting/vsh/hud.sp
+++ b/addons/sourcemod/scripting/vsh/hud.sp
@@ -79,13 +79,13 @@ void Hud_Think(int iClient)
 	if (!IsPlayerAlive(iClient))
 	{
 		//If dead, display whoever client is spectating and damage
-		int iOberserTarget = GetEntPropEnt(iClient, Prop_Send, "m_hObserverTarget");
-		if (iOberserTarget != iClient && 0 < iOberserTarget <= MaxClients && IsClientInGame(iOberserTarget) && !SaxtonHaleBase(iOberserTarget).bValid)
+		int iObserverTarget = GetEntPropEnt(iClient, Prop_Send, "m_hObserverTarget");
+		if (iObserverTarget != iClient && 0 < iObserverTarget <= MaxClients && IsClientInGame(iObserverTarget) && !SaxtonHaleBase(iObserverTarget).bValid)
 		{
-			if (g_iPlayerAssistDamage[iOberserTarget] <= 0)
-				Format(sMessage, sizeof(sMessage), "%N's Damage: %i", iOberserTarget, g_iPlayerDamage[iOberserTarget]);
+			if (g_iPlayerAssistDamage[iObserverTarget] <= 0)
+				Format(sMessage, sizeof(sMessage), "%N's Damage: %i", iObserverTarget, g_iPlayerDamage[iObserverTarget]);
 			else
-				Format(sMessage, sizeof(sMessage), "%N's Damage: %i Assist: %i", iOberserTarget, g_iPlayerDamage[iOberserTarget], g_iPlayerAssistDamage[iOberserTarget]);
+				Format(sMessage, sizeof(sMessage), "%N's Damage: %i Assist: %i", iObserverTarget, g_iPlayerDamage[iObserverTarget], g_iPlayerAssistDamage[iObserverTarget]);
 			
 			Hud_AddText(iClient, sMessage, true);
 		}


### PR DESCRIPTION
Just minor changes regarding HUD text, here's a list of them:
- By default, text will now go away on death. This was most commonly seen in duo bosses (and would probably be noticed the most with minibosses in the future), includes text like rage meter, super jump info, boss/ability info, etc. and does not include important text such as boss health, your own damage/assistance and damage/assistance from people who you are spectating.
- (Multi-)Bosses who die will now be able to see remaining boss(es)' health and damage/assistance from people who are being spectated.
- Added info text for the wall climbing ability, as it's not obvious to unfamiliar people.