### PR TITLE
Change Pain Train to suit the team dome mechanic

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -529,8 +529,8 @@
 		
 		"154"	//Pain Train
 		{
-			"desp"			"Pain Train: {positive}+30% health from healers, {negative}-50% health from health packs"
-			"attrib"		"70 ; 1.3 ; 109 ; 0.5 ; 68 ; 0.0 ; 67 ; 1.0"
+			"desp"			"Pain Train: {negative}+10% damage vulnerability from all sources"
+			"attrib"		"67 ; 1.0 ; 412 ; 1.1"
 		}
 
 		// SCOUT


### PR DESCRIPTION
Now that there's a control point to capture, the stock upside of the Pain Train shouldn't be touched, and this PR reverts it.
The +10% bullet vulnerability stat is changed to +10% general damage vulnerability so the weapon has an actual, yet simple, downside.