### PR TITLE
Use GiveNamedItem to remove weapons

### DIFF
--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -67,6 +67,11 @@
 				"linux"		"19"
 				"windows"	"18"
 			}
+			"CTFPlayer::GiveNamedItem"
+			{
+				"windows"	"475"
+				"linux"		"482"
+			}
 			"CTFWeaponBase::SendWeaponAnim"
 			{
 				"linux"		"248"

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -537,6 +537,7 @@ public void OnPluginStart()
 	SaxtonHaleFunction("OnThink", ET_Ignore);
 	SaxtonHaleFunction("OnSpawn", ET_Ignore);
 	SaxtonHaleFunction("OnRage", ET_Ignore);
+	SaxtonHaleFunction("OnGiveNamedItem", ET_Single, Param_String, Param_Cell);
 	SaxtonHaleFunction("OnEntityCreated", ET_Ignore, Param_Cell, Param_String);
 	SaxtonHaleFunction("OnCommandKeyValues", ET_Hook, Param_String);
 	SaxtonHaleFunction("OnAttackCritical", ET_Hook, Param_Cell, Param_CellByRef);
@@ -1116,6 +1117,7 @@ public void OnClientConnected(int iClient)
 public void OnClientPutInServer(int iClient)
 {
 	SDK_HookGetMaxHealth(iClient);
+	SDK_HookGiveNamedItem(iClient);
 	SDKHook(iClient, SDKHook_PreThink, Client_OnThink);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	
@@ -1181,7 +1183,7 @@ public void Client_OnThink(int iClient)
 		if (IsValidEntity(iActiveWep))
 		{
 			iIndex = GetEntProp(iActiveWep, Prop_Send, "m_iItemDefinitionIndex");
-			iSlot = TF2_GetSlotInItem(iIndex, nClass);
+			iSlot = TF2_GetItemSlot(iIndex, nClass);
 		}
 
 		if (0 <= iSlot < sizeof(g_ConfigClass[]) && IsValidEntity(iActiveWep) && !TF2_IsPlayerInCondition(iClient, TFCond_Disguised) && !TF2_IsPlayerInCondition(iClient, TFCond_Cloaked))
@@ -1421,7 +1423,7 @@ public Action TF2_CalcIsAttackCritical(int iClient, int iWeapon, char[] sWepClas
 	else
 	{
 		int iIndex = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
-		int iSlot = TF2_GetSlotInItem(iIndex, TF2_GetPlayerClass(iClient));
+		int iSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(iClient));
 		
 		TagsParams tParams = new TagsParams();
 		TagsCore_CallSlot(iClient, TagsCall_Attack, iSlot, tParams);

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -691,6 +691,8 @@ public void OnPluginEnd()
 {
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
+		SDK_UnhookClient(iClient);
+		
 		if (SaxtonHale_IsValidBoss(iClient))
 		{
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
@@ -1155,6 +1157,8 @@ public void OnClientDisconnect(int iClient)
 	Preferences_SetAll(iClient, -1);
 	Queue_SetPlayerPoints(iClient, -1);
 	Winstreak_SetCurrent(iClient, -1);
+	
+	SDK_UnhookClient(iClient);
 }
 
 public void OnClientDisconnect_Post(int iClient)

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -55,6 +55,30 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 			Call_Finish();
 		}
 		
+		if (TF2_GetPlayerClass(this.iClient) == this.nClass)
+		{
+			//Player is about to play as same class unchanged, strip weapon and cosmetics for GiveNamedItem to regenerate
+			
+			int iEntity = MaxClients+1;
+			while ((iEntity = FindEntityByClassname(iEntity, "tf_weapon_*")) > MaxClients)
+				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
+					AcceptEntityInput(iEntity, "Kill");
+			
+			iEntity = MaxClients+1;
+			while ((iEntity = FindEntityByClassname(iEntity, "tf_wearable*")) > MaxClients)
+				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
+					AcceptEntityInput(iEntity, "Kill");
+			
+			iEntity = MaxClients+1;
+			while ((iEntity = FindEntityByClassname(iEntity, "tf_powerup_bottle")) > MaxClients)
+				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
+					AcceptEntityInput(iEntity, "Kill");
+		}
+		else if (this.nClass != TFClass_Unknown)
+		{
+			TF2_SetPlayerClass(this.iClient, this.nClass);
+		}
+		
 		return view_as<SaxtonHaleBase>(this);
 	}
 	
@@ -182,29 +206,11 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		{
 			ApplyBossModel(this.iClient);
 			
-			//Remove his zombie skin cosmetic
+			//Remove zombie skin cosmetic
 			SetEntProp(this.iClient, Prop_Send, "m_bForcedSkin", 0);
 			SetEntProp(this.iClient, Prop_Send, "m_nForcedSkin", 0);
 			SetEntProp(this.iClient, Prop_Send, "m_iPlayerSkinOverride", 0);
-			
-			int iEntity = MaxClients+1;
-			while ((iEntity = FindEntityByClassname(iEntity, "tf_wearable*")) > MaxClients)
-				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
-					AcceptEntityInput(iEntity, "Kill");
-			
-			iEntity = MaxClients+1;
-			while ((iEntity = FindEntityByClassname(iEntity, "tf_powerup_bottle")) > MaxClients)
-				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
-					AcceptEntityInput(iEntity, "Kill");
-			
-			iEntity = MaxClients+1;
-			while ((iEntity = FindEntityByClassname(iEntity, "tf_weapon_spellbook")) > MaxClients)
-				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
-					AcceptEntityInput(iEntity, "Kill");
 		}
-		
-		for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_InvisWatch; iSlot++)	//Don't remove toolbox weapon
-			TF2_RemoveItemInSlot(this.iClient, iSlot);
 		
 		int iHealth = this.CallFunction("CalculateMaxHealth");
 		if (iHealth > 0)
@@ -212,6 +218,20 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 			this.iMaxHealth = iHealth;
 			this.iHealth = iHealth;
 		}
