### PR TITLE
Changes to Sniper

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1660,11 +1660,6 @@
 			"prefab"		"526"
 		}
 		
-		"1098"	//Classic
-		{
-			"attrib"		"144 ; 0.0"
-		}
-		
 		"58"	//Jarate
 		{
 			"desp"			"Jarate: {neutral}Replaces jarate effect into a rage drain"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -357,22 +357,8 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+100% bodyshot damage, adds an outline to the boss on hit, {negative}fires tracer rounds"
-				"attrib"	"305 ; 1.0"
-				
-				"attackdamage"
-				{
-					"filter"
-					{
-						"damagecustom"	"noheadshot"
-						"damagetype"	"nocrit"
-					}
-					
-					"params"
-					{
-						"multiply"		"2.0"	//2x non-crit-bodyshot dmg bonus
-					}
-				}
+				"desp"		"Primary: {positive}Adds an outline to the boss on hit"
+				"minicrit"	"1"
 				
 				"attackdamage"
 				{
@@ -1575,7 +1561,6 @@
 		"56"	//Huntsman
 		{
 			"desp"			"Huntsman: {positive}Arrows explode on impact"
-			"crit"			"1"
 			
 			"projectile"	//Called when projectile touches something
 			{
@@ -1616,7 +1601,7 @@
 		
 		"402"	//Bazaar Bargain
 		{
-			"desp"			"Bazaar Bargain: {positive}+1 head on every headshot, {negative}-33% outline duration"
+			"desp"			"Bazaar Bargain: {positive}+1 head on every headshot"
 			
 			"attackdamage"
 			{
@@ -1633,15 +1618,6 @@
 					
 					"math"			"add"
 					"value"			"1"
-				}
-			}
-			
-			"attackdamage"
-			{
-				"Tags_Glow"
-				{
-					"override"		"sniper-primary-glow"	//Override function with new values
-					"duration"		"4.0"
 				}
 			}
 		}


### PR DESCRIPTION
Kinda gets rid of issue #113

PR #106 allows damage calculation for internal stuff to be more accurate, which is helpful for bosses/modifiers/etc, but the specific look-for-crit-but-not-minicrit-damage case got hit in the crossfire, and since we wanted to simplify sniper primaries, this (un)fortunately is a good opportunity to do so, changes:

- Bonus damage for bodyshots and tracer rounds on all sniper rifles have been removed
    - Instead, they're minicrit buffed. Includes huntsman.

- Bazaar bargain has its outline downside removed, as it simply didn't deserve it

It's worth mentioning that headshots, the main gimmick of the Sniper class of the Team Fortress 2 videogame, exist! Making use of them will deservingly increase your damage output.