### PR TITLE
Fix backstab and market gardner damage set

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -440,7 +440,7 @@
 					
 					"params"
 					{
-						"set"			"333.3"			//Set backstab damage to 333.3 (crit multiplies by 3 to make 1000dmg)
+						"set"			"1000.0"		//Set backstab damage to 1000 dmg
 						"damagetype"	"crit"			//Force crit
 						"damagetype"	"noknockback"	//Disable knockback
 					}
@@ -812,7 +812,7 @@
 				
 				"params"
 				{
-					"set"			"500"		//Set stomp damage to 500
+					"set"			"500.0"		//Set stomp damage to 500
 				}
 			}
 		}
@@ -830,12 +830,11 @@
 					"cond"			"81"		//Blast jumping
 				}
 				
-				//Values but divided by 3 because crit
 				"params"
 				{
-					"perplayer"		"16.7"		//50dmg per player
-					"min"			"100"		//Min 300 dmg
-					"max"			"333.3"		//Max 1000 dmg
+					"perplayer"		"50.0"		//50 dmg per player
+					"min"			"300.0"		//Min 300 dmg
+					"max"			"1000.0"	//Max 1000 dmg
 				
 					"damagetype"	"crit"		//Force crit
 				}
@@ -893,7 +892,7 @@
 					//Act this as a passive, always call regardless of weapon/slot
 					//Reason this is done is because takedamage hook returns weapon stomp as -1
 					"passive"		"1"
-					"set"			"1024"		//Set stomp damage to 1024
+					"set"			"1024.0"	//Set stomp damage to 1024
 				}
 			}
 		}
@@ -998,7 +997,7 @@
 				
 				"params"
 				{
-					"set"			"1024"	//Set stomp damage to 1024
+					"set"			"1024.0"	//Set stomp damage to 1024
 				}
 			}
 		}
@@ -1957,7 +1956,7 @@
 				
 				"params"
 				{
-					"set"			"2666.7"	//8000dmg when multiplied from crit
+					"set"			"8000.0"	//8000 dmg on +4th backstab
 				}
 			}
 		}


### PR DESCRIPTION
PR #106 changed damage where damage param take into account from crit damages, but forgot to update configs for actual damage values rather than cut off by 1/3.