+	}
+	
+	public Action OnGiveNamedItem(const char[] sClassname, int iIndex)
+	{
+		//If dont modify player model, allow keep cosmetics
+		if (!this.bModel)
+		{
+			int iSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(this.iClient));
+			if (iSlot > WeaponSlot_BuilderEngie)
+				return Plugin_Continue;
+		}
+		
+		//Otherwise block everything by default
+		return Plugin_Handled;
 	}
 	
 	public int CreateWeapon(int iIndex, char[] sClassname, int iLevel, TFQuality iQuality, char[] sAttrib)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -175,7 +175,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 			return Plugin_Continue;
 		
 		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
-		if (TF2_GetSlotInItem(iIndex, TF2_GetPlayerClass(this.iClient)) != WeaponSlot_Primary)
+		if (TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(this.iClient)) != WeaponSlot_Primary)
 			return Plugin_Continue;
 		
 		if (TF2_IsUbercharged(victim))

--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -110,6 +110,15 @@ methodmap CVagineer < SaxtonHaleBase
 		*/
 	}
 	
+	public Action OnGiveNamedItem(const char[] sClassname, int iIndex)
+	{
+		//Allow keep tf_weapon_builder
+		if (StrEqual(sClassname, "tf_weapon_builder"))
+			return Plugin_Continue;
+		
+		return Plugin_Handled;
+	}
+	
 	public void GetModel(char[] sModel, int length)
 	{
 		strcopy(sModel, length, VAGINEER_MODEL);

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -685,42 +685,30 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
 	if (GetClientTeam(iClient) <= 1) return;
 
-	if (!SaxtonHale_IsValidBoss(iClient))
+	if (SaxtonHale_IsValidAttack(iClient))
 	{
-		/*Balance or restrict specific weapons*/
+		/*Balance specific weapons*/
 		TFClassType nClass = TF2_GetPlayerClass(iClient);
 		for (int iSlot = 0; iSlot <= WeaponSlot_InvisWatch; iSlot++)
 		{
 			int iWeapon = TF2_GetItemInSlot(iClient, iSlot);
-
-			if (IsValidEdict(iWeapon))
+			
+			if (iWeapon <= MaxClients)
 			{
-				int iIndex = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
-				
-				// Restrict weapons, including 1st eound
-				if (g_ConfigIndex.IsRestricted(iIndex))
-				{
-					TF2_RemoveItemInSlot(iClient, iSlot);
-					
-					//Get default weapon index for class and slot
-					iIndex = g_iDefaultWeaponIndex[view_as<int>(nClass)][iSlot];
-					if (iIndex < 0)
-					{
-						char sError[256];
-						Format(sError, sizeof(sError), "[VSH] UNABLE TO GET DEFAULT WEAPON INDEX FOR CLASS %d SLOT %d!!!!", nClass, iSlot);
-						PluginStop(true, sError);
-						return;
-					}
-					
+				//No weapon in this slot, may be removed from GiveNamedItem hook
+				//Generate default weapon index for class and slot
+				int iIndex = g_iDefaultWeaponIndex[view_as<int>(nClass)][iSlot];
+				if (iIndex >= 0)
 					iWeapon = TF2_CreateAndEquipWeapon(iClient, iIndex, .bAttrib = true);
-				}
-
-				if (g_iTotalRoundPlayed <= 0)
-					continue;
-
+			}
+			
+			if (iWeapon > MaxClients)
+			{
 				// Balance weapons, not including 1st round
-				if (SaxtonHale_IsValidAttack(iClient))
+				if (g_iTotalRoundPlayed > 0)
 				{
+					int iIndex = GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex");
+					
 					for (int i = 0; i <= 1; i++)
 					{
 						char sAttrib[255], atts[32][32];

--- a/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
@@ -37,7 +37,7 @@ void MenuWeapon_Refresh()
 			//Loop through all classes to get slot to add desp if found
 			for (int iClass = 1; iClass < sizeof(g_strClassName); iClass++)
 			{
-				int iSlot = TF2_GetSlotInItem(iIndex, view_as<TFClassType>(iClass));
+				int iSlot = TF2_GetItemSlot(iIndex, view_as<TFClassType>(iClass));
 				
 				if (iSlot >= MENU_MAX_SLOT) iSlot = WeaponSlot_Secondary;
 				if (iSlot >= 0) Format(sClassDesp[iClass][iSlot], sizeof(sClassDesp[][]), "%s \n%s", sClassDesp[iClass][iSlot], sDesp);

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -199,6 +199,8 @@ public MRESReturn Hook_EntityShouldTransmit(int iEntity, Handle hReturn, Handle 
 
 public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams)
 {
+	if (DHookIsNullParam(hParams, 1) || DHookIsNullParam(hParams, 3))
+		return MRES_Ignored;
 	char sClassname[256];
 	DHookGetParamString(hParams, 1, sClassname, sizeof(sClassname));
 	int iIndex = DHookGetParamObjectPtrVar(hParams, 3, 4, ObjectValueType_Int) & 0xFFFF;

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -201,6 +201,7 @@ public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams
 {
 	if (DHookIsNullParam(hParams, 1) || DHookIsNullParam(hParams, 3))
 		return MRES_Ignored;
+	
 	char sClassname[256];
 	DHookGetParamString(hParams, 1, sClassname, sizeof(sClassname));
 	int iIndex = DHookGetParamObjectPtrVar(hParams, 3, 4, ObjectValueType_Int) & 0xFFFF;

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -231,17 +231,33 @@ stock int TF2_GetSlotFromWeapon(int iWeapon)
 	return -1;
 }
 
-stock int TF2_GetSlotInItem(int iIndex, TFClassType nClass)
+stock int TF2_GetItemSlot(int iIndex, TFClassType nClass)
 {
 	int iSlot = TF2Econ_GetItemSlot(iIndex, nClass);
 	if (iSlot >= 0)
 	{
-		//Spy slots is a bit messy
-		if (nClass == TFClass_Spy)
+		// Econ reports wrong slots for Engineer and Spy
+		switch (nClass)
 		{
-			if (iSlot == 1) iSlot = WeaponSlot_Primary;		//Revolver
-			if (iSlot == 4) iSlot = WeaponSlot_Secondary;	//Sapper
-			if (iSlot == 6) iSlot = WeaponSlot_InvisWatch;	//Invis Watch
+			case TFClass_Engineer:
+			{
+				switch (iSlot)
+				{
+					case 4: iSlot = WeaponSlot_BuilderEngie; // Toolbox
+					case 5: iSlot = WeaponSlot_PDABuild; // Construction PDA
+					case 6: iSlot = WeaponSlot_PDADestroy; // Destruction PDA
+				}
+			}
+			case TFClass_Spy:
+			{
+				switch (iSlot)
+				{
+					case 1: iSlot = WeaponSlot_Primary; // Revolver
+					case 4: iSlot = WeaponSlot_Secondary; // Sapper
+					case 5: iSlot = WeaponSlot_PDADisguise; // Disguise Kit
+					case 6: iSlot = WeaponSlot_InvisWatch; // Invis Watch
+				}
+			}
 		}
 	}
 	
@@ -381,7 +397,7 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 			EquipPlayerWeapon(iClient, iWeapon);
 			
 			//Make sure max ammo is set correctly
-			int iSlot = TF2_GetSlotInItem(iIndex, TF2_GetPlayerClass(iClient));
+			int iSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(iClient));
 			int iMaxAmmo = SDK_GetMaxAmmo(iClient, iSlot);
 			int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
 			

--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -27,7 +27,7 @@ public Action TagsDamage_OnTakeDamage(int victim, int &attacker, int &inflictor,
 	if (weapon > MaxClients && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
 	{
 		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
-		iWeaponSlot = TF2_GetSlotInItem(iIndex, TF2_GetPlayerClass(attacker));
+		iWeaponSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(attacker));
 	}
 	
 	//Call attackdamage function


### PR DESCRIPTION
Also totally not stolen from https://github.com/redsunservers/SuperZombieFortress/pull/55

Some notes from this PR:
- Use to block boss's weapon and cosmetics on given (unless don't have `this.bModel`, dont remove cosmetic)
- Use to block any blacklisted weapon from config
- new boss function `OnGiveNamedItem` is made to allow any bosses to keep whatever weapon if needed (vagineer keeping `tf_weapon_builder`)
- If player spawns as boss with same class, `GiveNamedItem` wont be called as weapon/cosmetic is unmodified, so those need to be manually killed before respawning to call `GiveNamedItem`
- Rename `TF2_GetSlotInItem` to `TF2_GetItemSlot`