### PR TITLE
Buff Last Yeti's abilities

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
@@ -46,7 +46,7 @@ methodmap CGroundPound < SaxtonHaleBase
 	public CGroundPound(CGroundPound ability)
 	{
 		ability.flImpactRadius = 500.0;
-		ability.flImpactDamage = 25.0;
+		ability.flImpactDamage = 50.0;
 		ability.flImpactLaunchVelocity = 650.0;
 	}
 	

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_freeze.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_freeze.sp
@@ -9,7 +9,7 @@ static float g_flAbilityRadius[TF_MAXPLAYERS + 1];
 static float g_flSlowDuration[TF_MAXPLAYERS + 1];
 static float g_flSlowPercentage[TF_MAXPLAYERS + 1];
 static float g_flFreezeDuration[TF_MAXPLAYERS + 1];
-static float g_flRageFreezeSuperRageMultiplier[TF_MAXPLAYERS+1];
+static float g_flRageFreezeSuperRageMultiplier[TF_MAXPLAYERS + 1];
 static bool g_bFreezeAffected[TF_MAXPLAYERS + 1];
 
 methodmap CRageFreeze < SaxtonHaleBase

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -48,7 +48,13 @@ methodmap CYeti < SaxtonHaleBase
 	{
 		boss.CallFunction("CreateAbility", "CBraveJump");
 		boss.CallFunction("CreateAbility", "CGroundPound");
-		boss.CallFunction("CreateAbility", "CRageFreeze");
+		CRageFreeze rageFreeze = boss.CallFunction("CreateAbility", "CRageFreeze");
+		
+		//CRageAddCond should last as long as slow + freeze
+		CRageAddCond rageCond = boss.CallFunction("CreateAbility", "CRageAddCond");
+		rageCond.AddCond(TFCond_RuneHaste);
+		rageCond.flRageCondDuration = rageFreeze.flSlowDuration + rageFreeze.flFreezeDuration;
+		rageCond.flRageCondSuperRageMultiplier = rageFreeze.flRageFreezeSuperRageMultiplier;
 		
 		boss.iBaseHealth = 800;
 		boss.iHealthPerPlayer = 850;


### PR DESCRIPTION
This may make the freeze feel less janky, as well as make the boss not suck as much.

- Boss now uses `CRageAddCond`
  - Applies `TFCond_RuneHaste`
  - Lasts as long as the slow + freeze combined
- Changes to `CRageFreeze`
  - Slow duration `3.0` -> `2.0`
  - Rage now freezes all inputs for affected players
  - Players now drop to the floor instead of getting stuck in the air
  - Added `flRageFreezeSuperRageMultiplier` property
- Changes to `CGroundPound `
  - Impact damage `25.0` -> `50.0`