### PR TITLE
Announcer: Update rage behaviour & other small changes

### DIFF
--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -28,6 +28,12 @@
 				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x10\x01\x00\x00"
 			}
+			"CTFPlayer::RemoveObject"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x7C\x21\x00\x00"
+				"linux"		"@_ZN9CTFPlayer12RemoveObjectEP11CBaseObject"
+			}
 		}
 		"Functions"
 		{

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -32,6 +32,7 @@
 			{
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer9AddObjectEP11CBaseObject"
+				//TODO: get windows sig
 			}
 			"CTFPlayer::RemoveObject"
 			{

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -28,11 +28,17 @@
 				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x10\x01\x00\x00"
 			}
+			"CTFPlayer::AddObject"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer9AddObjectEP11CBaseObject"
+				"windows"	"\x8B\x91\xA4\x06\x00\x00\x83\xFA\xFF"
+			}
 			"CTFPlayer::RemoveObject"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x7C\x21\x00\x00"
 				"linux"		"@_ZN9CTFPlayer12RemoveObjectEP11CBaseObject"
+				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x7C\x21\x00\x00"
 			}
 		}
 		"Functions"

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -32,7 +32,6 @@
 			{
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer9AddObjectEP11CBaseObject"
-				"windows"	"\x8B\x91\xA4\x06\x00\x00\x83\xFA\xFF"
 			}
 			"CTFPlayer::RemoveObject"
 			{

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -32,7 +32,7 @@
 			{
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer9AddObjectEP11CBaseObject"
-				//TODO: get windows sig
+				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x74\x2A\x8B\x07\x8B\xCF\xFF\x50\x08\x8B\xCF"
 			}
 			"CTFPlayer::RemoveObject"
 			{

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -66,6 +66,7 @@
 
 const TFTeam TFTeam_Boss = TFTeam_Blue;
 const TFTeam TFTeam_Attack = TFTeam_Red;
+const TFObjectType TFObject_Invalid = view_as<TFObjectType>(-1);
 
 enum ClientFlags ( <<=1 )
 {
@@ -512,6 +513,7 @@ public void OnPluginStart()
 	//Boss functions
 	SaxtonHaleFunction("CreateBoss", ET_Single, Param_String);
 	SaxtonHaleFunction("IsBossHidden", ET_Single);
+	SaxtonHaleFunction("IsBossType", ET_Single, Param_String);
 	SaxtonHaleFunction("SetBossType", ET_Ignore, Param_String);
 	
 	func = SaxtonHaleFunction("GetBossType", ET_Ignore, Param_String, Param_Cell);

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -66,7 +66,9 @@
 
 const TFTeam TFTeam_Boss = TFTeam_Blue;
 const TFTeam TFTeam_Attack = TFTeam_Red;
+
 const TFObjectType TFObject_Invalid = view_as<TFObjectType>(-1);
+const TFObjectMode TFObjectMode_Invalid = view_as<TFObjectMode>(-1);
 
 enum ClientFlags ( <<=1 )
 {
@@ -236,10 +238,10 @@ char g_strSlotName[][] = {
 
 // TF2 Building names
 char g_strBuildingName[TFObjectType][TFObjectMode][] = {
-    {"Dispenser", ""},
-    {"Teleporter Entrance", "Teleporter Exit"},
-    {"Sentry Gun", ""},
-    {"Sapper", ""},
+	{"Dispenser", ""},
+	{"Teleporter Entrance", "Teleporter Exit"},
+	{"Sentry Gun", ""},
+	{"Sapper", ""},
 };
 
 // Color Tag

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -232,6 +232,14 @@ char g_strSlotName[][] = {
 	"Building"
 };
 
+// TF2 Building names
+char g_strBuildingName[TFObjectType][TFObjectMode][] = {
+    {"Dispenser", ""},
+    {"Teleporter Entrance", "Teleporter Exit"},
+    {"Sentry Gun", ""},
+    {"Sapper", ""},
+};
+
 // Color Tag
 char g_strColorTag[][] = {
 	"{positive}",

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -553,6 +553,10 @@ public void OnPluginStart()
 	SaxtonHaleFunction("OnPlayerKilled", ET_Ignore, Param_Cell, Param_Cell);
 	SaxtonHaleFunction("OnDeath", ET_Ignore, Param_Cell);
 	
+	func = SaxtonHaleFunction("OnAttackBuilding", ET_Hook, Param_CellByRef, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
+	func.SetParam(6, Param_Array, VSHArrayType_Static, 3);
+	func.SetParam(7, Param_Array, VSHArrayType_Static, 3);
+	
 	func = SaxtonHaleFunction("OnAttackDamage", ET_Hook, Param_CellByRef, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
 	func.SetParam(6, Param_Array, VSHArrayType_Static, 3);
 	func.SetParam(7, Param_Array, VSHArrayType_Static, 3);
@@ -925,6 +929,11 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 		|| strcmp(sClassname, "func_regenerate") == 0)
 	{
 		SDKHook(iEntity, SDKHook_Touch, ItemPack_OnTouch);
+	}
+	
+	if (StrContains(sClassname, "obj_") == 0)
+	{
+		SDKHook(iEntity, SDKHook_OnTakeDamage, Building_OnTakeDamage);
 	}
 }
 
@@ -1317,6 +1326,27 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 			}
 		}
 	}
+	return finalAction;
+}
+
+public Action Building_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	if (!g_bEnabled) return Plugin_Continue;
+	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
+	if (victim <= MaxClients) return Plugin_Continue;
+	
+	Action finalAction = Plugin_Continue;
+	Action action = Plugin_Continue;
+	
+	SaxtonHaleBase bossAttacker = SaxtonHaleBase(attacker);
+	
+	if (0 < attacker <= MaxClients && bossAttacker.bValid)
+	{
+		action = bossAttacker.CallFunction("OnAttackBuilding", victim, inflictor, damage, damagetype, weapon, damageForce, damagePosition, damagecustom);
+		if (action > finalAction)
+			finalAction = action;
+	}
+
 	return finalAction;
 }
 

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -562,11 +562,11 @@ public void OnPluginStart()
 	SaxtonHaleFunction("OnPlayerKilled", ET_Ignore, Param_Cell, Param_Cell);
 	SaxtonHaleFunction("OnDeath", ET_Ignore, Param_Cell);
 	
-	func = SaxtonHaleFunction("OnAttackBuilding", ET_Hook, Param_CellByRef, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
+	func = SaxtonHaleFunction("OnAttackBuilding", ET_Hook, Param_Cell, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
 	func.SetParam(6, Param_Array, VSHArrayType_Static, 3);
 	func.SetParam(7, Param_Array, VSHArrayType_Static, 3);
 	
-	func = SaxtonHaleFunction("OnAttackDamage", ET_Hook, Param_CellByRef, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
+	func = SaxtonHaleFunction("OnAttackDamage", ET_Hook, Param_Cell, Param_CellByRef, Param_FloatByRef, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell);
 	func.SetParam(6, Param_Array, VSHArrayType_Static, 3);
 	func.SetParam(7, Param_Array, VSHArrayType_Static, 3);
 	

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -41,6 +41,7 @@
 #define SOUND_METERFULL		"player/recharged.wav"
 #define SOUND_BACKSTAB		"player/spy_shield_break.wav"
 #define SOUND_DOUBLEDONK	"player/doubledonk.wav"
+#define SOUND_NULL			"vo/null.mp3"
 
 #define PARTICLE_GHOST 		"ghost_appearation"
 
@@ -868,6 +869,7 @@ public void OnMapStart()
 		PrecacheSound(SOUND_METERFULL);
 		PrecacheSound(SOUND_BACKSTAB);
 		PrecacheSound(SOUND_DOUBLEDONK);
+		PrecacheSound(SOUND_NULL);
 		
 		g_iSpritesLaserbeam = PrecacheModel("materials/sprites/laserbeam.vmt", true);
 		g_iSpritesGlow = PrecacheModel("materials/sprites/glow01.vmt", true);
@@ -938,8 +940,7 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 	{
 		SDKHook(iEntity, SDKHook_Touch, ItemPack_OnTouch);
 	}
-	
-	if (StrContains(sClassname, "obj_") == 0)
+	else if (StrContains(sClassname, "obj_") == 0)
 	{
 		SDKHook(iEntity, SDKHook_OnTakeDamage, Building_OnTakeDamage);
 	}
@@ -1337,25 +1338,17 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 	return finalAction;
 }
 
-public Action Building_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action Building_OnTakeDamage(int building, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	if (!g_bEnabled) return Plugin_Continue;
 	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
-	if (victim <= MaxClients) return Plugin_Continue;
-	
-	Action finalAction = Plugin_Continue;
-	Action action = Plugin_Continue;
 	
 	SaxtonHaleBase bossAttacker = SaxtonHaleBase(attacker);
 	
 	if (0 < attacker <= MaxClients && bossAttacker.bValid)
-	{
-		action = bossAttacker.CallFunction("OnAttackBuilding", victim, inflictor, damage, damagetype, weapon, damageForce, damagePosition, damagecustom);
-		if (action > finalAction)
-			finalAction = action;
-	}
-
-	return finalAction;
+		return bossAttacker.CallFunction("OnAttackBuilding", building, inflictor, damage, damagetype, weapon, damageForce, damagePosition, damagecustom);
+		
+	return Plugin_Continue;
 }
 
 public bool BossTargetFilter(char[] sPattern, ArrayList aClients)

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -317,7 +317,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		return Plugin_Continue;
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (damagecustom == TF_CUSTOM_BOOTS_STOMP)
 		{

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -99,7 +99,7 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		strcopy(type, length, g_sClientBossType[this.iClient]);
 	}
 	
-	public bool IsBossType(char[] type)
+	public bool IsBossType(const char[] type)
 	{
 		return StrEqual(g_sClientBossType[this.iClient], type);
 	}

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -98,6 +98,11 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 	{
 		strcopy(type, length, g_sClientBossType[this.iClient]);
 	}
+	
+	public bool IsBossType(char[] type)
+	{
+		return StrEqual(g_sClientBossType[this.iClient], type);
+	}
 
 	public int CalculateMaxHealth()
 	{

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -515,7 +515,7 @@ public void Announcer_SetBuilder(int iBuilding, int iClient, bool bDisplay = tru
 	if (StrEqual(sClassname, "obj_sentrygun"))
 		Format(sBuildingName, sizeof(sBuildingName), "Sentry Gun");
 	
-	if (StrEqual(sClassname, "obj_teleporter"))
+	else if (StrEqual(sClassname, "obj_teleporter"))
 	{
 		Format(sBuildingName, sizeof(sBuildingName), "Teleporter");
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -156,7 +156,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 	{
 		//Need to block gun sounds
 		
-		if (strncmp(sample, "vo/", 3) == 0 && !(strncmp(sample, "vo/announcer_", 13) == 0 || strncmp(sample, "vo/mvm_", 7) == 0 || strncmp(sample, "vo/compmode/cm_admin_", 21) == 0))	//Block voicelines, except her own's. Cancer pathing btw
+		if (strncmp(sample, "vo/", 3) == 0 && !(strncmp(sample, "vo/announcer_", 13) == 0 || strncmp(sample, "vo/mvm_", 7) == 0 || strncmp(sample, "vo/compmode/cm_admin_", 21) == 0))	//Block voicelines, except her own's
 			return Plugin_Handled;
 		return Plugin_Continue;
 	}
@@ -296,8 +296,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		g_hAnnouncerMinionTimer[boss.iClient] = CreateTimer(0.0, Timer_AnnouncerChangeTeam, boss.iClient);
 		
 		//Make minions untargetable by all sentries until the team-swapping countdown ends
-		int iFlags = (GetEntityFlags(boss.iClient) | FL_NOTARGET);
-		SetEntityFlags(boss.iClient, iFlags);
+		SetEntityFlags(boss.iClient, (GetEntityFlags(boss.iClient) | FL_NOTARGET));
 	}
 	
 	public bool IsBossHidden()
@@ -349,7 +348,8 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
 	{
-		//Let engineers build, but auto-destroy the buildings they built, but no longer own, if there are any
+		//Let engineers build, but auto-destroy the same building they're attempting to build if there's one active from before they were converted
+		//This is a backup mechanic in case the CTFPlayer:AddObject hook isn't loaded
 		int iBuilding = TF2_GetBuilding(this.iClient, nType, nMode);
 		if (iBuilding != -1)
 		{
@@ -425,8 +425,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		g_hAnnouncerMinionTimer[this.iClient] = null;
 		
 		//Make them targetable by sentries, just in case
-		int iFlags = (GetEntityFlags(this.iClient) & ~FL_NOTARGET);
-		SetEntityFlags(this.iClient, iFlags);
+		SetEntityFlags(this.iClient, (GetEntityFlags(this.iClient) & ~FL_NOTARGET));
 	}
 };
 
@@ -519,8 +518,7 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	}
 	
 	//Allow sentries to target this fella from now on
-	int iFlags = (GetEntityFlags(iClient) & ~FL_NOTARGET);
-	SetEntityFlags(iClient, iFlags);
+	SetEntityFlags(iClient, (GetEntityFlags(iClient) & ~FL_NOTARGET));
 	
 	//Dont give health overheal
 	SetEntProp(iClient, Prop_Send, "m_iHealth", SDK_GetMaxHealth(iClient));

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -349,7 +349,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	}
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
-	{	
+	{
 		//Let them build normally
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -353,12 +353,9 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		int iBuilding = TF2_GetBuilding(this.iClient, nType, nMode);
 		if (iBuilding != -1)
 		{
-			if (iBuilding > MaxClients)
-			{
-				SetVariantInt(999999);
-				AcceptEntityInput(iBuilding, "RemoveHealth");
-				PrintCenterText(this.iClient, "Your previous %s has been destroyed.", g_strBuildingName[nType][nMode]);
-			}
+			SetVariantInt(999999);
+			AcceptEntityInput(iBuilding, "RemoveHealth");
+			PrintCenterText(this.iClient, "Your previous %s has been destroyed.", g_strBuildingName[nType][nMode]);
 		}
 		
 		return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -350,7 +350,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
 	{	
-		//Let them build normally		
+		//Let them build normally
 		return Plugin_Continue;
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -428,12 +428,18 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	if (TF2_GetClientTeam(iClient) == TFTeam_Boss || TF2_GetClientTeam(iClient) <= TFTeam_Spectator || !IsPlayerAlive(iClient))
 		return;
 	
+	int iFlags = GetEntityFlags(iClient);
+	
 	if (g_iAnnouncerMinionTimeLeft[iClient] > 0)
 	{
 		//Warning on about to become boss
 		PrintCenterText(iClient, "YOU'RE SWAPPING TEAMS IN %d SECOND%s", g_iAnnouncerMinionTimeLeft[iClient], g_iAnnouncerMinionTimeLeft[iClient] > 1 ? "S" : "");
 		g_iAnnouncerMinionTimeLeft[iClient]--;
 		g_hAnnouncerMinionTimer[iClient] = CreateTimer(1.0, Timer_AnnouncerChangeTeam, iClient);
+		
+		//Make them untargetable by all sentries during the countdown 
+		iFlags |= FL_NOTARGET;
+		SetEntityFlags(iClient, iFlags);
 		return;
 	}
 	
@@ -484,6 +490,10 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 			}
 		}
 	}
+	
+	//Allow sentries to target this fella from now on
+	iFlags &= ~FL_NOTARGET;
+	SetEntityFlags(iClient, iFlags);
 	
 	//Dont give health overheal
 	SetEntProp(iClient, Prop_Send, "m_iHealth", SDK_GetMaxHealth(iClient));

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -556,16 +556,16 @@ public void Frame_Announcer_EnableBuilding(int iBuilding)
 		SetEntProp(iBuilding, Prop_Send, "m_iState", 1);
 }
 
-public void Announcer_ShowAnnotation(int iEntity, char[] sText, float flTime = 3.0)
+public void Announcer_ShowAnnotation(int iTarget, char[] sText, float flTime = 3.0)
 {
 	int iBits = 0;
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
 		SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 		
-		if (boss.bValid && IsPlayerAlive(iClient))
+		if (boss.bValid && iClient != iTarget && IsPlayerAlive(iClient))
 		{
-			char sType[128];
+			char sType[64];
 			boss.CallFunction("GetBossType", sType, sizeof(sType));
 			
 			if (StrContains(sType, "CAnnouncer"))
@@ -574,7 +574,7 @@ public void Announcer_ShowAnnotation(int iEntity, char[] sText, float flTime = 3
 	}
 
 	Event event = CreateEvent("show_annotation");
-	event.SetInt("follow_entindex", iEntity);
+	event.SetInt("follow_entindex", iTarget);
 	event.SetFloat("lifetime", flTime);
 	event.SetString("text", sText);
 	event.SetString("play_sound", ANNOUNCER_NULLSOUND); //This is just done so console doesn't get a non-existent soundfile error

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -27,7 +27,7 @@ static char g_strAnnouncerKill[][] = {
 	"vo/announcer_am_lastmanforfeit03.mp3",
 	"vo/announcer_dec_kill07.mp3",
 	"vo/announcer_dec_kill10.mp3",
-	"vo/announcer_dec_missionbegin30s02.mp3",
+	"vo/announcer_dec_missionbegins30s02.mp3",
 };
 
 static char g_strAnnouncerKillMinion[][] = {

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -348,8 +348,13 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
 	{
+		//No point in doing anything here if this goes through
+		if (g_hSDKAddObject != null)
+			return Plugin_Continue;
+		
+		//However, as a backup mechanic in case CTFPlayer:AddObject isn't hooked...
 		//Let engineers build, but auto-destroy the same building they're attempting to build if there's one active from before they were converted
-		//This is a backup mechanic in case the CTFPlayer:AddObject hook isn't loaded
+		//This is done so engies can't have more than one of the same building, which can happen as a result of old buildings lacking a "true" owner
 		int iBuilding = TF2_GetBuilding(this.iClient, nType, nMode);
 		if (iBuilding != -1)
 		{
@@ -464,8 +469,8 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	TF2_ChangeClientTeam(iClient, TFTeam_Boss);
 	SetEntProp(iClient, Prop_Send, "m_lifeState", LifeState_Alive);
 	
-	//...and add them all back (windows sig does nothing right now)
-	if (TF2_GetPlayerClass(iClient) == TFClass_Engineer)
+	//...and add them all back (windows signature for this is missing)
+	if (TF2_GetPlayerClass(iClient) == TFClass_Engineer && g_hSDKAddObject != null)
 	{
 		int iBuilding = MaxClients+1;
 		while ((iBuilding = FindEntityByClassname(iBuilding, "obj_*")) > MaxClients)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -347,12 +347,8 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	}
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
-	{
-		//No point in doing anything here if this goes through
-		if (g_hSDKAddObject != null)
-			return Plugin_Continue;
-		
-		//However, as a backup mechanic in case CTFPlayer:AddObject isn't hooked...
+	{	
+		//As a backup mechanic in case CTFPlayer:AddObject isn't hooked...
 		//Let engineers build, but auto-destroy the same building they're attempting to build if there's one active from before they were converted
 		//This is done so engies can't have more than one of the same building, which can happen as a result of old buildings lacking a "true" owner
 		int iBuilding = TF2_GetBuilding(this.iClient, nType, nMode);
@@ -470,7 +466,7 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	SetEntProp(iClient, Prop_Send, "m_lifeState", LifeState_Alive);
 	
 	//...and add them all back (windows signature for this is missing)
-	if (TF2_GetPlayerClass(iClient) == TFClass_Engineer && g_hSDKAddObject != null)
+	if (TF2_GetPlayerClass(iClient) == TFClass_Engineer)
 	{
 		int iBuilding = MaxClients+1;
 		while ((iBuilding = FindEntityByClassname(iBuilding, "obj_*")) > MaxClients)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -321,12 +321,8 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		//Stop minions from damaging buildings of other minions in opposite teams or players in the boss team
 		int iBuilder = TF2_GetBuildingOwner(building);
 		SaxtonHaleBase boss = SaxtonHaleBase(iBuilder);
-		char sType[MAX_TYPE_CHAR];
 		
-		if (boss.bValid)
-			boss.CallFunction("GetBossType", sType, sizeof(sType));
-		
-		if (TF2_GetClientTeam(iBuilder) == TFTeam_Boss || StrEqual(sType, "CAnnouncerMinion"))
+		if (TF2_GetClientTeam(iBuilder) == TFTeam_Boss || (boss.bValid && boss.CallFunction("IsBossType", "CAnnouncerMinion")))
 		{
 			damage = 0.0;
 			return Plugin_Stop;
@@ -375,12 +371,8 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 			if (boss.bValid && IsPlayerAlive(iClient))
 			{
-				char sType[MAX_TYPE_CHAR];
-				boss.CallFunction("GetBossType", sType, sizeof(sType));
-				if (StrEqual(sType, "CAnnouncer"))
-				{
+				if (boss.CallFunction("IsBossType", "CAnnouncer"))
 					EmitSoundToAll(g_strAnnouncerKillMinion[GetRandomInt(0,sizeof(g_strAnnouncerKillMinion)-1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
-				}
 			}
 		}
 	}
@@ -535,11 +527,11 @@ public void Announcer_ShowAnnotation(int iTarget, char[] sMessage, float flDurat
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		if (IsClientInGame(iClient))
+		if (IsClientInGame(iClient) && iClient != iTarget)
 		{
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 			
-			if (iClient != iTarget && (TF2_GetClientTeam(iClient) != TFTeam_Attack || boss.CallFunction("IsBossType", "CAnnouncerMinion")))
+			if (TF2_GetClientTeam(iClient) != TFTeam_Attack || (boss.bValid && boss.CallFunction("IsBossType", "CAnnouncerMinion")))
 				iClients[iCount++] = iClient;
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -25,8 +25,6 @@ static char g_strAnnouncerLose[][] = {
 static char g_strAnnouncerKill[][] = {
 	"vo/announcer_am_lastmanforfeit01.mp3",
 	"vo/announcer_am_lastmanforfeit03.mp3",
-	"vo/announcer_dec_kill07.mp3",
-	"vo/announcer_dec_kill10.mp3",
 	"vo/announcer_dec_missionbegins30s02.mp3",
 };
 
@@ -35,6 +33,8 @@ static char g_strAnnouncerKillMinion[][] = {
 	"vo/mvm_general_destruction04.mp3",
 	"vo/mvm_general_destruction05.mp3",
 	"vo/mvm_general_destruction08.mp3",
+	"vo/announcer_dec_kill07.mp3",
+	"vo/announcer_dec_kill10.mp3",
 };
 
 static char g_strAnnouncerDisguise[][] = {
@@ -44,8 +44,9 @@ static char g_strAnnouncerDisguise[][] = {
 };
 
 static char g_strAnnouncerLastMan[][] = {
-	"vo/taunts/announcer_am_lastmanalive02.mp3",
-	"vo/taunts/announcer_am_lastmanalive03.mp3",
+	"vo/announcer_am_lastmanalive01.mp3"
+	"vo/announcer_am_lastmanalive03.mp3",
+	"vo/announcer_am_lastmanalive04.mp3",
 };
 
 static char g_strAnnouncerBackStabbed[][] = {

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -350,17 +350,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 	
 	public Action OnBuild(TFObjectType nType, TFObjectMode nMode)
 	{	
-		//As a backup mechanic in case CTFPlayer:AddObject isn't hooked...
-		//Let engineers build, but auto-destroy the same building they're attempting to build if there's one active from before they were converted
-		//This is done so engies can't have more than one of the same building, which can happen as a result of old buildings lacking a "true" owner
-		int iBuilding = TF2_GetBuilding(this.iClient, nType, nMode);
-		if (iBuilding != -1)
-		{
-			SetVariantInt(999999);
-			AcceptEntityInput(iBuilding, "RemoveHealth");
-			PrintCenterText(this.iClient, "Your previous %s has been destroyed.", g_strBuildingName[nType][nMode]);
-		}
-		
+		//Let them build normally		
 		return Plugin_Continue;
 	}
 	
@@ -460,7 +450,7 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	TF2_ChangeClientTeam(iClient, TFTeam_Boss);
 	SetEntProp(iClient, Prop_Send, "m_lifeState", LifeState_Alive);
 	
-	//...and add them all back (windows signature for this is missing)
+	//...and add them all back
 	iBuilding = MaxClients+1;
 	while ((iBuilding = FindEntityByClassname(iBuilding, "obj_*")) > MaxClients)
 	{

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -178,7 +178,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 		}
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (weapon <= MaxClients)
 			return Plugin_Continue;
@@ -215,7 +215,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 		return Plugin_Stop;
 	}
 	
-	public Action OnAttackBuilding(int &building, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackBuilding(int building, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (weapon <= MaxClients)
 			return Plugin_Continue;
@@ -303,7 +303,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		return true;
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		//Don't allow minion attack boss team
 		if (this.iClient != victim && TF2_GetClientTeam(victim) == TFTeam_Boss)
@@ -315,7 +315,7 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		return Plugin_Continue;
 	}
 	
-	public Action OnAttackBuilding(int &building, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackBuilding(int building, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		//Stop minions from damaging buildings of other minions in opposite teams or players in the boss team
 		int iBuilder = GetEntPropEnt(building, Prop_Send, "m_hBuilder");

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -196,7 +196,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 		}
 		
 		char sMessage[128];
-		Format(sMessage, sizeof(sMessage), "%N is hit!", victim);
+		Format(sMessage, sizeof(sMessage), "%N was hit and will switch teams!", victim);
 		
 		if (TF2_GetPlayerClass(victim) == TFClass_Engineer)
 		{
@@ -207,7 +207,7 @@ methodmap CAnnouncer < SaxtonHaleBase
 				//In favor of the boss, buildings will not wait for the engie to team switch
 				if (GetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder") == victim && GetEntProp(iBuilding, Prop_Send, "m_iTeamNum") != iTeam)
 				{
-					Format(sMessage, sizeof(sMessage), "%N is hit!\n%N's buildings swapped teams!", victim, victim);
+					Format(sMessage, sizeof(sMessage), "%N was hit and will switch teams!\n%N's buildings have switched teams!", victim, victim);
 					Announcer_SetBuilder(iBuilding, this.iClient);
 				}
 			}
@@ -545,7 +545,7 @@ public void Announcer_SetBuilder(int iBuilding, int iClient, bool bDisplay = tru
 	if (bDisplay)
 	{
 		char sMessage[128];
-		Format(sMessage, sizeof(sMessage), "%N's %s is hit!", iBuilder, sBuildingName);
+		Format(sMessage, sizeof(sMessage), "%N's %s is hit and has switched teams!", iBuilder, sBuildingName);
 		Announcer_ShowAnnotation(iBuilding, sMessage);
 	}
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -325,10 +325,8 @@ methodmap CAnnouncerMinion < SaxtonHaleBase
 		if (boss.bValid)
 			boss.CallFunction("GetBossType", sType, sizeof(sType));
 		
-		PrintToChatAll("we here? type: %s", sType);
 		if (TF2_GetClientTeam(iBuilder) == TFTeam_Boss || StrEqual(sType, "CAnnouncerMinion"))
 		{
-			PrintToChatAll("how about here?");
 			damage = 0.0;
 			return Plugin_Stop;
 		}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -291,7 +291,7 @@ methodmap CGentleSpy < SaxtonHaleBase
 		Hud_SetColor(iClient, iColor);
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (damagetype & DMG_FALL && TF2_IsPlayerInCondition(this.iClient, TFCond_Cloaked))
 		{

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -119,7 +119,7 @@ methodmap CRedmond < SaxtonHaleBase
 		}
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		//Monos spell damage sucks, buff it
 		if (weapon > MaxClients)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -152,7 +152,7 @@ methodmap CYeti < SaxtonHaleBase
 		return Plugin_Continue;
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		// Prevent kill taunt
 		if (victim != this.iClient && damagecustom == TF_CUSTOM_TAUNT_HIGH_NOON)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
@@ -48,7 +48,7 @@ methodmap CZombie < SaxtonHaleBase
 			TF2_MakeBleed(iClient, iClient, 99999.0);
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (this.iClient != victim && GetClientTeam(this.iClient) != GetClientTeam(victim))
 		{

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
@@ -32,7 +32,7 @@ methodmap CModifiersElectric < SaxtonHaleBase
 		iColor[3] = 255;
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{		
 		if (TF2_IsUbercharged(victim)) return Plugin_Continue;
 		

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_hot.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_hot.sp
@@ -47,7 +47,7 @@ methodmap CModifiersHot < SaxtonHaleBase
 		}
 	}
 	
-	public Action OnAttackDamage(int &victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+	public Action OnAttackDamage(int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 	{
 		if (damagetype & DMG_BURN)
 		{

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -10,6 +10,7 @@ static Handle g_hSDKGetMaxClip;
 static Handle g_hSDKRemoveWearable;
 static Handle g_hSDKGetEquippedWearable;
 static Handle g_hSDKEquipWearable;
+static Handle g_hSDKAddObject;
 static Handle g_hSDKRemoveObject;
 
 static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1] = {-1, ...};
@@ -94,6 +95,14 @@ void SDK_Init()
 	g_hSDKGetMaxClip = EndPrepSDKCall();
 	if (g_hSDKGetMaxClip == null)
 		LogMessage("Failed to create call: CTFWeaponBase::GetMaxClip1!");
+
+	//This call is used to give an owner to a building
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::AddObject");
+	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
+	g_hSDKAddObject = EndPrepSDKCall();
+	if (g_hSDKAddObject == null)
+		LogMessage("Failed to create call: CTFPlayer::AddObject!");
 
 	//This call is used to remove a building's owner
 	StartPrepSDKCall(SDKCall_Player);
@@ -365,7 +374,13 @@ void SDK_EquipWearable(int client, int iWearable)
 		SDKCall(g_hSDKEquipWearable, client, iWearable);
 }
 
-int SDK_RemoveObject(int iClient, int iEntity)
+void SDK_AddObject(int iClient, int iEntity)
+{
+	if(g_hSDKAddObject != null)
+		SDKCall(g_hSDKAddObject, iClient, iEntity);
+}
+
+void SDK_RemoveObject(int iClient, int iEntity)
 {
 	if(g_hSDKRemoveObject != null)
 		SDKCall(g_hSDKRemoveObject, iClient, iEntity);

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -10,6 +10,7 @@ static Handle g_hSDKGetMaxClip;
 static Handle g_hSDKRemoveWearable;
 static Handle g_hSDKGetEquippedWearable;
 static Handle g_hSDKEquipWearable;
+static Handle g_hSDKRemoveObject;
 
 static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1] = {-1, ...};
 
@@ -93,6 +94,14 @@ void SDK_Init()
 	g_hSDKGetMaxClip = EndPrepSDKCall();
 	if (g_hSDKGetMaxClip == null)
 		LogMessage("Failed to create call: CTFWeaponBase::GetMaxClip1!");
+
+	//This call is used to remove a building's owner
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::RemoveObject");
+	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
+	g_hSDKRemoveObject = EndPrepSDKCall();
+	if (g_hSDKRemoveObject == null)
+		LogMessage("Failed to create call: CTFPlayer::RemoveObject!");
 
 	// This hook allows entity to always transmit
 	iOffset = hGameData.GetOffset("CBaseEntity::ShouldTransmit");
@@ -354,4 +363,10 @@ void SDK_EquipWearable(int client, int iWearable)
 {
 	if(g_hSDKEquipWearable != null)
 		SDKCall(g_hSDKEquipWearable, client, iWearable);
+}
+
+int SDK_RemoveObject(int iClient, int iEntity)
+{
+	if(g_hSDKRemoveObject != null)
+		SDKCall(g_hSDKRemoveObject, iClient, iEntity);
 }

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -336,15 +336,46 @@ stock int TF2_GetBuilding(int iClient, TFObjectType nType, TFObjectMode nMode = 
 	int iBuilding = MaxClients+1;
 	while ((iBuilding = FindEntityByClassname(iBuilding, "obj_*")) > MaxClients)
 	{
-		if (GetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder") == iClient
-			&& view_as<TFObjectType>(GetEntProp(iBuilding, Prop_Send, "m_iObjectType")) == nType
-			&& view_as<TFObjectMode>(GetEntProp(iBuilding, Prop_Send, "m_iObjectMode")) == nMode)
+		if (TF2_GetBuildingOwner(iBuilding) == iClient
+			&& TF2_GetBuildingType(iBuilding) == nType
+			&& TF2_GetBuildingMode(iBuilding) == nMode)
 		{
 			return iBuilding;
 		}
 	}
 	
 	return -1;
+}
+
+stock int TF2_GetBuildingOwner(int iBuilding)
+{
+	//There is the possibility that a map has buildings without ownership
+	return GetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder");
+}
+
+stock void TF2_SetBuildingOwner(int iBuilding, int iClient)
+{
+	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
+	{
+		SetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder", iClient);
+		SDK_AddObject(iClient, iBuilding);
+	}
+}
+
+stock TFObjectType TF2_GetBuildingType(int iBuilding)
+{
+	if (iBuilding > MaxClients)
+		return view_as<TFObjectType>(GetEntProp(iBuilding, Prop_Send, "m_iObjectType"));
+		
+	return TFObject_Invalid;
+}
+
+stock TFObjectMode TF2_GetBuildingMode(int iBuilding)
+{
+	if (iBuilding > MaxClients)
+		return view_as<TFObjectMode>(GetEntProp(iBuilding, Prop_Send, "m_iObjectMode"));
+		
+	return TFObjectMode_None;
 }
 
 stock void TF2_StunBuilding(int iBuilding, float flDuration)
@@ -358,6 +389,46 @@ public Action Timer_EnableBuilding(Handle timer, int iRef)
 	int iBuilding = EntRefToEntIndex(iRef);
 	if (iBuilding > MaxClients)
 		SetEntProp(iBuilding, Prop_Send, "m_bDisabled", false);
+}
+
+stock void TF2_SetBuildingTeam(int iBuilding, TFTeam nTeam, int iNewBuilder = -1)
+{
+	int iBuilder = TF2_GetBuildingOwner(iBuilding);
+	
+	//Remove the building from the original builder so it doesn't explode on team switch
+	SDK_RemoveObject(iBuilder, iBuilding);
+	
+	//Set its team. If we were attempting to do this by changing its TeamNum ent prop, Sentries would act derpy by actively trying to shoot itself
+	int iTeam = view_as<int>(nTeam);
+	SetVariantInt(iTeam);
+	AcceptEntityInput(iBuilding, "SetTeam");
+	
+	//Set a new builder and give them the building, if specified
+	TF2_SetBuildingOwner(iBuilding, iNewBuilder);
+	
+	//Mini-sentries use different skins, adjust accordingly
+	if (GetEntProp(iBuilding, Prop_Send, "m_bMiniBuilding"))
+		SetEntProp(iBuilding, Prop_Send, "m_nSkin", iTeam);
+	else
+		SetEntProp(iBuilding, Prop_Send, "m_nSkin", iTeam-2);
+	
+	TFObjectType nType = TF2_GetBuildingType(iBuilding);
+	
+	if (nType == TFObject_Dispenser)
+	{
+		//Disable the dispenser's screen, it's better than having it not change team color
+		int iScreen = MaxClients+1;
+		while ((iScreen = FindEntityByClassname(iScreen, "vgui_screen")) > MaxClients)
+		{
+			if (GetEntPropEnt(iScreen, Prop_Send, "m_hOwnerEntity") == iBuilding)
+				AcceptEntityInput(iScreen, "Kill");
+		}
+	}
+	else if (nType == TFObject_Teleporter)
+	{
+		//Disable teleporters for a little bit to reset the effects' colors
+		TF2_StunBuilding(iBuilding, 0.1);
+	}
 }
 
 stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTemp = NULL_STRING, int iLevel = 0, TFQuality iQuality = TFQual_Normal, char[] sAttrib = NULL_STRING, bool bAttrib = false)
@@ -609,6 +680,45 @@ stock int TF2_CreateLightEntity(float flRadius, int iColor[4], int iBrightness)
 	}
 	
 	return iGlow;
+}
+
+stock void TF2_ShowAnnotation(int[] iClients, int iCount, int iTarget, char[] sMessage, float flDuration = 5.0, char[] sSound = SOUND_NULL)
+{
+	//Create an annotation and show it to a specified array of clients
+	Event event = CreateEvent("show_annotation");
+	event.SetInt("follow_entindex", iTarget);
+	event.SetFloat("lifetime", flDuration);
+	event.SetString("text", sMessage);
+	event.SetString("play_sound", sSound);	//If this is missing, it'll try to play a sound with an empty soundpath
+	
+	for (int i = 0; i < iCount; i++)
+		event.FireToClient(iClients[i]);
+	
+	delete event;
+}
+
+stock void TF2_ShowAnnotationToAll(int iTarget, char[] sMessage, float flDuration = 5.0, char[] sSound = SOUND_NULL)
+{
+	//Create an annotation and show it to everyone. event.Fire() closes the handle on its own, so we don't need to do that here
+	Event event = CreateEvent("show_annotation");
+	event.SetInt("follow_entindex", iTarget);
+	event.SetFloat("lifetime", flDuration);
+	event.SetString("text", sMessage);
+	event.SetString("play_sound", sSound);
+	event.Fire();
+}
+
+stock void TF2_ShowAnnotationToClient(int iClient, int iTarget, char[] sMessage, float flDuration = 5.0, char[] sSound = SOUND_NULL)
+{
+	//Create an annotation and show it to a single client
+	Event event = CreateEvent("show_annotation");
+	event.SetInt("follow_entindex", iTarget);
+	event.SetFloat("lifetime", flDuration);
+	event.SetString("text", sMessage);
+	event.SetString("play_sound", sSound);
+	event.FireToClient(iClient);
+	
+	delete event;
 }
 
 stock void BroadcastSoundToTeam(TFTeam nTeam, const char[] strSound)


### PR DESCRIPTION
This PR addresses issue #102 and probably does a lot of things wrong unintentionally, sorry

Changes to Announcer:
Rage:
- Alongside having a sound, the boss will have an annotation bubble telling her who was hit and where they are until they get team-swapped if they're within the boss' line of sight
	- This annotation bubble shows up to the Announcer and all of her (living) minions, even if they're in the process of switching teams
	- Note that only one annotation bubble can show up at a time
- Hitting an Engineer will also convert all of his buildings to the boss' team
    - The boss can also hit individual buildings to instantly convert them without caring about the Engineer who owns it
	
Misc:
- Fixed voicelines for the following events not playing:
    - Killing
    - Getting backstabbed
    - Getting to the last man standing
    - Cheering minions who are getting kills on
	
Changes not exclusive to Announcer:
- Added a new boss function: `OnAttackBuilding`
    - Is called when damage is dealt to a building
    - Not tied to `OnAttackDamage` because I don't want to break 10 different bosses
	
Current issues:
- `OnAttackBuilding` could be improved by giving easy access to the building's owner and its type/mode or at the very least getting `victim` renamed to `building`, but I'm unsure if that should be done or not to keep it consistent with the other functions
- If a dispenser gets converted, its screen will disappear until rebuilt. This is done by the plugin, as otherwise the screen would be red instead.
- If a mini-sentry gets converted, the little siren particle will stay red until rebuilt. The siren itself will have the correct color so this is very, very minor.
- The windows signature for CTFPlayer::AddObject, used to give **true** ownership of buildings after Engineers get converted, is missing
    - To clarify, true ownership is lost in the first place so these buildings don't explode when the Engineer that owned them gets team-switched
    - By itself, not much goes wrong if it's missing, problem is that engies can build one more of the same building and can't destroy or pick up no-longer-owned buildings by themselves
    - If it is missing, a backup mechanic is in place: the building that was built but is no longer owned by this engie is destroyed if he tries to build a different instance of that active building

ty 42 for helping out :)