### PR TITLE
Update dome to only damage one team based from CP owner

### DIFF
--- a/addons/sourcemod/configs/vsh/maps.cfg
+++ b/addons/sourcemod/configs/vsh/maps.cfg
@@ -221,10 +221,6 @@
 		{
 			"vsh_dome_radius_start"	"2500"
 		}
-//		"vsh_streets"	//This map really only used for plugin testing purposes
-//		{
-//			"vsh_dome_enable"		"0"
-//		}
 		"vsh_teul"
 		{
 			"vsh_dome_radius_start"	"2250"

--- a/addons/sourcemod/configs/vsh/maps.cfg
+++ b/addons/sourcemod/configs/vsh/maps.cfg
@@ -2,8 +2,7 @@
 //
 //Dome config that mainly been used for it
 //- vsh_dome_centre 	- move centre of the dome/CP to a new given pos, use to move to a more reasonable flat/centre/lower spot everyone tend to be at
-//- vsh_dome_radius_max	- Max radius the dome when starting, use to set value to wherever playable spot thats furthest away from centre
-//- vsh_dome_speed_max	- Max speed of the dome when starting, use to combine with max radius (bigger size means faster dome speed)
+//- vsh_dome_radius_start	- Max radius the dome when starting, use to set value to wherever playable spot thats furthest away from centre
 //
 //If map/convar is not listed here, values in vsh.cfg is used instead
 
@@ -14,299 +13,240 @@
 		"arena_dust"
 		{
 			"vsh_dome_centre"		"-16 752 -48"
-			"vsh_dome_radius_max"	"3750"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3750"
 		}
 		"arena_lumberyard"
 		{
-			"vsh_dome_radius_max"	"2000"
-			"vsh_dome_speed_max"	"15"
-			"vsh_dome_speed_min"	"10"
+			"vsh_dome_radius_start"	"2000"
 		}
 		"arena_rust"
 		{
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_anubis_catharsis"
 		{
 			"vsh_dome_centre"		"768 1920 -64"
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 		"vsh_arakawa"
 		{
 			"vsh_dome_centre"		"136 0 0"
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_brewery"
 		{
 			"vsh_dome_centre"		"-208 -1440 0"
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 		"vsh_castle_siege"
 		{
 			"vsh_dome_centre"		"-2816 0 0"
-			"vsh_dome_radius_max"	"3750"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3750"
 		}
 		"vsh_chemical"
 		{
 			"vsh_dome_centre"		"-704 -192 -64"
-			"vsh_dome_radius_max"	"3250"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3250"
 		}
 		"vsh_chimeralabs"
 		{
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_chinatown"
 		{
 			"vsh_dome_centre"		"1024 1472 48"
-			"vsh_dome_radius_max"	"2750"
-			"vsh_dome_speed_max"	"35"
+			"vsh_dome_radius_start"	"2750"
 		}
 		"vsh_citypeak"
 		{
-			"vsh_dome_radius_max"	"3250"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3250"
 		}
 		"vsh_coldvine"
 		{
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 		"vsh_colossal_vessel"
 		{
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_courtyard"
 		{
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_crevice"
 		{
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_detra"
 		{
 			"vsh_dome_centre"		"-1728 0 -512"
-			"vsh_dome_radius_max"	"2750"
-			"vsh_dome_speed_max"	"35"
+			"vsh_dome_radius_start"	"2750"
 		}
 		"vsh_drejun"
 		{
 			"vsh_dome_centre"		"320 -128 -44"
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_egyptyspot"
 		{
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_gyros"
 		{
 			"vsh_dome_centre"		"2944 960 -104"
-			"vsh_dome_radius_max"	"4000"
-			"vsh_dome_speed_max"	"50"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_hakurei_shrine"
 		{
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_impure"
 		{
-			"vsh_dome_radius_max"	"4000"
-			"vsh_dome_speed_max"	"50"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_jealo"
 		{
-			"vsh_dome_radius_max"	"3250"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3250"
 		}
 		"vsh_jungle_beach"
 		{
 			"vsh_dome_centre"		"-512 640 -224"
-			"vsh_dome_radius_max"	"4500"
-			"vsh_dome_speed_max"	"60"
+			"vsh_dome_radius_start"	"4500"
 		}
 		"vsh_lobster_shore"
 		{
 			"vsh_dome_centre"		"-1504 64 120"
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 		"vsh_manncohq"
 		{
 			"vsh_dome_centre"		"620 -3196 24"
-			"vsh_dome_radius_max"	"4250"
-			"vsh_dome_speed_max"	"60"
+			"vsh_dome_radius_start"	"4250"
 		}
 		"vsh_megaman6"
 		{
-			"vsh_dome_radius_max"	"6000"
-			"vsh_dome_speed_max"	"120"
+			"vsh_dome_radius_start"	"6000"
 		}
 		"vsh_militaryzone"
 		{
 			"vsh_dome_centre"		"0 288 64"
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_moving_in"
 		{
 			"vsh_dome_centre"		"-1920 -1480 -192"
-			"vsh_dome_radius_max"	"4750"
-			"vsh_dome_speed_max"	"80"
+			"vsh_dome_radius_start"	"4750"
 		}
 		"vsh_nale"
 		{
 			"vsh_dome_centre"		"64 -896 0"
-			"vsh_dome_radius_max"	"5750"
-			"vsh_dome_speed_max"	"110"
+			"vsh_dome_radius_start"	"5750"
 		}
 		"vsh_nebula"
 		{
 			"vsh_dome_centre"		"1096 -1152 -972"
-			"vsh_dome_radius_max"	"2500"
-			"vsh_dome_speed_max"	"25"
-		}
-		"vsh_oh_multimaps"	//Multi-CP
-		{
-			"vsh_dome_enable"		"0"
+			"vsh_dome_radius_start"	"2500"
 		}
 		"vsh_pbjungle"
 		{
 			"vsh_dome_centre"		"640 4864 6"
-			"vsh_dome_radius_max"	"5000"
-			"vsh_dome_speed_max"	"90"
+			"vsh_dome_radius_start"	"5000"
 		}
 		"vsh_pyramidtime"
 		{
 			"vsh_dome_centre"		"-1920 -2176 128"
-			"vsh_dome_radius_max"	"4250"
-			"vsh_dome_speed_max"	"60"
+			"vsh_dome_radius_start"	"4250"
 		}
 		"vsh_radwater"
 		{
-			"vsh_dome_radius_max"	"4000"
-			"vsh_dome_speed_max"	"50"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_ram_shacked"
 		{
 			"vsh_dome_centre"		"768 -400 136"
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_reiltas_hills"
 		{
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 		"vsh_rocketyard"
 		{
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_rockslide"
 		{
-			"vsh_dome_radius_max"	"2500"
-			"vsh_dome_speed_max"	"25"
+			"vsh_dome_radius_start"	"2500"
 		}
 		"vsh_rooftops"
 		{
-			"vsh_dome_radius_max"	"2750"
-			"vsh_dome_speed_max"	"35"
+			"vsh_dome_radius_start"	"2750"
 		}
 		"vsh_rubble"
 		{
 			"vsh_dome_centre"		"-864 1184 190"
-			"vsh_dome_radius_max"	"4500"
-			"vsh_dome_speed_max"	"60"
+			"vsh_dome_radius_start"	"4500"
 		}
 		"vsh_seine"
 		{
-			"vsh_dome_radius_max"	"3250"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3250"
 		}
 		"vsh_shiri_peak"
 		{
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_snowdime"
 		{
-			"vsh_dome_radius_max"	"3750"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3750"
 		}
 		"vsh_snowglobe"
 		{
-			"vsh_dome_radius_max"	"2000"
-			"vsh_dome_speed_max"	"15"
-			"vsh_dome_speed_min"	"10"
+			"vsh_dome_radius_start"	"2000"
 		}
 		"vsh_spaaaaace"
 		{
 			"vsh_dome_centre"		"0 -64 1728"
-			"vsh_dome_radius_max"	"4000"
-			"vsh_dome_speed_max"	"50"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_split"
 		{
-			"vsh_dome_radius_max"	"2750"
-			"vsh_dome_speed_max"	"35"
+			"vsh_dome_radius_start"	"2750"
 		}
 		"vsh_spotline"
 		{
 			"vsh_dome_centre"		"-512 24 -688"
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_starboard"
 		{
-			"vsh_dome_radius_max"	"2500"
-			"vsh_dome_speed_max"	"25"
+			"vsh_dome_radius_start"	"2500"
 		}
-		"vsh_streets"	//This map really only used for plugin testing purposes
-		{
-			"vsh_dome_enable"		"0"
-		}
+//		"vsh_streets"	//This map really only used for plugin testing purposes
+//		{
+//			"vsh_dome_enable"		"0"
+//		}
 		"vsh_teul"
 		{
-			"vsh_dome_radius_max"	"2250"
-			"vsh_dome_speed_max"	"20"
-			"vsh_dome_speed_min"	"15"
+			"vsh_dome_radius_start"	"2250"
 		}
 		"vsh_trainyard"
 		{
 			"vsh_dome_centre"		"160 128 64"
-			"vsh_dome_radius_max"	"4000"
-			"vsh_dome_speed_max"	"50"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_tranquil"
 		{
-			"vsh_dome_radius_max"	"2750"
-			"vsh_dome_speed_max"	"35"
+			"vsh_dome_radius_start"	"2750"
 		}
 		"vsh_warebloom"
 		{
 			"vsh_dome_centre"		"512 0 -320"
-			"vsh_dome_radius_max"	"3000"
-			"vsh_dome_speed_max"	"40"
+			"vsh_dome_radius_start"	"3000"
 		}
 		"vsh_yammoe"
 		{
 			"vsh_dome_centre"		"384 1168 192"
-			"vsh_dome_radius_max"	"3500"
-			"vsh_dome_speed_max"	"45"
+			"vsh_dome_radius_start"	"3500"
 		}
 	}
 }

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2037,21 +2037,21 @@
 	
 	"cvars"
 	{
-		"vsh_force_load"            "-1"        //Force enable VSH on map start? (-1 for default, 0 for force unload, 1 for force load)
-		"vsh_telefrag_damage"       "4242.0"    //Damage amount to boss from telefrag
+		"vsh_force_load"            "-1"                //Force enable VSH on map start? (-1 for default, 0 for force unload, 1 for force load)
+		"vsh_telefrag_damage"       "4242.0"            //Damage amount to boss from telefrag
 		
-		"vsh_boss_chance_saxton"    "0.25"      //% chance for next boss to be Saxton Hale (0.0 - 1.0)
-		"vsh_boss_chance_multi"     "0.20"      //% chance for next boss to be Multiple bosses (after Saxton Hale roll) (0.0 - 1.0)
-		"vsh_boss_chance_modifiers" "0.15"      //% chance for next boss to have random modifiers (0.0 - 1.0)
-		"vsh_boss_ping_limit"       "200"       //Max ping/latency to allow player play as boss
-		"vsh_boss_winstreak_health" "0.05"      //Percentage loss per winstreak to reduce boss healh
+		"vsh_boss_chance_saxton"    "0.25"              //% chance for next boss to be Saxton Hale (0.0 - 1.0)
+		"vsh_boss_chance_multi"     "0.20"              //% chance for next boss to be Multiple bosses (after Saxton Hale roll) (0.0 - 1.0)
+		"vsh_boss_chance_modifiers" "0.15"              //% chance for next boss to have random modifiers (0.0 - 1.0)
+		"vsh_boss_ping_limit"       "200"               //Max ping/latency to allow player play as boss
+		"vsh_boss_winstreak_health" "0.05"              //Percentage loss per winstreak to reduce boss healh
 		
-		"vsh_cookies_preferences"   "1"         //Should preferences use cookies to store? (Disable if you want to store preferences somewhere else)
-		"vsh_cookies_queue"         "1"         //Should queue use cookies to store? (Disable if you want to store queue somewhere else)
-		"vsh_cookies_winstreak"     "1"         //Should winstreak use cookies to store? (Disable if you want to store winstreak somewhere else)
+		"vsh_cookies_preferences"   "1"                 //Should preferences use cookies to store? (Disable if you want to store preferences somewhere else)
+		"vsh_cookies_queue"         "1"                 //Should queue use cookies to store? (Disable if you want to store queue somewhere else)
+		"vsh_cookies_winstreak"     "1"                 //Should winstreak use cookies to store? (Disable if you want to store winstreak somewhere else)
 
-		"vsh_class_limit"           "1"         //Enable/Disable entire class limit
-		"vsh_class_limit_scout"     "5"         //Max on how many players can play as that class, use -1 for no limit
+		"vsh_class_limit"           "1"                 //Enable/Disable entire class limit
+		"vsh_class_limit_scout"     "5"                 //Max on how many players can play as that class, use -1 for no limit
 		"vsh_class_limit_soldier"   "5"
 		"vsh_class_limit_pyro"      "5"
 		"vsh_class_limit_demoman"   "5"
@@ -2061,13 +2061,17 @@
 		"vsh_class_limit_sniper"    "5"
 		"vsh_class_limit_spy"       "5"
 
-		"vsh_dome_enable"           "1"         //Enable dome?
-		"vsh_dome_centre"           ""          //Map centre pos for Dome/CP (always leave it blank here)
-		"vsh_dome_color"            "255 0 0"   //Color of dome in RGB
-		"vsh_dome_radius_max"       "3500"      //Max radius of dome
-		"vsh_dome_radius_min"       "0"         //Min radius of dome
-		"vsh_dome_speed_max"        "30"        //Start speed of dome
-		"vsh_dome_speed_min"        "20"        //End speed of dome
-		"vsh_dome_freeze_duration"  "8.0"       //Duration in seconds to stop dome whenever player dies
+		"vsh_dome_enable"           "1"                 //Enable dome?
+		"vsh_dome_centre"           ""                  //Map centre pos for Dome/CP (always leave it blank here)
+		"vsh_dome_cp_unlock"        "60"                //Time in second to unlock CP on round start
+		"vsh_dome_cp_unlockplayer"  "5"                 //Time in second to add on every player to unlock CP on round start
+		"vsh_dome_cp_caprate"       "15"                //How long to capture CP
+		"vsh_dome_cp_bossrate"      "2"                 //Capture value for boss
+		"vsh_dome_color_neu"        "192 192 192 255"   //Color of dome in RGBA if nobody owns the capture point
+		"vsh_dome_color_red"        "255 0 0 255"       //Color of dome in RGBA if red owns the capture point
+		"vsh_dome_color_blu"        "0 0 255 255"       //Color of dome in RGBA if red owns the capture point
+		"vsh_dome_radius_start"     "3500"              //Start radius of dome
+		"vsh_dome_radius_end"       "0"                 //End radius of dome
+		"vsh_dome_speed_duration"   "120"               //How long it takes in second for dome to fully shrink, without any slowdown
 	}
 }

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2063,6 +2063,7 @@
 
 		"vsh_dome_enable"           "1"                 //Enable dome?
 		"vsh_dome_centre"           ""                  //Map centre pos for Dome/CP (always leave it blank here)
+		"vsh_dome_cp_radius"        "250"               //If vsh_dome_centre specified, new radius from CP to capture
 		"vsh_dome_cp_unlock"        "60"                //Time in second to unlock CP on round start
 		"vsh_dome_cp_unlockplayer"  "5"                 //Time in second to add on every player to unlock CP on round start
 		"vsh_dome_cp_caprate"       "15"                //How long to capture CP

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -62,6 +62,11 @@
 		}
 		"Offsets"
 		{
+			"CTFGameRules::GetCaptureValueForPlayer"
+			{
+				"linux"		"154"
+				"windows"	"153"
+			}
 			"CTFGameRules::SetWinningTeam"
 			{
 				"linux"		"161"

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -62,6 +62,11 @@
 		}
 		"Offsets"
 		{
+			"CTFGameRules::SetWinningTeam"
+			{
+				"linux"		"161"
+				"windows"	"160"
+			}
 			"CBaseEntity::ShouldTransmit"
 			{
 				"linux"		"19"

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -16,18 +16,6 @@
 				"linux"		"@_ZN9CTFPlayer33GetEquippedWearableForLoadoutSlotEi"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x2A\x8B\xC1\x53\x56\x33\xF6\x89\x45\xF8\x8B\x88\x2A\x2A\x2A\x2A\x57\x89\x4D\xFC"
 			}
-			"CWeaponMedigun::AllowedToHealTarget"
-			{
-				"library"	"server"
-				"linux"		"@_ZN14CWeaponMedigun19AllowedToHealTargetEP11CBaseEntity"
-				"windows"	"\x55\x8B\xEC\x53\x8B\xD9\x56\x57\x8B\xB3\xE8\x01\x00\x00"
-			}
-			"CObjectDispenser::CouldHealTarget"
-			{
-				"library"	"server"
-				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
-				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x10\x01\x00\x00"
-			}
 			"CTFPlayer::AddObject"
 			{
 				"library"	"server"
@@ -40,9 +28,41 @@
 				"linux"		"@_ZN9CTFPlayer12RemoveObjectEP11CBaseObject"
 				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x7C\x21\x00\x00"
 			}
+			"CTriggerAreaCapture::SetCapTimeRemaining"
+			{
+				"library"	"server"
+				"linux"		"@_ZN19CTriggerAreaCapture19SetCapTimeRemainingEf"
+				"windows"	"\x55\x8B\xEC\xF3\x0F\x10\x45\x08\x56\x8B\xF1\xC7\x45\x08\x00\x00\x00\x00"
+			}
+			"CWeaponMedigun::AllowedToHealTarget"
+			{
+				"library"	"server"
+				"linux"		"@_ZN14CWeaponMedigun19AllowedToHealTargetEP11CBaseEntity"
+				"windows"	"\x55\x8B\xEC\x53\x8B\xD9\x56\x57\x8B\xB3\xE8\x01\x00\x00"
+			}
+			"CObjectDispenser::CouldHealTarget"
+			{
+				"library"	"server"
+				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
+				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x10\x01\x00\x00"
+			}
 		}
 		"Functions"
 		{
+			"CTriggerAreaCapture::SetCapTimeRemaining"
+			{
+				"signature"	"CTriggerAreaCapture::SetCapTimeRemaining"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"entity"
+				"arguments"
+				{
+					"flTime"
+					{
+						"type"	"float"
+					}
+				}
+			}
 			"CWeaponMedigun::AllowedToHealTarget"
 			{
 				"signature"	"CWeaponMedigun::AllowedToHealTarget"

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -931,6 +931,10 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 	else if (StrEqual(sClassname, "trigger_capture_area"))
 	{
 		SDKHook(iEntity, SDKHook_Spawn, Dome_TriggerSpawn);
+		
+		SDKHook(iEntity, SDKHook_StartTouch, Dome_TriggerTouch);
+		SDKHook(iEntity, SDKHook_Touch, Dome_TriggerTouch);
+		SDKHook(iEntity, SDKHook_EndTouch, Dome_TriggerTouch);
 	}
 }
 
@@ -1182,6 +1186,7 @@ public void Client_OnThink(int iClient)
 	else
 	{
 		Tags_OnThink(iClient);
+		Dome_OnThink(iClient);
 		
 		TFClassType nClass = TF2_GetPlayerClass(iClient);
 		

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -17,7 +17,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION 					"1.3.0"
+#define PLUGIN_VERSION 					"1.3.1"
 #define PLUGIN_VERSION_REVISION 		"manual"
 
 #if !defined SP_MAX_EXEC_PARAMS

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -82,6 +82,14 @@ enum Preferences ( <<=1 )
 	Preferences_Revival,
 };
 
+enum WinReason
+{
+	WinReason_PointCaptured = 1, 
+	WinReason_Elimination, 
+	WinReason_AllPointsCaptured = 4, 
+	WinReason_Stalemate
+};
+
 enum
 {
 	WeaponSlot_Primary = 0,
@@ -771,7 +779,6 @@ void Plugin_Cvars(bool toggle)
 		tf_dropped_weapon_lifetime.IntValue = iDroppedWeaponLifetime;
 		tf_damage_disablespread.IntValue = iDamageDisableSpread;
 
-
 		tf_scout_hype_pep_max.FloatValue = flScoutHypePepMax;
 		tf_feign_death_activate_damage_scale.FloatValue = flFeignDeathActiveDamageScale;
 		tf_feign_death_damage_scale.FloatValue = flFeignDeathDamageScale;
@@ -920,6 +927,10 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 		|| strcmp(sClassname, "func_regenerate") == 0)
 	{
 		SDKHook(iEntity, SDKHook_Touch, ItemPack_OnTouch);
+	}
+	else if (StrEqual(sClassname, "trigger_capture_area"))
+	{
+		SDKHook(iEntity, SDKHook_Spawn, Dome_TriggerSpawn);
 	}
 }
 

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1243,15 +1243,17 @@ public void OnClientDisconnect_Post(int iClient)
 public void Client_OnThink(int iClient)
 {
 	if (!g_bEnabled) return;
+	
+	Dome_OnThink(iClient);
+	
 	if (g_iTotalRoundPlayed <= 0) return;
-
+	
 	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 	if (boss.bValid)
 		boss.CallFunction("OnThink");
 	else
 	{
 		Tags_OnThink(iClient);
-		Dome_OnThink(iClient);
 		
 		TFClassType nClass = TF2_GetPlayerClass(iClient);
 		

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -936,6 +936,11 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 		SDKHook(iEntity, SDKHook_Touch, Dome_TriggerTouch);
 		SDKHook(iEntity, SDKHook_EndTouch, Dome_TriggerTouch);
 	}
+	else if (StrEqual(sClassname, "game_end"))
+	{
+		//Superceding SetWinningTeam causes some maps to force a map change on capture
+		AcceptEntityInput(iEntity, "Kill");
+	}
 }
 
 public Action ItemPack_OnTouch(int iEntity, int iToucher)

--- a/addons/sourcemod/scripting/vsh/command.sp
+++ b/addons/sourcemod/scripting/vsh/command.sp
@@ -35,6 +35,8 @@ public void Command_Init()
 	Command_Create("queue", Command_AddQueuePoints);
 	Command_Create("point", Command_AddQueuePoints);
 	Command_Create("special", Command_ForceSpecialRound);
+	Command_Create("cap", Command_EnableCap);
+	Command_Create("cp", Command_EnableCap);
 	Command_Create("dome", Command_ForceDome);
 	Command_Create("rage", Command_SetRage);
 }
@@ -401,6 +403,29 @@ public Action Command_ForceSpecialRound(int iClient, int iArgs)
 		return Plugin_Handled;
 	}
 
+	ReplyToCommand(iClient, "%s%s You do not have permission to use this command.", TEXT_TAG, TEXT_ERROR);
+	return Plugin_Handled;
+}
+
+public Action Command_EnableCap(int iClient, int iArgs)
+{
+	if (!g_bEnabled) return Plugin_Continue;
+
+	if (Client_HasFlag(iClient, ClientFlags_Admin))
+	{
+		if (GameRules_GetPropFloat("m_flCapturePointEnableTime") > GetGameTime())
+		{
+			GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
+			PrintToChatAll("%s%s %N force unlocked capture point!", TEXT_TAG, TEXT_COLOR, iClient);
+		}
+		else
+		{
+			ReplyToCommand(iClient, "%s%s Capture point is already unlocked", TEXT_TAG, TEXT_ERROR);
+		}
+		
+		return Plugin_Handled;
+	}
+	
 	ReplyToCommand(iClient, "%s%s You do not have permission to use this command.", TEXT_TAG, TEXT_ERROR);
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/vsh/command.sp
+++ b/addons/sourcemod/scripting/vsh/command.sp
@@ -411,16 +411,48 @@ public Action Command_ForceDome(int iClient, int iArgs)
 
 	if (Client_HasFlag(iClient, ClientFlags_Admin))
 	{
-		if (Dome_Start())
-		{
-			PrintToChatAll("%s%s %N force start the dome!", TEXT_TAG, TEXT_COLOR, iClient);
-			return Plugin_Handled;
-		}
+		char sBuffer[32];
+		GetCmdArgString(sBuffer, sizeof(sBuffer));
+		
+		TFTeam nTeam;
+		if (StrContains(sBuffer, "red", false) == 0)
+			nTeam = TFTeam_Red;
+		else if (StrContains(sBuffer, "blu", false) == 0)
+			nTeam = TFTeam_Blue;
+		else if (StrContains(sBuffer, "attack", false) == 0)
+			nTeam = TFTeam_Attack;
+		else if (StrContains(sBuffer, "boss", false) == 0)
+			nTeam = TFTeam_Boss;
 		else
+			nTeam = view_as<TFTeam>(StringToInt(sBuffer));
+		
+		char sTeam[32];
+		
+		switch (nTeam)
 		{
-			ReplyToCommand(iClient, "%s%s There is already a active dome!", TEXT_TAG, TEXT_ERROR);
-			return Plugin_Handled;
+			case TFTeam_Attack:
+			{
+				Dome_SetTeam(TFTeam_Attack);
+				sTeam = "attack";
+			}
+			case TFTeam_Boss:
+			{
+				Dome_SetTeam(TFTeam_Boss);
+				sTeam = "boss";
+			}
+			default:
+			{
+				Dome_SetTeam(TFTeam_Unassigned);
+				sTeam = "neutral";
+			}
 		}
+		
+		if (Dome_Start())
+			PrintToChatAll("%s%s %N force start %s dome!", TEXT_TAG, TEXT_COLOR, iClient, sTeam);
+		else
+			PrintToChatAll("%s%s %N changed dome team to %s!", TEXT_TAG, TEXT_COLOR, iClient, sTeam);
+		
+		return Plugin_Handled;
 	}
 
 	ReplyToCommand(iClient, "%s%s You do not have permission to use this command.", TEXT_TAG, TEXT_ERROR);

--- a/addons/sourcemod/scripting/vsh/config.sp
+++ b/addons/sourcemod/scripting/vsh/config.sp
@@ -353,32 +353,32 @@ methodmap ConfigConvar < StringMap
 		this.GetString(sName, sValue, sizeof(sValue));
 	}
 	
-	public bool LookupVector(const char[] sName, float vecValue[3])
+	public bool LookupIntArray(const char[] sName, int[] iArray, int iLength)
 	{
 		char sValue[MAXLEN_CONFIG_VALUE];
 		this.GetString(sName, sValue, sizeof(sValue));
 		
-		char sVec[3][12];
-		if (ExplodeString(sValue, " ", sVec, sizeof(sVec), sizeof(sVec[])) != 3)
+		char[][] sArray = new char[iLength][12];
+		if (ExplodeString(sValue, " ", sArray, iLength, 12) != iLength)
 			return false;
 		
-		for (int i = 0; i < 3; i++)
-			vecValue[i] = StringToFloat(sVec[i]);
+		for (int i = 0; i < iLength; i++)
+			iArray[i] = StringToInt(sArray[i]);
 		
 		return true;
 	}
 	
-	public bool LookupColor(const char[] sName, int iColor[4])
+	public bool LookupFloatArray(const char[] sName, float[] flArray, int iLength)
 	{
 		char sValue[MAXLEN_CONFIG_VALUE];
 		this.GetString(sName, sValue, sizeof(sValue));
 		
-		char sColor[4][12];
-		if (ExplodeString(sValue, " ", sColor, sizeof(sColor), sizeof(sColor[])) != 4)
+		char[][] sArray = new char[iLength][12];
+		if (ExplodeString(sValue, " ", sArray, iLength, 12) != iLength)
 			return false;
 		
-		for (int i = 0; i < 4; i++)
-			iColor[i] = StringToInt(sColor[i]);
+		for (int i = 0; i < iLength; i++)
+			flArray[i] = StringToFloat(sArray[i]);
 		
 		return true;
 	}

--- a/addons/sourcemod/scripting/vsh/config.sp
+++ b/addons/sourcemod/scripting/vsh/config.sp
@@ -352,6 +352,36 @@ methodmap ConfigConvar < StringMap
 	{
 		this.GetString(sName, sValue, sizeof(sValue));
 	}
+	
+	public bool LookupVector(const char[] sName, float vecValue[3])
+	{
+		char sValue[MAXLEN_CONFIG_VALUE];
+		this.GetString(sName, sValue, sizeof(sValue));
+		
+		char sVec[3][12];
+		if (ExplodeString(sValue, " ", sVec, sizeof(sVec), sizeof(sVec[])) != 3)
+			return false;
+		
+		for (int i = 0; i < 3; i++)
+			vecValue[i] = StringToFloat(sVec[i]);
+		
+		return true;
+	}
+	
+	public bool LookupColor(const char[] sName, int iColor[4])
+	{
+		char sValue[MAXLEN_CONFIG_VALUE];
+		this.GetString(sName, sValue, sizeof(sValue));
+		
+		char sColor[4][12];
+		if (ExplodeString(sValue, " ", sColor, sizeof(sColor), sizeof(sColor[])) != 4)
+			return false;
+		
+		for (int i = 0; i < 4; i++)
+			iColor[i] = StringToInt(sColor[i]);
+		
+		return true;
+	}
 };
 
 ConfigClass g_ConfigClass[10][WeaponSlot_BuilderEngie+1];	//Double array of StringMap
@@ -385,7 +415,6 @@ void Config_Refresh()
 	}
 	
 	g_ConfigIndex.Clear();
-	g_ConfigConvar.Clear();
 	TagsCore_Clear();
 	TagsName_Clear();
 	

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -506,8 +506,6 @@ void Dome_UpdateRadius()
 	
 	//Update global variable
 	g_flDomeRadius = flRadius;
-	
-	//PrintToConsoleAll("flSpeedAverage (%.2f) flSpeedMultiplier (%.2f) flSpeed (%.2f)", flSpeedAverage, flSpeedMultiplier, flSpeed);
 }
 
 float Dome_GetDistance(int iEntity)

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -102,6 +102,9 @@ public void Dome_TriggerSpawn(int iTrigger)
 
 public Action Dome_TriggerTouch(int iTrigger, int iToucher)
 {
+	if (iToucher <= 0 || iToucher > MaxClients)
+		return Plugin_Continue;
+	
 	//If CP is in custom pos and player is not nearby new pos (touching original pos), prevent call
 	if (g_bDomeCustomPos && !g_bDomeCapturing[iToucher])
 		return Plugin_Handled;

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -8,29 +8,33 @@
 #define DOME_NEARBY_SOUND	"ui/medic_alert.wav"
 #define DOME_PERPARE_DURATION 4.5
 
-static float g_flDomeEnableTime = 0.0;
+//Dome prop
+static int g_iDomeEntRef;
+static TFTeam g_nDomeTeamOwner = TFTeam_Unassigned;
+static float g_vecDomeCP[3];
+static int g_iDomeColor[4];
+
 static float g_flDomeStart = 0.0;
 static float g_flDomeRadius = 0.0;
 static float g_flDomePreviousGameTime = 0.0;
-static float g_flDomeFreeze = 0.0;
 static float g_flDomePlayerTime[TF_MAXPLAYERS+1] = 0.0;
 static bool g_bDomePlayerOutside[TF_MAXPLAYERS+1] = false;
 static Handle g_hDomeTimerBleed = null;
-
-static char g_strCP[64];
-static float g_vecCP[3];
-static int g_vecColor[3];
 
 void Dome_Init()
 {
 	g_ConfigConvar.Create("vsh_dome_enable", "1", "Enable dome?", _, true, 0.0, true, 1.0);
 	g_ConfigConvar.Create("vsh_dome_centre", "", "Map centre pos for Dome/CP (blank for CP's default centre)");
-	g_ConfigConvar.Create("vsh_dome_color", "255 0 0", "Color of dome in RGB");
-	g_ConfigConvar.Create("vsh_dome_radius_max", "3500", "Max radius of dome", _, true, 0.0);
-	g_ConfigConvar.Create("vsh_dome_radius_min", "0", "Min radius of dome", _, true, 0.0);
-	g_ConfigConvar.Create("vsh_dome_speed_max", "30", "Start speed of dome", _, true, 0.0);
-	g_ConfigConvar.Create("vsh_dome_speed_min", "20", "End speed of dome", _, true, 0.0);
-	g_ConfigConvar.Create("vsh_dome_freeze_duration", "8", "Duration in seconds to stop dome whenever player dies", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_cp_unlock", "60", "Time in second to unlock CP on round start", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_cp_unlockplayer", "5", "Time in second to add on every player to unlock CP on round start", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_cp_caprate", "15", "How long to capture CP", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_cp_bossrate", "3", "Capture value for boss", _, true, 1.0);
+	g_ConfigConvar.Create("vsh_dome_color_neu", "192 192 192 255", "Color of dome in RGBA if nobody owns the capture point");
+	g_ConfigConvar.Create("vsh_dome_color_red", "255 0 0 255", "Color of dome in RGBA if red owns the capture point");
+	g_ConfigConvar.Create("vsh_dome_color_blu", "0 0 255 255", "Color of dome in RGBA if blu owns the capture point");
+	g_ConfigConvar.Create("vsh_dome_radius_start", "3500", "Start radius of dome", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_radius_end", "0", "End radius of dome", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_speed_duration", "120", "How long it takes in second for dome to fully shrink, without any slowdown", _, true, 0.0);
 }
 
 void Dome_MapStart()
@@ -56,15 +60,34 @@ void Dome_MapStart()
 
 	PrepareSound(DOME_START_SOUND);
 	PrecacheSound(DOME_NEARBY_SOUND);
+	
+	SDK_HookSetWinningTeam(Dome_SetWinningTeam);
+}
+
+public MRESReturn Dome_SetWinningTeam(Handle hParams)
+{
+	//This function is called on every frame when suppose to end a round. Prevent round ending from capture
+	WinReason nReason = DHookGetParam(hParams, 2);
+	if (nReason == WinReason_PointCaptured || nReason == WinReason_AllPointsCaptured)
+		return MRES_Supercede;
+	
+	return MRES_Ignored;
+}
+
+public void Dome_TriggerSpawn(int iEntity)
+{
+	//Set time to cap to whatever in convar
+	DispatchKeyValueFloat(iEntity, "area_time_to_cap", g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate"));
 }
 
 void Dome_RoundStart()
 {
-	g_flDomeEnableTime = 0.0;
+	g_iDomeEntRef = 0;
+	g_nDomeTeamOwner = TFTeam_Unassigned;
+	
 	g_flDomeStart = 0.0;
 	g_flDomeRadius = 0.0;
 	g_flDomePreviousGameTime = 0.0;
-	g_flDomeFreeze = 0.0;
 	g_hDomeTimerBleed = null;
 	
 	for (int i = 1; i <= MaxClients; i++)
@@ -73,188 +96,123 @@ void Dome_RoundStart()
 		g_bDomePlayerOutside[i] = false;
 	}
 	
-	char sCentre[256];
-	g_ConfigConvar.LookupString("vsh_dome_centre", sCentre);
-	if (!StrEmpty(sCentre))
+	float vecCentre[3];
+	if (g_ConfigConvar.LookupVector("vsh_dome_centre", vecCentre))
 	{
-		//Get vec pos to move CP
-		float flVec[3];
-		char sVec[3][32];
-		int iCount = ExplodeString(sCentre, " ", sVec, 3, 32);
-		if (iCount == 3)
-			for (int i = 0; i < 3; i++)
-				flVec[i] = StringToFloat(sVec[i]);
-			
 		//Find CP to teleport
 		int iCP = FindEntityByClassname(-1, "team_control_point");
 		if (IsValidEntity(iCP))
-		{
-			TeleportEntity(iCP, flVec, NULL_VECTOR, NULL_VECTOR);
-		}
-			
+			TeleportEntity(iCP, vecCentre, NULL_VECTOR, NULL_VECTOR);
+		
 		//Find any CP prop to move aswell
 		int iProp = MaxClients+1;
 		while ((iProp = FindEntityByClassname(iProp, "prop_dynamic")) > MaxClients)
 		{
-			char strModel[128];
-			GetEntPropString(iProp, Prop_Data, "m_ModelName", strModel, sizeof(strModel));
+			char sModel[128];
+			GetEntPropString(iProp, Prop_Data, "m_ModelName", sModel, sizeof(sModel));
 			
-			if (StrEqual(strModel, "models/props_gameplay/cap_point_base.mdl")
-				|| StrEqual(strModel, "models/props_doomsday/cap_point_small.mdl"))
+			if (StrEqual(sModel, "models/props_gameplay/cap_point_base.mdl")
+				|| StrEqual(sModel, "models/props_doomsday/cap_point_small.mdl"))
 			{
-				TeleportEntity(iProp, flVec, NULL_VECTOR, NULL_VECTOR);
+				TeleportEntity(iProp, vecCentre, NULL_VECTOR, NULL_VECTOR);
 				DispatchKeyValue(iProp, "disableshadows", "1");
 			}
 		}
 	}
-
-	GameRules_SetPropFloat("m_flCapturePointEnableTime", 31536000.0+GetGameTime()); //3 years
 	
-	//Hide CP in hud, 0 for default, 1 for CTF, 2 for CP, 3 for Payload
-	//0 and 2 displays CP, 1 displays CTF with no intels, so 3 is the only option left as there no payload in map, nothing to display
-	GameRules_SetProp("m_nHudType", 3);
-}
-
-void Dome_RoundSelected(Event event)
-{
-	//If map have team_control_point_round, we get active CP for dome
-	char strRound[64];
-	event.GetString("round", strRound, sizeof(strRound));
-
-	//Search for each team_control_point_round
-	int iRound = MaxClients+1;
-	while((iRound = FindEntityByClassname(iRound, "team_control_point_round")) > MaxClients)
+	//CP hud is in the way from our VSH hud, move em to better place
+	int iObjectiveRessource = TF2_GetObjectiveResource();
+	if (iObjectiveRessource > MaxClients)
 	{
-		//Check if it the same name as from event
-		char strName[64];
-		GetEntPropString(iRound, Prop_Data, "m_iName", strName, sizeof(strName));
-		if (strcmp(strRound, strName) == 0)
-		{
-			//Take his CP, then save into global g_strCP
-			char strCPName[64];
-			GetEntPropString(iRound, Prop_Data, "m_iszCPNames", strCPName, sizeof(strCPName));
-			strcopy(g_strCP, sizeof(g_strCP), strCPName);
-		}
+		SetEntPropFloat(iObjectiveRessource, Prop_Send, "m_flCustomPositionX", 0.20);
+		SetEntPropFloat(iObjectiveRessource, Prop_Send, "m_flCustomPositionY", -1.0);
 	}
 }
 
 void Dome_RoundArenaStart()
 {
-	if (!g_ConfigConvar.LookupBool("vsh_dome_enable")) return;
+	if (!g_ConfigConvar.LookupBool("vsh_dome_enable"))
+		return;
 	
-	g_flDomeEnableTime = GetGameTime() + 60.0;	//60 seconds initial time
-	RequestFrame(Dome_Frame_Start);	//Start the checks when we reached the time
+	float flTime = g_ConfigConvar.LookupFloat("vsh_dome_cp_unlock") + (g_ConfigConvar.LookupFloat("vsh_dome_cp_unlockplayer") * g_iTotalAttackCount);
+	GameRules_SetPropFloat("m_flCapturePointEnableTime", GetGameTime() + flTime);
 }
 
-void Dome_PlayerDeath(int iPlayerCount)
+void Dome_PointCaptured(int iCP, TFTeam nTeam)
 {
-	if (!g_ConfigConvar.LookupBool("vsh_dome_enable")) return;
+	Dome_SetTeam(nTeam);
 	
-	//Check if dome isnt enabled yet
 	if (g_flDomeStart == 0.0)
-	{
-		//Add time everytime (non-zombie) attack team dies
-		g_flDomeEnableTime += g_ConfigConvar.LookupFloat("vsh_dome_freeze_duration");
+		Dome_Start(iCP);
+}
 
-		//Calculate max time we can allow for dome to start based on current alive player count
-		float flMaxTime = float(iPlayerCount) * 8.0;
-		if (flMaxTime > 60.0)
-			flMaxTime = 60.0;
-		
-		//If dome is going to be triggered longer than max time, set as that time
-		float flGameTime = GetGameTime();
-		if (g_flDomeEnableTime > flGameTime + flMaxTime)
-			g_flDomeEnableTime = flGameTime + flMaxTime;
-	}
-	else
+bool Dome_Start(int iCP = 0)
+{
+	if (g_flDomeStart != 0.0)	//Check if we already have dome enabled, if so return false
+		return false;
+
+	if (iCP < MaxClients)
 	{
-		//If boss kills attack team while dome is on, pause dome
-		g_flDomeFreeze = GetGameTime() + g_ConfigConvar.LookupFloat("vsh_dome_freeze_duration");
+		iCP = FindEntityByClassname(-1, "team_control_point");
+		if (!IsValidEntity(iCP))
+			return false;
+	}
+	
+	GetEntPropVector(iCP, Prop_Send, "m_vecOrigin", g_vecDomeCP);
+	
+	//Create dome prop
+	int iDome = CreateEntityByName("prop_dynamic");
+	if (!IsValidEntity(iDome))
+		return false;
+	
+	g_flDomeRadius = g_ConfigConvar.LookupFloat("vsh_dome_radius_start");
+	
+	DispatchKeyValueVector(iDome, "origin", g_vecDomeCP);						//Set origin to CP
+	DispatchKeyValue(iDome, "model", "models/kirillian/brsphere_huge.mdl");	//Set model
+	DispatchKeyValue(iDome, "disableshadows", "1");							//Disable shadow
+	SetEntPropFloat(iDome, Prop_Send, "m_flModelScale", SquareRoot(g_flDomeRadius / DOME_PROP_RADIUS));	//Calculate model scale
+	
+	DispatchSpawn(iDome);
+	
+	SetEntityRenderMode(iDome, RENDER_TRANSCOLOR);
+	SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], 0);
+	
+	g_flDomeStart = GetGameTime();
+	EmitSoundToAll(DOME_START_SOUND);
+	PrintHintTextToAll("The dome is active. Prepare to move!");
+	
+	g_iDomeEntRef = EntIndexToEntRef(iDome);
+	RequestFrame(Dome_Frame_Prepare);
+	return true;
+}
+
+void Dome_SetTeam(TFTeam nTeam)
+{
+	g_nDomeTeamOwner = nTeam;
+	
+	switch (nTeam)
+	{
+		case TFTeam_Unassigned, TFTeam_Spectator: g_ConfigConvar.LookupColor("vsh_dome_color_neu", g_iDomeColor);
+		case TFTeam_Red: g_ConfigConvar.LookupColor("vsh_dome_color_red", g_iDomeColor);
+		case TFTeam_Blue: g_ConfigConvar.LookupColor("vsh_dome_color_blu", g_iDomeColor);
+	}
+	
+	int iDome = EntRefToEntIndex(g_iDomeEntRef);
+	if (iDome > MaxClients)
+	{
+		SetEntityRenderMode(iDome, RENDER_TRANSCOLOR);
+		SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], g_iDomeColor[3]);
 	}
 }
 
-public void Dome_Frame_Start()
+public void Dome_Frame_Prepare()
 {
-	if (!g_ConfigConvar.LookupBool("vsh_dome_enable") || g_flDomeEnableTime == 0.0 || g_flDomeStart != 0.0) return;
+	if (g_flDomeStart == 0.0)
+		return;
 
-	//Check if time reached to start the dome
-	if (g_flDomeEnableTime < GetGameTime())
-		Dome_Start();	//Start the dome
-	else
-		RequestFrame(Dome_Frame_Start);
-}
-
-bool Dome_Start()
-{
-	if (g_flDomeStart != 0.0) return false;	//Check if we already have dome enabled, if so return false
-
-	//Find current active CP
-	int iCP = MaxClients + 1;
-	while((iCP = FindEntityByClassname(iCP, "team_control_point")) > MaxClients)
-	{
-		char strName[64];
-		GetEntPropString(iCP, Prop_Data, "m_iName", strName, sizeof(strName));
-		if (strcmp(g_strCP, strName) == 0 || StrEmpty(g_strCP))
-			break;
-	}
-
-	if (IsValidEntity(iCP))
-	{
-		GetEntPropVector(iCP, Prop_Send, "m_vecOrigin", g_vecCP);
-
-		//Create dome prop
-		int iDome = CreateEntityByName("prop_dynamic");
-		if (IsValidEntity(iDome))
-		{
-			g_flDomeRadius = g_ConfigConvar.LookupFloat("vsh_dome_radius_max");
-			
-			DispatchKeyValueVector(iDome, "origin", g_vecCP);						//Set origin to CP
-			DispatchKeyValue(iDome, "model", "models/kirillian/brsphere_huge.mdl");	//Set model
-			DispatchKeyValue(iDome, "disableshadows", "1");							//Disable shadow
-			SetEntPropFloat(iDome, Prop_Send, "m_flModelScale", SquareRoot(g_flDomeRadius / DOME_PROP_RADIUS));	//Calculate model scale
-			
-			//Set color
-			char sBuffer[256];
-			g_ConfigConvar.LookupString("vsh_dome_color", sBuffer);
-			if (!StrEmpty(sBuffer))
-			{
-				char sColor[3][32];
-				int iCount = ExplodeString(sBuffer, " ", sColor, 3, 32);
-				if (iCount == 3)
-					for (int i = 0; i < 3; i++)
-						g_vecColor[i] = StringToInt(sColor[i]);
-				
-				SetEntityRenderMode(iDome, RENDER_TRANSCOLOR);
-				SetEntityRenderColor(iDome, g_vecColor[0], g_vecColor[1], g_vecColor[2], 0);
-			}
-			
-			DispatchSpawn(iDome);
-			
-			g_flDomeStart = GetGameTime();
-			EmitSoundToAll(DOME_START_SOUND);
-			PrintHintTextToAll("The dome is active. Prepare to move!");
-			
-			//Call any map events from CP unlock
-			FireEntityOutput(iCP, "OnUnlocked");
-			int iLogicArena = FindEntityByClassname(-1, "tf_logic_arena");
-			if (IsValidEntity(iLogicArena))
-				FireEntityOutput(iLogicArena, "OnCapEnabled");
-			
-			RequestFrame(Dome_Frame_Prepare, EntIndexToEntRef(iDome));
-
-			return true;
-		}
-	}
-
-	return false;
-}
-
-void Dome_Frame_Prepare(int iRef)
-{
-	if (g_flDomeStart == 0.0) return;
-
-	int iDome = EntRefToEntIndex(iRef);
-	if (!IsValidEntity(iDome)) return;
+	int iDome = EntRefToEntIndex(g_iDomeEntRef);
+	if (!IsValidEntity(iDome))
+		return;
 
 	float flTime = GetGameTime() - g_flDomeStart;
 
@@ -262,26 +220,30 @@ void Dome_Frame_Prepare(int iRef)
 	{
 		//Calculate transparent to dome during prepare, i should also redo this
 		float flRender = flTime;
-
+		
 		while (flRender > 1.0)
 			flRender -= 1.0;
-
+		
 		if (flRender > 0.5)
 			flRender = (1 - flRender);
-
-		flRender *= 255.0 * 2;
-		SetEntityRenderColor(iDome, g_vecColor[0], g_vecColor[1], g_vecColor[2], RoundToFloor(flRender));
+		
+		flRender *= 2 * float(g_iDomeColor[3]);
+		SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], RoundToFloor(flRender));
 		
 		//Create fade to players near/outside of dome
-		for (int i = 1; i <= MaxClients; i++)
+		for (int iClient = 1; iClient <= MaxClients; iClient++)
 		{
-			if (IsClientInGame(i) && IsPlayerAlive(i) && GetClientTeam(i) > 1)
+			if (IsClientInGame(iClient) && IsPlayerAlive(iClient))
 			{
+				TFTeam nTeam = TF2_GetClientTeam(iClient);
+				if (nTeam <= TFTeam_Spectator || nTeam == g_nDomeTeamOwner)
+					continue;
+				
 				// 0.0 = centre of CP
 				//<1.0 = inside dome
 				// 1.0 = at border of dome
 				//>1.0 = outside of dome 
-				float flDistanceMultiplier = Dome_GetDistance(i) / g_flDomeRadius;
+				float flDistanceMultiplier = Dome_GetDistance(iClient) / g_flDomeRadius;
 				
 				if (flDistanceMultiplier > DOME_FADE_START_MULTIPLIER)
 				{
@@ -291,70 +253,70 @@ void Dome_Frame_Prepare(int iRef)
 					else
 						flAlpha = (flDistanceMultiplier - DOME_FADE_START_MULTIPLIER) * (1.0/(1.0-DOME_FADE_START_MULTIPLIER)) * DOME_FADE_ALPHA_MAX * (flRender/255.0);
 					
-					CreateFade(i, _, g_vecColor[0], g_vecColor[1], g_vecColor[2], RoundToNearest(flAlpha));
+					CreateFade(iClient, _, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], RoundToNearest(flAlpha));
 				}
 			}
 		}
 		
-		RequestFrame(Dome_Frame_Prepare, iRef);
+		RequestFrame(Dome_Frame_Prepare);
 	}
 	else
 	{
 		//Start the shrink
-		SetEntityRenderColor(iDome, g_vecColor[0], g_vecColor[1], g_vecColor[2], 255);
+		SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], g_iDomeColor[3]);
 		g_hDomeTimerBleed = CreateTimer(0.5, Dome_TimerBleed, _, TIMER_REPEAT);
-
+		
 		g_flDomePreviousGameTime = GetGameTime();
-		RequestFrame(Dome_Frame_Shrink, iRef);
+		RequestFrame(Dome_Frame_Shrink);
 	}
 }
 
-void Dome_Frame_Shrink(int iRef)
+public void Dome_Frame_Shrink()
 {
-	if (g_flDomeStart == 0.0) return;
+	if (g_flDomeStart == 0.0)
+		return;
 
-	int iDome = EntRefToEntIndex(iRef);
-	if (!IsValidEntity(iDome)) return;
+	int iDome = EntRefToEntIndex(g_iDomeEntRef);
+	if (!IsValidEntity(iDome))
+		return;
 	
 	Dome_UpdateRadius();
 	SetEntPropFloat(iDome, Prop_Send, "m_flModelScale", SquareRoot(g_flDomeRadius / DOME_PROP_RADIUS));
 
 	//Give client bleed if outside of dome
-	for (int i = 1; i <= MaxClients; i++)
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		if (IsClientInGame(i) && IsPlayerAlive(i) && GetClientTeam(i) > 1)
+		if (IsClientInGame(iClient) && IsPlayerAlive(iClient))
 		{
 			// 0.0 = centre of CP
 			//<1.0 = inside dome
 			// 1.0 = at border of dome
-			//>1.0 = outside of dome 
-			float flDistanceMultiplier = Dome_GetDistance(i) / g_flDomeRadius;
+			//>1.0 = outside of dome
+			TFTeam nTeam = TF2_GetClientTeam(iClient);
+			float flDistanceMultiplier = Dome_GetDistance(iClient) / g_flDomeRadius;
 			
-			if (flDistanceMultiplier > 1.0)
+			if (flDistanceMultiplier > 1.0 && nTeam > TFTeam_Spectator && nTeam != g_nDomeTeamOwner)
 			{
 				//If client is outside of dome, state that player is outside of dome
-				if (!g_bDomePlayerOutside[i])
-					g_bDomePlayerOutside[i] = true;
+				if (!g_bDomePlayerOutside[iClient])
+					g_bDomePlayerOutside[iClient] = true;
 				
 				//Add time on how long player have been outside of dome
-				g_flDomePlayerTime[i] += GetGameTime() - g_flDomePreviousGameTime;
-
+				g_flDomePlayerTime[iClient] += GetGameTime() - g_flDomePreviousGameTime;
+				
 				//give bleed if havent been given one
-				if (!TF2_IsPlayerInCondition(i, TFCond_Bleeding))
-					TF2_MakeBleed(i, i, 9999.0);	//Does no damage, ty sourcemod
+				if (!TF2_IsPlayerInCondition(iClient, TFCond_Bleeding))
+					TF2_MakeBleed(iClient, iClient, 9999.0);	//Does no damage, ty sourcemod
 			}
-			else
+			else if (g_bDomePlayerOutside[iClient])
 			{
 				//If client is not outside of dome, remove bleed
-				if (g_bDomePlayerOutside[i])
-				{
-					TF2_RemoveCondition(i, TFCond_Bleeding);
-					g_bDomePlayerOutside[i] = false;
-				}
+				TF2_RemoveCondition(iClient, TFCond_Bleeding);
+				g_bDomePlayerOutside[iClient] = false;
 			}
 			
 			//Create fade
-			if (flDistanceMultiplier > DOME_FADE_START_MULTIPLIER)
+			if (flDistanceMultiplier > DOME_FADE_START_MULTIPLIER && nTeam > TFTeam_Spectator && nTeam != g_nDomeTeamOwner)
 			{
 				float flAlpha;
 				if (flDistanceMultiplier > 1.0)
@@ -362,14 +324,14 @@ void Dome_Frame_Shrink(int iRef)
 				else
 					flAlpha = (flDistanceMultiplier - DOME_FADE_START_MULTIPLIER) * (1.0/(1.0-DOME_FADE_START_MULTIPLIER)) * DOME_FADE_ALPHA_MAX;
 				
-				CreateFade(i, _, g_vecColor[0], g_vecColor[1], g_vecColor[2], RoundToNearest(flAlpha));
+				CreateFade(iClient, _, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], RoundToNearest(flAlpha));
 			}
 		}
 	}
 
 	g_flDomePreviousGameTime = GetGameTime();
 
-	RequestFrame(Dome_Frame_Shrink, iRef);
+	RequestFrame(Dome_Frame_Shrink);
 }
 
 public Action Dome_TimerBleed(Handle hTimer)
@@ -377,96 +339,93 @@ public Action Dome_TimerBleed(Handle hTimer)
 	if (g_hDomeTimerBleed != hTimer)
 		return Plugin_Stop;
 
-	for (int i = 1; i <= MaxClients; i++)
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		if (IsClientInGame(i) && IsPlayerAlive(i) && GetClientTeam(i) > 1)
+		if (IsClientInGame(iClient) && IsPlayerAlive(iClient))
 		{
-			StopSound(i, SNDCHAN_AUTO, DOME_NEARBY_SOUND);
+			TFTeam nTeam = TF2_GetClientTeam(iClient);
+			if (nTeam <= TFTeam_Spectator || nTeam == g_nDomeTeamOwner)
+				continue;
+			
+			StopSound(iClient, SNDCHAN_AUTO, DOME_NEARBY_SOUND);
 			
 			//Check if player is outside of dome
-			if (g_bDomePlayerOutside[i])
+			if (g_bDomePlayerOutside[iClient])
 			{
 				float flDamage;
-				if (SaxtonHale_IsValidBoss(i, false))
+				if (SaxtonHale_IsValidBoss(iClient, false))
 				{
 					//Calculate max possible damage to deal boss based from player count
 					flDamage = float(g_iTotalAttackCount) * 25.0;
 					
 					//Scale damage down by current progress dome is at
-					float flRadiusMax = g_ConfigConvar.LookupFloat("vsh_dome_radius_max");
-					float flRadiusMin = g_ConfigConvar.LookupFloat("vsh_dome_radius_min");
+					float flRadiusMax = g_ConfigConvar.LookupFloat("vsh_dome_radius_start");
+					float flRadiusMin = g_ConfigConvar.LookupFloat("vsh_dome_radius_end");
 					float flRadiusPrecentage = (g_flDomeRadius - flRadiusMin) / (flRadiusMax - flRadiusMin);
 					flDamage *= (1.0 - flRadiusPrecentage);
 				}
 				else
 				{
 					//Calculate damage, the longer the player is outside of the dome, the more damage it deals
-					flDamage = Pow(2.0, g_flDomePlayerTime[i]);
+					flDamage = Pow(2.0, g_flDomePlayerTime[iClient]);
 				}
 				
 				if (flDamage < 1.0)
 					flDamage = 1.0;
-
+				
 				//Deal damage
-				SDKHooks_TakeDamage(i, 0, i, flDamage, DMG_PREVENT_PHYSICS_FORCE);
-				EmitSoundToClient(i, DOME_NEARBY_SOUND);
+				SDKHooks_TakeDamage(iClient, 0, iClient, flDamage, DMG_PREVENT_PHYSICS_FORCE);
+				EmitSoundToClient(iClient, DOME_NEARBY_SOUND);
 			}
 		}
 	}
 
 	//Deal damage to engineer buildings
-	int iEntity;
-
-	iEntity = MaxClients+1;
-	while((iEntity = FindEntityByClassname(iEntity, "obj_sentrygun")) > MaxClients)
-		Dome_Building_Damage(iEntity);
-
-	iEntity = MaxClients+1;
-	while((iEntity = FindEntityByClassname(iEntity, "obj_dispenser")) > MaxClients)
-		Dome_Building_Damage(iEntity);
-
-	iEntity = MaxClients+1;
-	while((iEntity = FindEntityByClassname(iEntity, "obj_teleporter")) > MaxClients)
-		Dome_Building_Damage(iEntity);
-
+	
+	int iEntity = MaxClients+1;
+	while ((iEntity = FindEntityByClassname(iEntity, "obj_*")) > MaxClients)
+	{
+		if (Dome_GetDistance(iEntity) <= g_flDomeRadius)
+			continue;
+		
+		if (GetEntProp(iEntity, Prop_Send, "m_bCarried"))
+			continue;
+		
+		if (view_as<TFTeam>(GetEntProp(iEntity, Prop_Send, "m_iTeamNum")) == g_nDomeTeamOwner)
+			continue;
+		
+		SetVariantInt(15);
+		AcceptEntityInput(iEntity, "RemoveHealth");
+	}
+	
 	return Plugin_Continue;
-}
-
-void Dome_Building_Damage(int iEntity)
-{
-	if (Dome_GetDistance(iEntity) <= g_flDomeRadius) return;
-	
-	if (GetEntProp(iEntity, Prop_Send, "m_bCarried")) return;
-	
-	SetVariantInt(15);
-	AcceptEntityInput(iEntity, "RemoveHealth");
 }
 
 void Dome_UpdateRadius()
 {
+	//Get current game time
 	float flGameTime = GetGameTime();
 	float flGameTimeDifference = flGameTime - g_flDomePreviousGameTime;
 	
-	//Check if we are in freeze process
-	if (g_flDomeFreeze < flGameTime)
-	{
-		//Calculate how fast dome should be in hu per second
-		float flRadiusMax = g_ConfigConvar.LookupFloat("vsh_dome_radius_max");
-		float flRadiusMin = g_ConfigConvar.LookupFloat("vsh_dome_radius_min");
-		float flRadiusPrecentage = (g_flDomeRadius - flRadiusMin) / (flRadiusMax - flRadiusMin);
-		
-		float flSpeedMax = g_ConfigConvar.LookupFloat("vsh_dome_speed_max");
-		float flSpeedMin = g_ConfigConvar.LookupFloat("vsh_dome_speed_min");
-		float flSpeed = ((flSpeedMax - flSpeedMin) * flRadiusPrecentage) + flSpeedMin;
-		
-		//Check if we already reached min value
-		float flRadius = g_flDomeRadius - (flSpeed * flGameTimeDifference);
-		if (flRadius < flRadiusMin)
-			flRadius = flRadiusMin;
-		
-		//Update global variable
-		g_flDomeRadius = flRadius;
-	}
+	//Get distance to travel
+	float flRadiusStart = g_ConfigConvar.LookupFloat("vsh_dome_radius_start");
+	float flRadiusEnd = g_ConfigConvar.LookupFloat("vsh_dome_radius_end");
+	float flRadiusDistance = flRadiusStart - flRadiusEnd;
+	
+	//Calculate speed dome should be
+	float flSpeed = flRadiusDistance / g_ConfigConvar.LookupFloat("vsh_dome_speed_duration");
+	
+	//Calculate new radius from speed and time
+	float flRadius = g_flDomeRadius - (flSpeed * flGameTimeDifference);
+	
+	//Check if we already reached min value
+	if (flRadius < flRadiusEnd)
+		flRadius = flRadiusEnd;
+	
+	//Update global variable
+	g_flDomeRadius = flRadius;
+	
+	//PrintToConsoleAll("flSpeedAverage (%.2f) flSpeedMultiplier (%.2f) flSpeed (%.2f)", flSpeedAverage, flSpeedMultiplier, flSpeed);
 }
 
 float Dome_GetDistance(int iEntity)
@@ -484,6 +443,6 @@ float Dome_GetDistance(int iEntity)
 	
 	else return -1.0;
 	
-	flDistance = GetVectorDistance(vecPos, g_vecCP);
+	flDistance = GetVectorDistance(vecPos, g_vecDomeCP);
 	return flDistance;
 }

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -61,7 +61,20 @@ void Dome_MapStart()
 	PrepareSound(DOME_START_SOUND);
 	PrecacheSound(DOME_NEARBY_SOUND);
 	
+	SDK_HookGetCaptureValueForPlayer(Dome_GetCaptureValueForPlayer);
 	SDK_HookSetWinningTeam(Dome_SetWinningTeam);
+}
+
+public MRESReturn Dome_GetCaptureValueForPlayer(Handle hReturn, Handle hParams)
+{
+	int iClient = DHookGetParam(hParams, 1);
+	if (SaxtonHale_IsValidBoss(iClient, false))
+	{
+		DHookSetReturn(hReturn, g_ConfigConvar.LookupInt("vsh_dome_cp_bossrate"));
+		return MRES_Supercede;
+	}
+
+	return MRES_Ignored;
 }
 
 public MRESReturn Dome_SetWinningTeam(Handle hParams)

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -12,6 +12,7 @@
 static bool g_bDomeCustomPos;	//Whenever if capture point is in custom pos
 static float g_vecDomeCP[3];	//Pos of CP
 static int g_iDomeTriggerRef;	//Trigger to control touch
+static float g_flDomeCPTimeRemaining;	//Time left to capture this CP
 static bool g_bDomeCapturing[TF_MAXPLAYERS+1];
 
 //Dome prop
@@ -96,8 +97,22 @@ public MRESReturn Dome_SetWinningTeam(Handle hParams)
 public void Dome_TriggerSpawn(int iTrigger)
 {
 	//Set time to cap to whatever in convar
-	DispatchKeyValueFloat(iTrigger, "area_time_to_cap", g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate"));
+	DispatchKeyValueFloat(iTrigger, "area_time_to_cap", g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate") / 2.0);
 	g_iDomeTriggerRef = EntIndexToEntRef(iTrigger);
+}
+
+public Action Dome_SetCapTimeRemaining(int iTrigger, float &flTime)
+{
+	//CTriggerAreaCapture::SetCapTimeRemaining sometimes start capture time incorrectly, set it properly
+	if (g_flDomeCPTimeRemaining == 0.0 && flTime > 0.0)
+	{
+		flTime = g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate");
+		g_flDomeCPTimeRemaining = flTime;
+		return Plugin_Changed;
+	}
+	
+	g_flDomeCPTimeRemaining = flTime;
+	return Plugin_Continue;
 }
 
 public Action Dome_TriggerTouch(int iTrigger, int iToucher)

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -190,6 +190,7 @@ bool Dome_Start(int iCP = 0)
 	SetEntityRenderMode(iDome, RENDER_TRANSCOLOR);
 	SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], 0);
 	
+	GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
 	g_flDomeStart = GetGameTime();
 	EmitSoundToAll(DOME_START_SOUND);
 	PrintHintTextToAll("The dome is active. Prepare to move!");
@@ -205,9 +206,9 @@ void Dome_SetTeam(TFTeam nTeam)
 	
 	switch (nTeam)
 	{
-		case TFTeam_Unassigned, TFTeam_Spectator: g_ConfigConvar.LookupColor("vsh_dome_color_neu", g_iDomeColor);
 		case TFTeam_Red: g_ConfigConvar.LookupColor("vsh_dome_color_red", g_iDomeColor);
 		case TFTeam_Blue: g_ConfigConvar.LookupColor("vsh_dome_color_blu", g_iDomeColor);
+		default: g_ConfigConvar.LookupColor("vsh_dome_color_neu", g_iDomeColor);
 	}
 	
 	int iDome = EntRefToEntIndex(g_iDomeEntRef);
@@ -215,6 +216,13 @@ void Dome_SetTeam(TFTeam nTeam)
 	{
 		SetEntityRenderMode(iDome, RENDER_TRANSCOLOR);
 		SetEntityRenderColor(iDome, g_iDomeColor[0], g_iDomeColor[1], g_iDomeColor[2], g_iDomeColor[3]);
+	}
+	
+	int iCP = MaxClients+1;
+	while ((iCP = FindEntityByClassname(iCP, "team_control_point")) > MaxClients)
+	{
+		SetVariantInt(view_as<int>(nTeam));
+		AcceptEntityInput(iCP, "SetOwner", 0, 0);
 	}
 }
 

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -468,9 +468,10 @@ public Action Event_RoundEnd(Event event, const char[] sName, bool bDontBroadcas
 public void Event_PointCaptured(Event event, const char[] sName, bool bDontBroadcast)
 {
 	int iCP = event.GetInt("cp");
-	TFTeam iTeam = view_as<TFTeam>(event.GetInt("team"));
+	TFTeam nTeam = view_as<TFTeam>(event.GetInt("team"));
 	
-	Dome_PointCaptured(iCP, iTeam);
+	Dome_SetTeam(nTeam);
+	Dome_Start(iCP);
 }
 
 public void Event_BroadcastAudio(Event event, const char[] sName, bool bDontBroadcast)

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -114,7 +114,6 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 	//Play one round of arena
 	if (g_iTotalRoundPlayed <= 0)
 	{
-		GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
 		Dome_SetTeam(TFTeam_Unassigned);
 		Dome_Start();
 		return;

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -114,6 +114,8 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 	//Play one round of arena
 	if (g_iTotalRoundPlayed <= 0)
 	{
+		GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
+		Dome_SetTeam(TFTeam_Unassigned);
 		Dome_Start();
 		return;
 	}

--- a/addons/sourcemod/scripting/vsh/menu/menu_admin.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_admin.sp
@@ -12,6 +12,7 @@ void MenuAdmin_Init()
 	g_hMenuAdminMain.AddItem("config", "Refresh VSH Config (!vshrefresh)");
 	g_hMenuAdminMain.AddItem("queue", "Add Queue (!vshqueue)");
 	g_hMenuAdminMain.AddItem("special", "Force Special Round (!vshspecial)");
+	g_hMenuAdminMain.AddItem("cap", "Force Unlock Capture Point (!vshcap)");
 	g_hMenuAdminMain.AddItem("dome", "Force Start Dome (!vshdome)");
 	g_hMenuAdminMain.AddItem("boss", "Set Next Boss & Modifiers (!vshsetboss)");
 	g_hMenuAdminMain.AddItem("rage", "Set Rage (!vshrage)");
@@ -76,6 +77,8 @@ public int MenuAdmin_SelectMain(Menu hMenu, MenuAction action, int iClient, int 
 		MenuAdmin_DisplayQueue(iClient);
 	else if (StrEqual(sSelect, "special"))
 		MenuAdmin_DisplaySpecial(iClient);
+	else if (StrEqual(sSelect, "cap"))
+		ClientCommand(iClient, "vsh_cap");
 	else if (StrEqual(sSelect, "dome"))
 		ClientCommand(iClient, "vsh_dome");
 	else if (StrEqual(sSelect, "boss"))

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -1,3 +1,4 @@
+static Handle g_hHookGetCaptureValueForPlayer;
 static Handle g_hHookSetWinningTeam;
 static Handle g_hHookGetMaxHealth;
 static Handle g_hHookShouldTransmit;
@@ -59,6 +60,14 @@ void SDK_Init()
 
 	hGameData = new GameData("vsh");
 	if (hGameData == null) SetFailState("Could not find vsh gamedata!");
+	
+	// This hook allows to change capture rate
+	iOffset = hGameData.GetOffset("CTFGameRules::GetCaptureValueForPlayer");
+	g_hHookGetCaptureValueForPlayer = DHookCreate(iOffset, HookType_GameRules, ReturnType_Int, ThisPointer_Ignore);
+	if (g_hHookGetCaptureValueForPlayer == null)
+		LogMessage("Failed to create hook: CTFGameRules::GetCaptureValueForPlayer");
+	else
+		DHookAddParam(g_hHookGetCaptureValueForPlayer, HookParamType_CBaseEntity);
 	
 	// This hook allows to prevent round win called
 	iOffset = hGameData.GetOffset("CTFGameRules::SetWinningTeam");
@@ -154,6 +163,12 @@ void SDK_Init()
 	
 	delete hHook;
 	delete hGameData;
+}
+
+void SDK_HookGetCaptureValueForPlayer(DHookCallback callback)
+{
+	if (g_hHookGetCaptureValueForPlayer)
+		DHookGamerules(g_hHookGetCaptureValueForPlayer, true, _, callback);
 }
 
 void SDK_HookSetWinningTeam(DHookCallback callback)

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -180,8 +180,17 @@ void SDK_Init()
 	else
 		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
 	
+	// This hook allows to change capture time remaining
+	Handle hHook = DHookCreateFromConf(hGameData, "CTriggerAreaCapture::SetCapTimeRemaining");
+	if (hHook == null)
+		LogMessage("Failed to create hook: CTriggerAreaCapture::SetCapTimeRemaining!");
+	else
+		DHookEnableDetour(hHook, false, Hook_SetCapTimeRemaining);
+	
+	delete hHook;
+	
 	// This hook allows to allow/block medigun heals
-	Handle hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
+	hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
 	if (hHook == null)
 		LogMessage("Failed to create hook: CWeaponMedigun::AllowedToHealTarget!");
 	else
@@ -306,6 +315,20 @@ public void Hook_GiveNamedItemRemoved(int iHookId)
 			return;
 		}
 	}
