### PR TITLE
Fix Blutsauger not self-healing

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1459,7 +1459,15 @@
 		"36"	//Blutsauger
 		{
 			"desp"			"Blutsauger: {positive}+3% ÜberCharge on hit, +5 health on hit"
-			"attrib"		"16 ; 0.0 ; 180 ; 5.0"
+			"attrib"		"16 ; 0.0"
+			
+			"attackdamage"
+			{
+				"Tags_AddHealthBase"	//Add 5 health. Using AddHealthBase as overheal in this case is limited to 1.5x of max hp, while AddHealth is limited to the given amount
+				{
+					"amount"		"0.033"
+				}
+			}
 		}
 		
 		"305"	//Crusader's Crossbow

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -115,9 +115,11 @@
 //
 //Tags_AddHealth          - Add health to player
 //- amount                  - Amount of health to add
+//- overheal                - Multiplier of the player's max health to cap the overheal at, default is 1.5
 //
 //Tags_AddHealthBase      - Add health to player
 //- amount                  - Max health percentage to add
+//- overheal                - Multiplier of the player's max health to cap the overheal at, default is 1.5
 //
 //Tags_DropHealth         - Drops small health pack to target player
 //
@@ -1463,9 +1465,9 @@
 			
 			"attackdamage"
 			{
-				"Tags_AddHealthBase"	//Add 5 health. Using AddHealthBase as overheal in this case is limited to 1.5x of max hp, while AddHealth is limited to the given amount
+				"Tags_AddHealth"	//Add 5 health
 				{
-					"amount"		"0.033"
+					"amount"		"5"
 				}
 			}
 		}
@@ -1959,6 +1961,7 @@
 				"Tags_AddHealth"	//Add 220 health
 				{
 					"amount"		"220"
+					"overheal"		"4.2"		//Caps at 294 health
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -568,7 +568,11 @@ public void Tags_AddHealth(int iClient, int iTarget, TagsParams tParams)
 		return;
 	
 	int iAmount = tParams.GetInt("amount");
-	Client_AddHealth(iTarget, iAmount, iAmount);
+	float flMaxOverheal = tParams.GetFloat("overheal", 1.5);
+	
+	int iMaxHealth = SDK_GetMaxHealth(iTarget);
+	
+	Client_AddHealth(iTarget, iAmount, RoundToNearest(float(iMaxHealth) * (flMaxOverheal - 1.0)));
 }
 
 public void Tags_AddHealthBase(int iClient, int iTarget, TagsParams tParams)
@@ -577,9 +581,11 @@ public void Tags_AddHealthBase(int iClient, int iTarget, TagsParams tParams)
 		return;
 	
 	float flAmount = tParams.GetFloat("amount");
+	float flMaxOverheal = tParams.GetFloat("overheal", 1.5);
+	
 	int iMaxHealth = SDK_GetMaxHealth(iTarget);
 	
-	Client_AddHealth(iTarget, RoundToNearest(float(iMaxHealth) * flAmount), RoundToNearest(float(iMaxHealth) * 0.5));
+	Client_AddHealth(iTarget, RoundToNearest(float(iMaxHealth) * flAmount), RoundToNearest(float(iMaxHealth) * (flMaxOverheal - 1.0)));
 }
 
 public void Tags_DropHealth(int iClient, int iTarget, TagsParams tParams)


### PR DESCRIPTION
The Blutsauger lost its ability to self-heal in the tags rework.