### PR TITLE
Give Vaccinator effects to medic itself instead of patient

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -21,6 +21,7 @@
 //- heal                  - Called when player attempts to healm only to medigun
 //
 //List of params to pass for calling to set values
+//- passive               - From 'attackdamage', always call this regardless of weapon used to damage boss
 //- perplayer             - From 'attackdamage' and 'takedamage', sets damage to X multiplied by amount of players
 //- set                   - From 'attackdamage' and 'takedamage', sets damage to X
 //- min                   - From 'attackdamage' and 'takedamage', min possible damage to be made
@@ -1528,7 +1529,7 @@
 		
 		"998"	//Vaccinator
 		{
-			"desp"			"Vaccinator: {positive}Each resistance gets patients the same effect as other Medi Guns, {negative}no area of range effect"
+			"desp"			"Vaccinator: {positive}Bullet resistance gives yourself uber, blast gives a damage bonus and fire a gives speed bonus, {negative}no area of range effect"
 			
 			"spawn"
 			{
@@ -1541,11 +1542,26 @@
 				
 				"Tags_AddCondVaccinator"
 				{
-					"target"		"patient"
-					"bullet"		"57"	//Uber
-					"blast"			"56"	//Kritz
-					"fire"			"32"	//Speed boost
-					"duration"		"2.5"	//2.5 seconds for cond
+					"target"		"client"		//Give conds to medic itself
+					"bullet"		"57"			//Uber
+					"blast"			"12"			//Damage buff
+					"fire"			"32"			//Speed boost
+					"duration"		"2.5"			//2.5 seconds for cond
+				}
+			}
+			
+			"attackdamage"
+			{
+				//Damage buff (cond 12) actually does nothing, just unused. Damage therefore need to manually be increased
+				"filter"
+				{
+					"cond"			"12"
+				}
+				
+				"params"
+				{
+					"passive"		"1"				//Enable damage multiplier for all weapons
+					"multiply"		"2.0"
 				}
 			}
 		}


### PR DESCRIPTION
Nobody can count how many times vaccinator has been rebalanced

We all know Vaccinator and Heavy can lead to certain death, lets give effects to medic itself instead.
Note that since medic already get full crit from primary and melee, 2x damage bonus is applied instead for blast resistance.