+}
+
+public MRESReturn Hook_SetCapTimeRemaining(int iTrigger, Handle hParams)
+{
+	float flTime = DHookGetParam(hParams, 1);
+	
+	Action action = Dome_SetCapTimeRemaining(iTrigger, flTime);
+	if (action >= Plugin_Changed)
+	{
+		DHookSetParam(hParams, 1, flTime);
+		return MRES_ChangedHandled;
+	}
+	
+	return MRES_Ignored;
 }
 
 public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle hParams)

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -403,6 +403,26 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 	return iWeapon;
 }
 
+stock int TF2_GetObjectiveResource()
+{
+	static int iRefObj = 0;
+	
+	if (iRefObj != 0)
+	{
+		int iObj = EntRefToEntIndex(iRefObj);
+		if (iObj > MaxClients)
+			return iObj;
+		
+		iRefObj = 0;
+	}
+	
+	int iObj = FindEntityByClassname(MaxClients+1, "tf_objective_resource");
+	if (iObj > MaxClients)
+		iRefObj = EntIndexToEntRef(iObj);
+	
+	return iObj;
+}
+
 stock void CheckForceAttackWin(int iVictim=0)
 {
 	//Check if all main bosses died while minions still alive, if so force make round end
@@ -593,6 +613,29 @@ stock int TF2_CreateLightEntity(float flRadius, int iColor[4], int iBrightness)
 	}
 	
 	return iGlow;
