### PR TITLE
Remove damage knockback from all minigun

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -273,6 +273,14 @@
 			{
 				"desp"		"Primary: {positive}25% faster weapon switch and 25% faster spin up time"
 				"attrib"	"178 ; 0.75 ; 87 ; 0.75"
+				
+				"attackdamage"
+				{
+					"params"
+					{
+						"damagetype"	"noknockback"
+					}
+				}
 			}
 			
 			"Secondary"
@@ -1212,16 +1220,8 @@
 		
 		"312"	//Brass Beast
 		{
-			"desp"			"Brass Beast: {negative}No spin up time bonus, no knockback"
+			"desp"			"Brass Beast: {negative}No spin up time bonus"
 			"attrib"		"87 ; 1.0"
-			
-			"attackdamage"
-			{
-				"params"
-				{
-					"damagetype"	"noknockback"
-				}
-			}
 		}
 		
 		"424"	//Tomislav


### PR DESCRIPTION
Heavy don't need damage knockback, and nobody likes fighting against lone heavy standing ontop of bullshit spot with knockback to push boss off