### PR TITLE
Add Vampire modifier

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -374,12 +374,13 @@ ConVar tf_arena_preround_time;
 #include "vsh/bosses/boss_pyromancer_scorched.sp"
 #include "vsh/bosses/boss_pyromancer_scalded.sp"
 
-#include "vsh/modifiers/modifiers_speed.sp"
-#include "vsh/modifiers/modifiers_jump.sp"
+#include "vsh/modifiers/modifiers_angry.sp"
+#include "vsh/modifiers/modifiers_electric.sp"
 #include "vsh/modifiers/modifiers_hot.sp"
 #include "vsh/modifiers/modifiers_ice.sp"
-#include "vsh/modifiers/modifiers_electric.sp"
-#include "vsh/modifiers/modifiers_angry.sp"
+#include "vsh/modifiers/modifiers_jump.sp"
+#include "vsh/modifiers/modifiers_speed.sp"
+#include "vsh/modifiers/modifiers_vampire.sp"
 
 #include "vsh/tags/tags_params.sp"
 #include "vsh/tags/tags_target.sp"
@@ -658,12 +659,13 @@ public void OnPluginStart()
 	SaxtonHale_RegisterClass("CWeaponSpells", VSHClassType_Ability);
 	
 	//Register modifiers
-	SaxtonHale_RegisterClass("CModifiersSpeed", VSHClassType_Modifier);
-	SaxtonHale_RegisterClass("CModifiersJump", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersAngry", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersElectric", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersHot", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersIce", VSHClassType_Modifier);
-	SaxtonHale_RegisterClass("CModifiersElectric", VSHClassType_Modifier);
-	SaxtonHale_RegisterClass("CModifiersAngry", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersJump", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersSpeed", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersVampire", VSHClassType_Modifier);
 	
 	//Init our convars
 	g_ConfigConvar.Create("vsh_force_load", "-1", "Force enable VSH on map start? (-1 for default, 0 for force disable, 1 for force enable)", _, true, -1.0, true, 1.0);

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
@@ -20,6 +20,11 @@ methodmap CModifiersVampire < SaxtonHaleBase
 		g_flVampireStartTime[boss.iClient] = 0.0;
 	}
 	
