### PR TITLE
Fix crash from electric modifier endless loop

### DIFF
--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
@@ -8,11 +8,6 @@ methodmap CModifiersElectric < SaxtonHaleBase
 	{
 	}
 	
-	public bool IsModifiersHidden()
-	{
-		return true;
-	}
-	
 	public void GetModifiersName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Electric");

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
@@ -1,4 +1,4 @@
-#define ELECTRIC_BEAM	"sprites/laserbeam.vmt"
+#define ELECTRIC_BEAM	"sprites/laserbeam.spr"
 
 static bool g_bElectricDamage[TF_MAXPLAYERS+1];	//Whenever if client is currently being damaged or not
 
@@ -73,7 +73,7 @@ methodmap CModifiersElectric < SaxtonHaleBase
 					int iLaser = CreateEntityByName("env_laser");
 					if (iLaser > MaxClients)
 					{
-						SetEntityModel(iLaser, ELECTRIC_BEAM);
+						DispatchKeyValue(iLaser, "texture", ELECTRIC_BEAM);
 						DispatchKeyValue(iLaser, "renderamt", "100");		//Brightness
 						DispatchKeyValue(iLaser, "rendermode", "0");
 						DispatchKeyValue(iLaser, "rendercolor", "255 192 0");	//Color
@@ -101,10 +101,5 @@ methodmap CModifiersElectric < SaxtonHaleBase
 		g_bElectricDamage[victim] = false;
 		
 		return Plugin_Changed;
-	}
-	
-	public void Precache()
-	{
-		PrecacheGeneric(ELECTRIC_BEAM);
 	}
 };


### PR DESCRIPTION
https://crash.limetech.org/yppcfvatnaip

I suspect this started from PR #106, `SDKHooks_TakeDamage` native bypassing `SDKHook_OnTakeDamage` hook, but apparently not `SDKHook_OnTakeDamageAlive`. This causes an endless loop of `SDKHooks_TakeDamage` calling `OnAttackDamage` boss function.