### PR TITLE
Fix demoboots stomp damage not being set properly

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -994,6 +994,7 @@
 				
 				"params"
 				{
+					"passive"		"1"
 					"set"			"1024.0"	//Set stomp damage to 1024
 				}
 			}


### PR DESCRIPTION
Same reason as Thermal Thruster's, needs to be set as passive so the config catches it because weapon is taken as -1. Mantreads stomping works fine without this, though