+	public bool IsModifiersHidden()
+	{
+		return true;
+	}
+	
 	public void GetModifiersName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Vampire");

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
@@ -1,0 +1,120 @@
+#define VAMPIRE_GAIN	300.0
+#define VAMPIRE_LOSS	35.0
+
+static int g_iVampireCount = 0;
+static int g_iVampireStartHealth[TF_MAXPLAYERS+1];
+static float g_flVampireStartTime[TF_MAXPLAYERS+1];
+
+methodmap CModifiersVampire < SaxtonHaleBase
+{
+	public CModifiersVampire(CModifiersVampire boss)
+	{
+		if (g_iVampireCount == 0)
+		{
+			SaxtonHale_HookFunction("CalculateMaxHealth", Vampire_CalculateMaxHealth, VSHHookMode_Pre);
+			HookEvent("player_death", Vampire_PlayerDeath);
+		}
+		
+		g_iVampireCount++;
+		g_iVampireStartHealth[boss.iClient] = 1;
+		g_flVampireStartTime[boss.iClient] = 0.0;
+	}
+	
+	public void GetModifiersName(char[] sName, int length)
+	{
+		strcopy(sName, length, "Vampire");
+	}
+	
+	public void GetModifiersInfo(char[] sInfo, int length)
+	{
+		StrCat(sInfo, length, "\nColor: Purple");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\n- Gain 300 health on player death");
+		StrCat(sInfo, length, "\n- Max health decays 35 per second");
+	}
+	
+	public int GetRenderColor(int iColor[4])
+	{
+		iColor[0] = 160;
+		iColor[1] = 144;
+		iColor[2] = 255;
+		iColor[3] = 255;
+	}
+	
+	public void OnThink()
+	{
+		if (GameRules_GetRoundState() != RoundState_Preround && IsPlayerAlive(this.iClient))
+		{
+			if (g_flVampireStartTime[this.iClient] == 0.0)
+			{
+				g_iVampireStartHealth[this.iClient] = this.iMaxHealth;
+				g_flVampireStartTime[this.iClient] = GetGameTime();
+			}
+			
+			int iHealth = this.CallFunction("CalculateMaxHealth");
+			this.iMaxHealth = iHealth;
+			if (this.iHealth > iHealth)
+				this.iHealth = iHealth;
+			
+			
+		}
+	}
+	
+	public void Destroy()
+	{
+		if (g_iVampireCount > 0)	//This should never fail but just in case...
+			g_iVampireCount--;
+		
+		if (g_iVampireCount == 0)
+		{
+			SaxtonHale_UnhookFunction("CalculateMaxHealth", Vampire_CalculateMaxHealth);
+			UnhookEvent("player_death", Vampire_PlayerDeath);
+		}
+	}
+};
+
+public Action Vampire_CalculateMaxHealth(SaxtonHaleBase boss, int &iHealth)
+{
+	if (Vampire_IsVampire(boss.iClient) && g_flVampireStartTime[boss.iClient] != 0.0)
+	{
+		//Remove health by starting hp and time
+		iHealth = g_iVampireStartHealth[boss.iClient] - RoundToFloor((GetGameTime() - g_flVampireStartTime[boss.iClient]) * VAMPIRE_LOSS);
+		
+		if (iHealth < 1)
+			iHealth = 1;
+		
+		return Plugin_Stop;
+	}
+	
+	return Plugin_Continue;
+}
+
+public Action Vampire_PlayerDeath(Event event, const char[] sName, bool bDontBroadcast)
+{
+	int iVictim = GetClientOfUserId(event.GetInt("userid"));
+	if (!SaxtonHale_IsValidAttack(iVictim))
+		return;
+	
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+	{
+		if (Vampire_IsVampire(iClient) && IsPlayerAlive(iClient))
+		{
+			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
+			boss.iHealth += VAMPIRE_GAIN;
+			
+			if (boss.iHealth > boss.iMaxHealth)
+				boss.iHealth = boss.iMaxHealth;
+		}
+	}
+}
+
+stock bool Vampire_IsVampire(int iClient)
+{
+	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
+	if (!boss.bValid || !boss.bModifiers)
+		return false;
+	
+	char sBossType[MAX_TYPE_CHAR];
+	boss.CallFunction("GetModifiersType", sBossType, sizeof(sBossType));
+	return StrEqual(sBossType, "CModifiersVampire");
+}

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
@@ -1,5 +1,5 @@
 #define VAMPIRE_GAIN	300.0
-#define VAMPIRE_LOSS	35.0
+#define VAMPIRE_LOSS	30.0
 
 static int g_iVampireCount = 0;
 static int g_iVampireStartHealth[TF_MAXPLAYERS+1];
@@ -30,7 +30,7 @@ methodmap CModifiersVampire < SaxtonHaleBase
 		StrCat(sInfo, length, "\nColor: Purple");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\n- Gain 300 health on player death");
-		StrCat(sInfo, length, "\n- Max health decays 35 per second");
+		StrCat(sInfo, length, "\n- Max health decays 30 per second");
 	}
 	
 	public int GetRenderColor(int iColor[4])

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_vampire.sp
@@ -55,8 +55,6 @@ methodmap CModifiersVampire < SaxtonHaleBase
 			this.iMaxHealth = iHealth;
 			if (this.iHealth > iHealth)
 				this.iHealth = iHealth;
-			
-			
 		}
 	}
 	


### PR DESCRIPTION
1 upside and 1 downside
- Gains 300 health on every attack team death. Including deaths not killed from boss, to prevent self-suicide to jew out health gain. Does not overheal.
- Max health decays by 35hp per second, down to min 1 max health. For 10k hp boss, this takes over 4 mins to each 1hp.