### PR TITLE
Fix all sniper melees having the same climb height amount

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1813,7 +1813,7 @@
 					"name"			"171-climb"
 					"override"		"sniper-melee-climb"	//Override function with new values
 					
-					"climb"			"600"	//From 750 to 600
+					"height"			"600"	//From 750 to 600
 					"max"			"2"		//From 1 to 2
 				}
 				
@@ -1839,7 +1839,7 @@
 					"name"			"232-climb"
 					"override"		"sniper-melee-climb"	//Override function with new values
 					
-					"climb"			"950"	//From 750 to 950
+					"height"			"950"	//From 750 to 950
 					"selfdamage"	"50"	//From 15 to 50
 				}
 			}


### PR DESCRIPTION
A lil wrong word in the config did this, this made the Shiv far better and the Bushwacka far worse than everything else. Persian Persuader didn't have this issue.