### PR TITLE
Fix Dragon Fury's airblast cooldown while under 100%

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1484,6 +1484,8 @@ void Client_OnButton(int iClient, int &buttons)
 	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 	if (boss.bValid)
 		boss.CallFunction("OnButton", buttons);
+	else
+		Tags_OnButton(iClient, buttons);
 }
 
 void Client_OnButtonPress(int iClient, int button)

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -221,6 +221,18 @@ void Tags_PlayerHurt(int iVictim, int iAttacker, int iDamage)
 	}
 }
 
+void Tags_OnButton(int iClient, int &iButtons)
+{
+	//Prevent clients holding m2 while airblast in cooldown
+	if (iButtons & IN_ATTACK2 && g_iTagsAirblastRequirement[iClient] > 0 && g_iTagsAirblastDamage[iClient] < g_iTagsAirblastRequirement[iClient])
+	{
+		int iPrimary = TF2_GetItemInSlot(iClient, WeaponSlot_Primary);
+		int iActiveWep = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
+		if (iActiveWep > MaxClients && iPrimary == iActiveWep)
+			iButtons &= ~IN_ATTACK2;
+	}
+}
+
 public Action Tags_OnProjectileTouch(int iProjectile, int iToucher)
 {
 	if (!g_bEnabled) return Plugin_Continue;


### PR DESCRIPTION
Fixes #83 

Simply just prevents client able to hold m2 while holding flamethrower and under 100%. Note that firstperson view will still look like attempting to airblast (while actually isn't), i don't think there a way to fix that.