### PR TITLE
Buff HHHJr. a little bit more

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -107,9 +107,9 @@ methodmap CRageGhost < SaxtonHaleBase
 		//Default values, these can be changed if needed
 		ability.flRadius = 400.0;
 		ability.flDuration = 8.0;
-		ability.flHealSteal = 20.0;	//Steals hp per second
-		ability.flHealGain = 40.0;	//Gains hp per second
-		ability.flBuildingDrain = 1.0;	//Building health drain multiplier based on flHealSteal, 0.0 or lower disables it
+		ability.flHealSteal = 25.0;	//Steals hp per second
+		ability.flHealGain = 50.0;	//Gains hp per second
+		ability.flBuildingDrain = 3.0;	//Building health drain multiplier based on flHealSteal, 0.0 or lower disables it
 		ability.flPullStrength = 10.0;	//Scale of pull strength, negative values push enemies away instead. Note that making it too weak will only pull players if they're airborne
 		
 		g_bGhostEnable[ability.iClient] = false;

--- a/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
@@ -75,8 +75,8 @@ methodmap CTeleportSwap < SaxtonHaleBase
 		//Default values, these can be changed if needed
 		ability.iMaxCharge = 200;
 		ability.iChargeBuild = 4;
-		ability.flCooldown = 40.0;
-		ability.flStunDuration = 3.0;
+		ability.flCooldown = 30.0;
+		ability.flStunDuration = 1.0;
 		
 		g_iTeleportSwapCharge[ability.iClient] = 0;
 		g_flTeleportSwapCooldownWait[ability.iClient] = GetGameTime() + ability.flCooldown;

--- a/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
@@ -1,5 +1,6 @@
 static float g_flWallClimbMaxHeight[TF_MAXPLAYERS+1];
 static float g_flWallClimbMaxDistance[TF_MAXPLAYERS+1];
+static float g_flWallClimbHorizontalSpeedMult[TF_MAXPLAYERS+1];
 
 methodmap CWallClimb < SaxtonHaleBase
 {
@@ -25,12 +26,24 @@ methodmap CWallClimb < SaxtonHaleBase
 			g_flWallClimbMaxDistance[this.iClient] = val;
 		}
 	}
+	property float flHorizontalSpeedMult
+	{
+		public get()
+		{
+			return g_flWallClimbHorizontalSpeedMult[this.iClient];
+		}
+		public set(float val)
+		{
+			g_flWallClimbHorizontalSpeedMult[this.iClient] = val;
+		}
+	}
 	
 	public CWallClimb(CWallClimb ability)
 	{
 		//Default values, these can be changed if needed
 		ability.flMaxHeight = 750.0;
 		ability.flMaxDistance = 100.0;
+		ability.flHorizontalSpeedMult = 2.0;	//Horizontal speed multiplier, for better mobility if the boss is trying to go anywhere besides straight up
 	}
 	
 	public Action OnAttackCritical(int iWeapon, bool &bResult)
@@ -66,10 +79,17 @@ methodmap CWallClimb < SaxtonHaleBase
 		
 		if (flDistance >= this.flMaxDistance) return;
 		
-		float fVelocity[3];
-		GetEntPropVector(iClient, Prop_Data, "m_vecVelocity", fVelocity);
-		fVelocity[2] = this.flMaxHeight;
-		TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, fVelocity);
+		float vecVelocity[3];
+		GetEntPropVector(iClient, Prop_Data, "m_vecVelocity", vecVelocity);
+		
+		//Increase horizontal velocity
+		vecVelocity[0] *= this.flHorizontalSpeedMult;
+		vecVelocity[1] *= this.flHorizontalSpeedMult;
+		
+		//Set vertical velocity, the main part of this ability
+		vecVelocity[2] = this.flMaxHeight;
+		
+		TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, vecVelocity);
 	}
 	
 	public void OnThink()

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -167,13 +167,13 @@ methodmap CHorsemann < SaxtonHaleBase
 			if (StrContains(sample, "vo/halloween_boss/", false) == 0)
 				return Plugin_Continue;
 			
-			Format(sample, sizeof(sample), g_strHorsemannVoice[GetRandomInt(0, sizeof(g_strHorsemannVoice) - 1)]);
+			Format(sample, sizeof(sample), g_strHorsemannVoice[GetRandomInt(0, sizeof(g_strHorsemannVoice)-1)]);
 			return Plugin_Changed;
 		}
 			
 		if (StrContains(sample, "player/footsteps/", false) == 0)
 		{
-			EmitSoundToAll(g_strHorsemannFootsteps[GetRandomInt(0, sizeof(g_strHorsemannFootsteps) - 1)], this.iClient, _, _, _, 0.4, GetRandomInt(90, 100));
+			EmitSoundToAll(g_strHorsemannFootsteps[GetRandomInt(0, sizeof(g_strHorsemannFootsteps)-1)], this.iClient, _, _, _, 0.4, GetRandomInt(90, 100));
 			return Plugin_Handled;
 		}
 		


### PR DESCRIPTION
boss still sux, changes:

- Wall climbing considers your current horizontal speed and doubles it with no speed cap
    - Allows the boss to jump from, for example, one building to another more easily. Also allows it to zoom across very open maps within seconds, like trimping
    - This is only for the boss ability, sniper wall climbing is unchanged
    
- Rage deals 25 damage per second to players instead of 20 (and heals for 50 hp per second instead of 40)
- Rage deals 75 damage per second to buildings instead of 20
- 200% rage effect is unchanged but will scale with the new values

- Teleport swap has a 30 second cooldown instead of 40
- Teleport swap self-stuns for 1 second instead of 3