+}
+
+stock bool EmitGameSoundToTeam(TFTeam nTeam,
+				const char[] gameSound,
+				int entity = SOUND_FROM_PLAYER,
+				int flags = SND_NOFLAGS,
+				int speakerentity = -1,
+				const float origin[3] = NULL_VECTOR,
+				const float dir[3] = NULL_VECTOR,
+				bool updatePos = true,
+				float soundtime = 0.0)
+{
+	int[] iClients = new int[MaxClients];
+	int iTotal = 0;
+
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+		if (IsClientInGame(iClient) && TF2_GetClientTeam(iClient) == nTeam)
+			iClients[iTotal++] = iClient;
+	
+	if (!iTotal)
+		return false;
+	
+	return EmitGameSound(iClients, iTotal, gameSound, entity, flags, speakerentity, origin, dir, updatePos, soundtime);
 }
 
 stock void BroadcastSoundToTeam(TFTeam nTeam, const char[] strSound)

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -195,7 +195,7 @@ void Tags_OnThink(int iClient)
 	}
 }
 
-void Tags_OnPlayerHurt(int iVictim, int iAttacker, int iDamage)
+void Tags_PlayerHurt(int iVictim, int iAttacker, int iDamage)
 {
 	if (SaxtonHale_IsValidBoss(iVictim) && SaxtonHale_IsValidAttack(iAttacker))
 	{


### PR DESCRIPTION
closes #99 

Decided to start this somewhat simple from what was originally planned:
- On round start, dome unlocks itself in `60 + (5 * N)` seconds where n is amount of attack players
- Takes 15 seconds to capture point for 1 player
- Boss have a 2x capture rate (unlike usual 3x rate)
- Dome takes 2 mins to fully shrink from start. Fixed speed, but depends on start radius on many maps.
- Dome will never slow down

Many of those numbers can be can be changed in config.

TODO
- Increase dome damages?
- Make capturing CP works with `vsh_dome_centre` convar, CP pos moved.

Other than that, rest is pretty much from what said in #99 