### PR TITLE
Make scare rage reset a victim's stun

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_scare.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_scare.sp
@@ -132,7 +132,12 @@ methodmap CScareRage < SaxtonHaleBase
 				float flDistance = GetVectorDistance(vecTargetPos, vecPos);
 				
 				if (flDistance <= flRadius)
-					TF2_StunPlayer(iVictim, flDuration, 0.1, iStunFlags, 0);
+				{
+					if (TF2_IsPlayerInCondition(iVictim, TFCond_Dazed))
+						TF2_RemoveCondition(iVictim, TFCond_Dazed);
+						
+					TF2_StunPlayer(iVictim, flDuration, 0.0, iStunFlags, 0);
+				}
 			}
 		}
 		


### PR DESCRIPTION
Addresses issue #2, as the FaN stuns you when it's being used, completely locking your movement if you get unlucky enough to get raged in a fraction of a second after jumping with it. The only downside I see to this is that bosses would let fullstunned people (slowly) move again, but you shouldn't rage at these people in the first place.

There is a more simple way to fix this but that involves not slowing scouts down as much and 42 doesn't like scout