### PR TITLE
Workaround fix for handling GiveNamedItem and TF2Items

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -12,10 +12,15 @@
 #include <tf2attributes>
 #include <tf_econ_data>
 #include <dhooks>
-#include "include/saxtonhale.inc"
+
+#undef REQUIRE_EXTENSIONS
+#tryinclude <tf2items>
+#define REQUIRE_EXTENSIONS
 
 #pragma semicolon 1
 #pragma newdecls required
+
+#include "include/saxtonhale.inc"
 
 #define PLUGIN_VERSION 					"1.3.0"
 #define PLUGIN_VERSION_REVISION 		"manual"
@@ -294,8 +299,9 @@ TFClassType g_nClassDisplay[sizeof(g_strClassName)] = {
 
 bool g_bEnabled;
 bool g_bRoundStarted;
-
 bool g_bSpecialRound;
+bool g_bTF2Items;
+
 TFClassType g_nSpecialRoundNextClass;
 
 int g_iSpritesLaserbeam;
@@ -457,6 +463,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 public void OnPluginStart()
 {
+	//OnLibraryAdded dont always call TF2Items on plugin start
+	g_bTF2Items = LibraryExists("TF2Items");
+	
 	AddMultiTargetFilter("@hale", BossTargetFilter, "all bosses", false);
 	AddMultiTargetFilter("@boss", BossTargetFilter, "all bosses", false);
 	AddMultiTargetFilter("@!hale", BossTargetFilter, "all non-bosses", false);
@@ -504,10 +513,10 @@ public void OnPluginStart()
 	FuncStack_Init();
 	Menu_Init();
 	NextBoss_Init();
+	SDK_Init();
 	TagsCall_Init();
 	TagsCore_Init();
 	TagsName_Init();
-	SDK_Init();
 	Winstreak_Init();
 	
 	SaxtonHaleFunction func;
@@ -690,8 +699,6 @@ public void OnPluginStart()
 	g_ConfigConvar.Create("vsh_boss_ping_limit", "200", "Max ping/latency to allow player to play as boss (-1 for no limit)", _, true, -1.0);
 	g_ConfigConvar.Create("vsh_telefrag_damage", "9001.0", "Damage amount to boss from telefrag", _, true, 0.0);
 	
-	Config_Refresh();
-	
 	//Incase of lateload, call client join functions
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
@@ -706,12 +713,35 @@ public void OnPluginStart()
 	}
 }
 
+public void OnLibraryAdded(const char[] sName)
+{
+	if (StrEqual(sName, "TF2Items"))
+	{
+		g_bTF2Items = true;
+		
+		//We cant allow TF2Items load while GiveNamedItem already hooked due to crash
+		if (SDK_IsGiveNamedItemActive())
+			PluginStop(true, "[VSH] DO NOT LOAD TF2ITEMS MIDGAME WHILE VSH IS ALREADY LOADED!!!!");
+	}
+}
+
+public void OnLibraryRemoved(const char[] sName)
+{
+	if (StrEqual(sName, "TF2Items"))
+	{
+		g_bTF2Items = false;
+		
+		//TF2Items unloaded with GiveNamedItem unhooked, we can now safely hook GiveNamedItem ourself
+		for (int iClient = 1; iClient <= MaxClients; iClient++)
+			if (IsClientInGame(iClient))
+				SDK_HookGiveNamedItem(iClient);
+	}
+}
+
 public void OnPluginEnd()
 {
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		SDK_UnhookClient(iClient);
-		
 		if (SaxtonHale_IsValidBoss(iClient))
 		{
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
@@ -1175,14 +1205,14 @@ public void OnClientDisconnect(int iClient)
 
 	g_iClientFlags[iClient] = 0;
 
+	SDK_UnhookGiveNamedItem(iClient);
+
 	ClassLimit_SetMainClass(iClient, TFClass_Unknown);
 	ClassLimit_SetDesiredClass(iClient, TFClass_Unknown);
 	
 	Preferences_SetAll(iClient, -1);
 	Queue_SetPlayerPoints(iClient, -1);
 	Winstreak_SetCurrent(iClient, -1);
-	
-	SDK_UnhookClient(iClient);
 }
 
 public void OnClientDisconnect_Post(int iClient)
@@ -1491,6 +1521,22 @@ public Action NormalSoundHook(int clients[MAXPLAYERS], int &numClients, char sam
 		if (boss.bValid)
 			return boss.CallFunction("OnSoundPlayed", clients, numClients, sample, channel, volume, level, pitch, flags, soundEntry, seed);
 	}
+	return Plugin_Continue;
+}
+
+public Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDefIndex, Handle &item)
+{
+	return GiveNamedItem(client, classname, itemDefIndex);
+}
+
+Action GiveNamedItem(int iClient, const char[] sClassname, int iIndex)
+{
+	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
+	if (boss.bValid)
+		return boss.CallFunction("OnGiveNamedItem", sClassname, iIndex);
+	else if (g_ConfigIndex.IsRestricted(iIndex))
+		return Plugin_Handled;
+	
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -237,8 +237,6 @@ public MRESReturn Hook_EntityShouldTransmit(int iEntity, Handle hReturn, Handle 
 
 public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams)
 {
-	PrintToServer("Hook_GiveNamedItem %N", iClient);
-	
 	if (DHookIsNullParam(hParams, 1) || DHookIsNullParam(hParams, 3))
 		return MRES_Ignored;
 	

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -13,7 +13,7 @@ static Handle g_hSDKEquipWearable;
 static Handle g_hSDKAddObject;
 static Handle g_hSDKRemoveObject;
 
-static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1] = {-1, ...};
+static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS+1];
 
 void SDK_Init()
 {
@@ -170,13 +170,28 @@ void SDK_Init()
 	delete hGameData;
 }
 
-void SDK_UnhookClient(int iClient)
+void SDK_HookGiveNamedItem(int iClient)
 {
-	if (g_iHookIdGiveNamedItem[iClient] != -1)
+	if (g_hHookGiveNamedItem && !g_bTF2Items)
+		g_iHookIdGiveNamedItem[iClient] = DHookEntity(g_hHookGiveNamedItem, false, iClient, Hook_GiveNamedItemRemoved, Hook_GiveNamedItem);
+}
+
+void SDK_UnhookGiveNamedItem(int iClient)
+{
+	if (g_iHookIdGiveNamedItem[iClient])
 	{
 		DHookRemoveHookID(g_iHookIdGiveNamedItem[iClient]);
-		g_iHookIdGiveNamedItem[iClient] = -1;	
+		g_iHookIdGiveNamedItem[iClient] = 0;	
 	}
+}
+
+bool SDK_IsGiveNamedItemActive()
+{
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+		if (g_iHookIdGiveNamedItem[iClient])
+			return true;
+	
+	return false;
 }
 
 void SDK_HookGetMaxHealth(int iClient)
@@ -189,12 +204,6 @@ void SDK_AlwaysTransmitEntity(int iEntity)
 {
 	if (g_hHookShouldTransmit)
 		DHookEntity(g_hHookShouldTransmit, true, iEntity);
-}
-
-void SDK_HookGiveNamedItem(int iClient)
-{
-	if (g_hHookGiveNamedItem)
-		g_iHookIdGiveNamedItem[iClient] = DHookEntity(g_hHookGiveNamedItem, false, iClient, Hook_GiveNamedItemRemoved, Hook_GiveNamedItem);
 }
 
 void SDK_HookBallImpact(int iEntity, DHookCallback callback)
@@ -228,6 +237,8 @@ public MRESReturn Hook_EntityShouldTransmit(int iEntity, Handle hReturn, Handle 
 
 public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams)
 {
+	PrintToServer("Hook_GiveNamedItem %N", iClient);
+	
 	if (DHookIsNullParam(hParams, 1) || DHookIsNullParam(hParams, 3))
 		return MRES_Ignored;
 	
@@ -235,19 +246,9 @@ public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams
 	DHookGetParamString(hParams, 1, sClassname, sizeof(sClassname));
 	int iIndex = DHookGetParamObjectPtrVar(hParams, 3, 4, ObjectValueType_Int) & 0xFFFF;
 	
-	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
-	if (boss.bValid)
+	Action action = GiveNamedItem(iClient, sClassname, iIndex);
+	if (action >= Plugin_Handled)
 	{
-		Action action = boss.CallFunction("OnGiveNamedItem", sClassname, iIndex);
-		if (action == Plugin_Handled)
-		{
-			DHookSetReturn(hReturn, 0);
-			return MRES_Supercede;
-		}
-	}
-	else if (g_ConfigIndex.IsRestricted(iIndex))
-	{
-		// Restrict weapons from config
 		DHookSetReturn(hReturn, 0);
 		return MRES_Supercede;
 	}
@@ -261,7 +262,7 @@ public void Hook_GiveNamedItemRemoved(int iHookId)
 	{
 		if (g_iHookIdGiveNamedItem[iClient] == iHookId)
 		{
-			g_iHookIdGiveNamedItem[iClient] = -1;
+			g_iHookIdGiveNamedItem[iClient] = 0;
 			return;
 		}
 	}


### PR DESCRIPTION
Fixes #116 

TF2Items hook GiveNamedItem using vp hooks, while DHooks done it differently. Whatever how those is done, SourceHook doesn't like when both is hooked at same time, eventually leading to a crash.

With that, VSH need to try its best to prevent GiveNamedItem hooked twice at same time.
TF2Items has been included optionally, and not required to compile. `TF2Items_OnGiveNamedItem` still works and called even when TF2Items not included, which is pretty epic.

When plugin starts, `LibraryExists` need to be used to check whenever if TF2Items is loaded or not, as `OnLibraryAdded` doesn't always call when plugin starts. Then DHooks need to initialize GiveNamedItem from gamedata, but that doesn't mean GiveNamedItem is already hooked from DHooks.

When client connects to server and TF2Items is loaded, `TF2Items_OnGiveNamedItem` is used. Otherwise DHooks hook client and uses this instead.

If TF2Items somehow unloaded midgame, GiveNamedItem is unhooked. Therefore from `OnLibraryRemoved`, we can safely rehook GiveNamedItem using DHooks.

If TF2Items is loaded midgame while DHooks already hook atleast one client, its too late. `OnLibraryAdded` is called after TF2Items hooked GiveNamedItem, meaning SourceHook get screwed up with GiveNamedItem hooked twice, eventually leading to server crash. Since we can't do anything about that, panic button is pressed (`PluginStop`), noting that this happened.