### PR TITLE
Add new natives to set client boss/modifier/special class

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2038,8 +2038,8 @@
 		"vsh_force_load"            "-1"                //Force enable VSH on map start? (-1 for default, 0 for force unload, 1 for force load)
 		"vsh_telefrag_damage"       "4242.0"            //Damage amount to boss from telefrag
 		
-		"vsh_boss_chance_saxton"    "0.25"              //% chance for next boss to be Saxton Hale (0.0 - 1.0)
-		"vsh_boss_chance_multi"     "0.20"              //% chance for next boss to be Multiple bosses (after Saxton Hale roll) (0.0 - 1.0)
+		"vsh_boss_chance_saxton"    "0.30"              //% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)
+		"vsh_boss_chance_multi"     "0.15"              //% chance for next boss to be Multiple bosses (0.0 - 1.0)
 		"vsh_boss_chance_modifiers" "0.15"              //% chance for next boss to have random modifiers (0.0 - 1.0)
 		"vsh_boss_ping_limit"       "200"               //Max ping/latency to allow player play as boss
 		"vsh_boss_winstreak_health" "0.05"              //Percentage loss per winstreak to reduce boss healh

--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -547,14 +547,14 @@ methodmap SaxtonHaleNextBoss
 		public native set(bool val);
 	}
 	
-	// Retrieve/Set this boss round to be a special class
+	// Retrieve/Set this boss round to be a special class round
 	property bool bSpecialClassRound
 	{
 		public native get();
 		public native set(bool val);
 	}
 	
-	// Retrieve/Set this boss to play class if bSpecialClass is true, random class if TFClass_Unknown
+	// Retrieve/Set this boss to play class if bSpecialClassRound is true, random class if TFClass_Unknown
 	property TFClassType nSpecialClassType
 	{
 		public native get();

--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -494,6 +494,75 @@ native void SaxtonHale_GetParamArray(int iParam, any[] value, int iLength);
 native void SaxtonHale_SetParamArray(int iParam, const any[] value);
 
 /**
+ * Methodmap to force set next boss
+ */
+methodmap SaxtonHaleNextBoss
+{
+	//Creates new SaxtonHaleNextBoss to set boss, modifier and special round for next match in the list
+	//
+	// @note If valid client index, client's existing next boss is passed. Otherwise if client index is 0, new Next Boss is made.
+	//
+	// @param iClient       Client to specify, or 0 for next client in queue
+	// @return              Next Boss Methodmap to get and set next boss
+	public native SaxtonHaleNextBoss(int iClient = 0);
+	
+	//Gets current boss type
+	//
+	// @param sBossType     String value to get, NULL_STRING if not specified yet
+	// @param iLength       Size of string
+	public native void GetBoss(char[] sBossType, int iLength);
+	
+	//Sets new boss type
+	//
+	// @param sBossType     String value to set, NULL_STRING for random boss
+	public native void SetBoss(const char[] sBossType);
+	
+	//Gets current modifier type
+	//
+	// @param sModifierType String value to get, NULL_STRING if not specified yet
+	// @param iLength       Size of string
+	public native void GetModifier(char[] sModifierType, int iLength);
+	
+	//Sets new modifier type
+	//
+	// @param sModifierType String value to set, NULL_STRING for random modifier
+	public native void SetModifier(const char[] sModifierType);
+	
+	//Gets name to display in chat with client, boss and modifier
+	//
+	// @param sBuffer       String value to get
+	// @param iLength       Size of string
+	public native void GetName(char[] sBuffer, int iLength);
+	
+	// Retrieve client index to play as this boss
+	property int iClient
+	{
+		public native get();
+	}
+	
+	// Retrieve/Set this boss to force play next round
+	property bool bForceNext
+	{
+		public native get();
+		public native set(bool val);
+	}
+	
+	// Retrieve/Set this boss round to be a special class
+	property bool bSpecialClass
+	{
+		public native get();
+		public native set(bool val);
+	}
+	
+	// Retrieve/Set this boss to play class if bSpecialClass is true, random class if TFClass_Unknown
+	property TFClassType nSpecialClass
+	{
+		public native get();
+		public native set(TFClassType val);
+	}
+}
+
+/**
  * Forward called when boss got telefraged
  *
  * @param iBoss				Client boss whose got telefraged
@@ -574,15 +643,6 @@ native int SaxtonHale_GetDamage(int iClient);
  * @error                   Invalid client index or client not in game
  */
 native int SaxtonHale_GetAssistDamage(int iClient);
-
-/**
- * Force a special round on client next turn as boss
- *
- * @param iClient	        Client to force special round, 0 for next client in queue
- * @param nClass	        Class to force special round, TFClass_Unknown for random class
- * @return		        	True on success, false on fail
- */
-native bool SaxtonHale_ForceSpecialRound(int iClient = 0, TFClassType nClass = TFClass_Unknown);
 
 /**
  * Set whoever client all preferences
@@ -737,6 +797,9 @@ native void SaxtonHale_RegisterAbility(const char[] sAbilityType);
 #pragma deprecated Use SaxtonHale_UnregisterClass instead!
 native void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
 
+#pragma deprecated Use SaxtonHaleNextBoss property bSpecialClass and nSpecialClass instead!
+native bool SaxtonHale_ForceSpecialRound(int iClient = 0, TFClassType nClass = TFClass_Unknown);
+
 public SharedPlugin __pl_saxtonhale =
 {
 	name = "saxtonhale",
@@ -818,12 +881,25 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHale_GetParamArray");
 	MarkNativeAsOptional("SaxtonHale_SetParamArray");
 	
+	MarkNativeAsOptional("SaxtonHaleNextBoss.SaxtonHaleNextBoss");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.GetBoss");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.SetBoss");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.GetModifier");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.SetModifier");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.GetName");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.iClient.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bForceNext.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bForceNext.set");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClass.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClass.set");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClass.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClass.set");
+	
 	MarkNativeAsOptional("SaxtonHale_GetBossTeam");
 	MarkNativeAsOptional("SaxtonHale_GetAttackTeam");
 	MarkNativeAsOptional("SaxtonHale_GetMainClass");
 	MarkNativeAsOptional("SaxtonHale_GetDamage");
 	MarkNativeAsOptional("SaxtonHale_GetAssistDamage");
-	MarkNativeAsOptional("SaxtonHale_ForceSpecialRound");
 	MarkNativeAsOptional("SaxtonHale_SetPreferences");
 	MarkNativeAsOptional("SaxtonHale_SetQueue");
 	MarkNativeAsOptional("SaxtonHale_SetWinstreak");
@@ -838,5 +914,6 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHale_UnregisterModifiers");
 	MarkNativeAsOptional("SaxtonHale_RegisterAbility");
 	MarkNativeAsOptional("SaxtonHale_UnregisterAbility");
+	MarkNativeAsOptional("SaxtonHale_ForceSpecialRound");
 }
 #endif

--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -548,14 +548,14 @@ methodmap SaxtonHaleNextBoss
 	}
 	
 	// Retrieve/Set this boss round to be a special class
-	property bool bSpecialClass
+	property bool bSpecialClassRound
 	{
 		public native get();
 		public native set(bool val);
 	}
 	
 	// Retrieve/Set this boss to play class if bSpecialClass is true, random class if TFClass_Unknown
-	property TFClassType nSpecialClass
+	property TFClassType nSpecialClassType
 	{
 		public native get();
 		public native set(TFClassType val);
@@ -890,10 +890,10 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHaleNextBoss.iClient.get");
 	MarkNativeAsOptional("SaxtonHaleNextBoss.bForceNext.get");
 	MarkNativeAsOptional("SaxtonHaleNextBoss.bForceNext.set");
-	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClass.get");
-	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClass.set");
-	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClass.get");
-	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClass.set");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClassRound.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.bSpecialClassRound.set");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClassType.get");
+	MarkNativeAsOptional("SaxtonHaleNextBoss.nSpecialClassType.set");
 	
 	MarkNativeAsOptional("SaxtonHale_GetBossTeam");
 	MarkNativeAsOptional("SaxtonHale_GetAttackTeam");

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -312,8 +312,8 @@ enum struct NextBoss
 	char sBossType[MAX_TYPE_CHAR];		//Boss to play on next turn
 	char sModifierType[MAX_TYPE_CHAR];	//Modifier to play on next turn
 	bool bForceNext;					//This client will be boss next round
-	bool bSpecialClass;					//All-Class on next turn
-	TFClassType nSpecialClass;			//If bSpecialClass, class to force, or TFClass_Unknown for random all-class
+	bool bSpecialClassRound;			//All-Class on next turn
+	TFClassType nSpecialClassType;		//If bSpecialClassRound, class to force, or TFClass_Unknown for random all-class
 }
 
 ArrayList g_aNextBoss;	//Arrays of NextBoss struct

--- a/addons/sourcemod/scripting/vsh/command.sp
+++ b/addons/sourcemod/scripting/vsh/command.sp
@@ -380,8 +380,7 @@ public Action Command_ForceSpecialRound(int iClient, int iArgs)
 		if (iArgs < 1)
 		{
 			Format(sClass, sizeof(sClass), "random");
-			g_bSpecialRound = true;
-			g_nSpecialRoundNextClass = TFClass_Unknown;
+			NextBoss_SetSpecialClass(TFClass_Unknown);
 		}
 		else
 		{
@@ -395,8 +394,7 @@ public Action Command_ForceSpecialRound(int iClient, int iArgs)
 			}
 			
 			Format(sClass, sizeof(sClass), g_strClassName[nClass]);
-			g_bSpecialRound = true;
-			g_nSpecialRoundNextClass = nClass;
+			NextBoss_SetSpecialClass(nClass);
 		}
 		
 		PrintToChatAll("%s%s %N force set next round a %s special round!", TEXT_TAG, TEXT_COLOR, iClient, sClass);

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -283,7 +283,7 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 		
 		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iNextPlayer);
 		
-		if (nextBoss.bSpecialClass)
+		if (nextBoss.bSpecialClassRound)
 			Format(sFormat, sizeof(sFormat), "%sYour round will be a special class round", sFormat);
 		else if (!Preferences_Get(iNextPlayer, Preferences_Winstreak))
 			Format(sFormat, sizeof(sFormat), "%sYour winstreak preference is currently disabled", sFormat);

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -98,7 +98,7 @@ public Action Event_RoundStart(Event event, const char[] sName, bool bDontBroadc
 		TF2_ForceTeamJoin(iClient, TFTeam_Attack);
 	}
 
-	PickNextBoss();	//Set boss
+	NextBoss_SetNextBoss();	//Set boss
 
 	g_iTotalAttackCount = SaxtonHale_GetAliveAttackPlayers();	//Update amount of attack players
 
@@ -280,9 +280,11 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 	{
 		char sFormat[512];
 		Format(sFormat, sizeof(sFormat), "%s================\nYou are about to be the next boss!\n", TEXT_COLOR);
-
-		if (g_bPlayerTriggerSpecialRound[iNextPlayer])
-			Format(sFormat, sizeof(sFormat), "%sYour round will be a special round", sFormat);
+		
+		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iNextPlayer);
+		
+		if (nextBoss.bSpecialClass)
+			Format(sFormat, sizeof(sFormat), "%sYour round will be a special class round", sFormat);
 		else if (!Preferences_Get(iNextPlayer, Preferences_Winstreak))
 			Format(sFormat, sizeof(sFormat), "%sYour winstreak preference is currently disabled", sFormat);
 		else if (Winstreak_IsAllowed(iNextPlayer))

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -9,10 +9,10 @@ void Native_AskLoad()
 	CreateNative("SaxtonHaleNextBoss.iClient.get", Native_NextBoss_GetClient);
 	CreateNative("SaxtonHaleNextBoss.bForceNext.get", Native_NextBoss_GetForceNext);
 	CreateNative("SaxtonHaleNextBoss.bForceNext.set", Native_NextBoss_SetForceNext);
-	CreateNative("SaxtonHaleNextBoss.bSpecialClass.get", Native_NextBoss_GetSpecialClass);
-	CreateNative("SaxtonHaleNextBoss.bSpecialClass.set", Native_NextBoss_SetSpecialClass);
-	CreateNative("SaxtonHaleNextBoss.nSpecialClass.get", Native_NextBoss_GetClass);
-	CreateNative("SaxtonHaleNextBoss.nSpecialClass.set", Native_NextBoss_SetClass);
+	CreateNative("SaxtonHaleNextBoss.bSpecialClassRound.get", Native_NextBoss_GetSpecialClassRound);
+	CreateNative("SaxtonHaleNextBoss.bSpecialClassRound.set", Native_NextBoss_SetSpecialClassRound);
+	CreateNative("SaxtonHaleNextBoss.nSpecialClassType.get", Native_NextBoss_GetSpecialClassType);
+	CreateNative("SaxtonHaleNextBoss.nSpecialClassType.set", Native_NextBoss_SetSpecialClassType);
 	
 	CreateNative("SaxtonHale_GetBossTeam", Native_GetBossTeam);
 	CreateNative("SaxtonHale_GetAttackTeam", Native_GetAttackTeam);
@@ -148,45 +148,45 @@ public any Native_NextBoss_SetForceNext(Handle hPlugin, int iNumParams)
 	NextBoss_SetStruct(nextBoss);
 }
 
-//bool SaxtonHaleNextBoss.bSpecialClass.get();
-public any Native_NextBoss_GetSpecialClass(Handle hPlugin, int iNumParams)
+//bool SaxtonHaleNextBoss.bSpecialClassRound.get();
+public any Native_NextBoss_GetSpecialClassRound(Handle hPlugin, int iNumParams)
 {
 	NextBoss nextBoss;
 	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
 	
-	return nextBoss.bSpecialClass;
+	return nextBoss.bSpecialClassRound;
 }
 
-//void SaxtonHaleNextBoss.bSpecialClass.set(bool val);
-public any Native_NextBoss_SetSpecialClass(Handle hPlugin, int iNumParams)
+//void SaxtonHaleNextBoss.bSpecialClassRound.set(bool val);
+public any Native_NextBoss_SetSpecialClassRound(Handle hPlugin, int iNumParams)
 {
 	NextBoss nextBoss;
 	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
 	
-	nextBoss.bSpecialClass = GetNativeCell(2);
+	nextBoss.bSpecialClassRound = GetNativeCell(2);
 	NextBoss_SetStruct(nextBoss);
 }
 
-//TFClassType SaxtonHaleNextBoss.nSpecialClass.get();
-public any Native_NextBoss_GetClass(Handle hPlugin, int iNumParams)
+//TFClassType SaxtonHaleNextBoss.nSpecialClassType.get();
+public any Native_NextBoss_GetSpecialClassType(Handle hPlugin, int iNumParams)
 {
 	NextBoss nextBoss;
 	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
 	
-	return nextBoss.nSpecialClass;
+	return nextBoss.nSpecialClassType;
 }
 
-//void SaxtonHaleNextBoss.nSpecialClass.set(bool val);
-public any Native_NextBoss_SetClass(Handle hPlugin, int iNumParams)
+//void SaxtonHaleNextBoss.nSpecialClassType.set(bool val);
+public any Native_NextBoss_SetSpecialClassType(Handle hPlugin, int iNumParams)
 {
 	NextBoss nextBoss;
 	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
 	
-	nextBoss.nSpecialClass = GetNativeCell(2);
+	nextBoss.nSpecialClassType = GetNativeCell(2);
 	NextBoss_SetStruct(nextBoss);
 }
 
@@ -335,11 +335,11 @@ public any Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
 	{
 		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iClient);
-		if (nextBoss.bSpecialClass)
+		if (nextBoss.bSpecialClassRound)
 			return false;
 		
-		nextBoss.bSpecialClass = true;
-		nextBoss.nSpecialClass = nClass;
+		nextBoss.bSpecialClassRound = true;
+		nextBoss.nSpecialClassType = nClass;
 		return true;
 	}
 	

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -1,5 +1,19 @@
 void Native_AskLoad()
 {
+	CreateNative("SaxtonHaleNextBoss.SaxtonHaleNextBoss", Native_NextBoss);
+	CreateNative("SaxtonHaleNextBoss.GetBoss", Native_NextBoss_GetBoss);
+	CreateNative("SaxtonHaleNextBoss.SetBoss", Native_NextBoss_SetBoss);
+	CreateNative("SaxtonHaleNextBoss.GetModifier", Native_NextBoss_GetModifier);
+	CreateNative("SaxtonHaleNextBoss.SetModifier", Native_NextBoss_SetModifier);
+	CreateNative("SaxtonHaleNextBoss.GetName", Native_NextBoss_GetName);
+	CreateNative("SaxtonHaleNextBoss.iClient.get", Native_NextBoss_GetClient);
+	CreateNative("SaxtonHaleNextBoss.bForceNext.get", Native_NextBoss_GetForceNext);
+	CreateNative("SaxtonHaleNextBoss.bForceNext.set", Native_NextBoss_SetForceNext);
+	CreateNative("SaxtonHaleNextBoss.bSpecialClass.get", Native_NextBoss_GetSpecialClass);
+	CreateNative("SaxtonHaleNextBoss.bSpecialClass.set", Native_NextBoss_SetSpecialClass);
+	CreateNative("SaxtonHaleNextBoss.nSpecialClass.get", Native_NextBoss_GetClass);
+	CreateNative("SaxtonHaleNextBoss.nSpecialClass.set", Native_NextBoss_SetClass);
+	
 	CreateNative("SaxtonHale_GetBossTeam", Native_GetBossTeam);
 	CreateNative("SaxtonHale_GetAttackTeam", Native_GetAttackTeam);
 	CreateNative("SaxtonHale_GetMainClass", Native_GetMainClass);
@@ -12,6 +26,168 @@ void Native_AskLoad()
 	CreateNative("SaxtonHale_IsWinstreakEnable", Native_IsWinstreakEnable);
 	CreateNative("SaxtonHale_SetAdmin", Native_SetAdmin);
 	CreateNative("SaxtonHale_SetPunishment", Native_SetPunishment);
+}
+
+//SaxtonHaleNextBoss SaxtonHaleNextBoss.SaxtonHaleNextBoss(int iClient = 0);
+public any Native_NextBoss(Handle hPlugin, int iNumParams)
+{
+	return NextBoss_CreateStruct(GetNativeCell(1));
+}
+
+//void SaxtonHaleNextBoss.GetBoss(char[] sBossType, int iLength);
+public any Native_NextBoss_GetBoss(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	SetNativeString(2, nextBoss.sBossType, GetNativeCell(3));
+}
+
+//void SaxtonHaleNextBoss.SetBoss(const char[] sBossType);
+public any Native_NextBoss_SetBoss(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	GetNativeString(2, nextBoss.sBossType, sizeof(nextBoss.sBossType));
+	NextBoss_SetStruct(nextBoss);
+}
+
+//void SaxtonHaleNextBoss.GetModifier(char[] sModifierType, int iLength);
+public any Native_NextBoss_GetModifier(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	SetNativeString(2, nextBoss.sModifierType, GetNativeCell(3));
+}
+
+//void SaxtonHaleNextBoss.SetModifier(const char[] sModifierType);
+public any Native_NextBoss_SetModifier(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	GetNativeString(2, nextBoss.sModifierType, sizeof(nextBoss.sModifierType));
+	NextBoss_SetStruct(nextBoss);
+}
+
+//void SaxtonHaleNextBoss.GetName(char[] sBuffer, int iLength);
+public any Native_NextBoss_GetName(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	int iLength = GetNativeCell(3);
+	char[] sBuffer = new char[iLength];
+	char[] sBossName = new char[iLength];
+	char[] sModifiersName = new char[iLength];
+	
+	if (0 < nextBoss.iClient <= MaxClients && IsClientInGame(nextBoss.iClient))
+		Format(sBuffer, iLength, "%s%N as ", sBuffer, nextBoss.iClient);
+	
+	//If boss not set, display as "random (modifiers) boss"
+	if (StrEmpty(nextBoss.sBossType))
+	{
+		Format(sBuffer, iLength, "%sRandom ", sBuffer);
+		Format(sBossName, iLength, "Boss");
+	}
+	else
+	{
+		SaxtonHaleBase boss = SaxtonHaleBase(0);
+		boss.CallFunction("SetBossType", nextBoss.sBossType);
+		boss.CallFunction("GetBossName", sBossName, iLength);
+	}
+	
+	if (!StrEmpty(nextBoss.sModifierType) && !StrEqual(nextBoss.sModifierType, "CModifiersNone"))
+	{
+		SaxtonHaleBase boss = SaxtonHaleBase(0);
+		boss.CallFunction("SetModifiersType", nextBoss.sModifierType);
+		boss.CallFunction("GetModifiersName", sModifiersName, iLength);
+		
+		Format(sBuffer, iLength, "%s%s ", sBuffer, sModifiersName);
+	}
+	
+	Format(sBuffer, iLength, "%s%s", sBuffer, sBossName);
+	SetNativeString(2, sBuffer, iLength);
+}
+
+//int SaxtonHaleNextBoss.iClient.get();
+public any Native_NextBoss_GetClient(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	return nextBoss.iClient;
+}
+
+//bool SaxtonHaleNextBoss.bForceNext.get();
+public any Native_NextBoss_GetForceNext(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	return nextBoss.bForceNext;
+}
+
+//void SaxtonHaleNextBoss.bForceNext.set(bool val);
+public any Native_NextBoss_SetForceNext(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	nextBoss.bForceNext = GetNativeCell(2);
+	NextBoss_SetStruct(nextBoss);
+}
+
+//bool SaxtonHaleNextBoss.bSpecialClass.get();
+public any Native_NextBoss_GetSpecialClass(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	return nextBoss.bSpecialClass;
+}
+
+//void SaxtonHaleNextBoss.bSpecialClass.set(bool val);
+public any Native_NextBoss_SetSpecialClass(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	nextBoss.bSpecialClass = GetNativeCell(2);
+	NextBoss_SetStruct(nextBoss);
+}
+
+//TFClassType SaxtonHaleNextBoss.nSpecialClass.get();
+public any Native_NextBoss_GetClass(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	return nextBoss.nSpecialClass;
+}
+
+//void SaxtonHaleNextBoss.nSpecialClass.set(bool val);
+public any Native_NextBoss_SetClass(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	nextBoss.nSpecialClass = GetNativeCell(2);
+	NextBoss_SetStruct(nextBoss);
 }
 
 //TFTeam SaxtonHale_GetBossTeam();
@@ -60,29 +236,6 @@ public any Native_GetAssistDamage(Handle hPlugin, int iNumParams)
 		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in game", iClient);
 	
 	return g_iPlayerAssistDamage[iClient];
-}
-
-//bool SaxtonHale_ForceSpecialRound(int iClient=0, TFClassType nClass=TFClass_Unknown);
-public any Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
-{
-	int iClient = GetNativeCell(1);
-	TFClassType nClass = GetNativeCell(2);
-
-	if (iClient == 0)
-	{
-		g_bSpecialRound = true;
-		g_nSpecialRoundNextClass = nClass;
-		return true;
-	}
-	
-	if (0 < iClient <= MaxClients && IsClientInGame(iClient) && !g_bPlayerTriggerSpecialRound[iClient])
-	{
-		g_bPlayerTriggerSpecialRound[iClient] = true;
-		g_nSpecialRoundNextClass = nClass;
-		return true;
-	}
-
-	return false;
 }
 
 //void SaxtonHale_SetPreferences(int iClient, int iPreferences);
@@ -165,4 +318,30 @@ public any Native_SetPunishment(Handle hPlugin, int iNumParams)
 		Client_AddFlag(iClient, ClientFlags_Punishment);
 	else
 		Client_RemoveFlag(iClient, ClientFlags_Punishment);
+}
+
+//bool SaxtonHale_ForceSpecialRound(int iClient=0, TFClassType nClass=TFClass_Unknown);
+public any Native_ForceSpecialRound(Handle hPlugin, int iNumParams)
+{
+	int iClient = GetNativeCell(1);
+	TFClassType nClass = GetNativeCell(2);
+	
+	if (iClient == 0)
+	{
+		NextBoss_SetSpecialClass(nClass);
+		return true;
+	}
+	
+	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
+	{
+		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iClient);
+		if (nextBoss.bSpecialClass)
+			return false;
+		
+		nextBoss.bSpecialClass = true;
+		nextBoss.nSpecialClass = nClass;
+		return true;
+	}
+	
+	return false;
 }

--- a/addons/sourcemod/scripting/vsh/nextboss.sp
+++ b/addons/sourcemod/scripting/vsh/nextboss.sp
@@ -1,174 +1,184 @@
 static ArrayList g_aNextBossMulti;
+static bool g_bNextBossSpecialClass;
+static TFClassType g_nNextBossSpecialClass;
 
 void NextBoss_Init()
 {
+	g_aNextBoss = new ArrayList(sizeof(NextBoss));
 	g_aNextBossMulti = new ArrayList();
 	
-	g_ConfigConvar.Create("vsh_boss_chance_saxton", "0.25", "% chance for next boss to be Saxton Hale (0.0 - 1.0)", _, true, 0.0, true, 1.0);
-	g_ConfigConvar.Create("vsh_boss_chance_multi", "0.20", "% chance for next boss to be multiple bosses (after Saxton Hale roll) (0.0 - 1.0)", _, true, 0.0, true, 1.0);
+	g_ConfigConvar.Create("vsh_boss_chance_saxton", "0.25", "% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)", _, true, 0.0, true, 1.0);
+	g_ConfigConvar.Create("vsh_boss_chance_multi", "0.20", "% chance for next boss to be multiple bosses (0.0 - 1.0)", _, true, 0.0, true, 1.0);
 	g_ConfigConvar.Create("vsh_boss_chance_modifiers", "0.15", "% chance for next boss to have random modifiers (0.0 - 1.0)", _, true, 0.0, true, 1.0);
 }
 
-void PickNextBoss()
+int NextBoss_CreateStruct(int iClient)
 {
-	//Get every non-specs
+	int iIndex = g_aNextBoss.FindValue(iClient, 1);	//assuming iClient is at 1 pos of struct
+	if (iIndex >= 0)
+	{
+		NextBoss nextBoss;
+		g_aNextBoss.GetArray(iIndex, nextBoss);
+		return nextBoss.iId;
+	}
+	
+	g_iNextBossId++;
+	
+	NextBoss nextBoss;
+	nextBoss.iId = g_iNextBossId;
+	nextBoss.iClient = iClient;
+	nextBoss.sBossType = NULL_STRING;
+	nextBoss.sModifierType = NULL_STRING;
+	
+	g_aNextBoss.PushArray(nextBoss);
+	return g_iNextBossId;
+}
+
+bool NextBoss_GetStruct(int iId, NextBoss nextBoss)
+{
+	int iIndex = g_aNextBoss.FindValue(iId, 0);	//assuming iId is at 0 pos of struct
+	if (iIndex < 0)
+		return false;
+	
+	g_aNextBoss.GetArray(iIndex, nextBoss);
+	return true;
+}
+
+void NextBoss_SetStruct(NextBoss nextBoss)
+{
+	int iIndex = g_aNextBoss.FindValue(nextBoss.iId, 0);	//assuming iId is at 0 pos of struct
+	if (iIndex >= 0)
+		g_aNextBoss.SetArray(iIndex, nextBoss);
+}
+
+void NextBoss_Delete(SaxtonHaleNextBoss nextBoss)
+{
+	int iIndex = g_aNextBoss.FindValue(nextBoss, 0);	//assuming iId is at 0 pos of struct
+	if (iIndex >= 0)
+		g_aNextBoss.Erase(iIndex);
+}
+
+void NextBoss_DeleteClient(int iClient)
+{
+	int iIndex = g_aNextBoss.FindValue(iClient, 1);	//assuming iClient is at 1 pos of struct
+	if (iIndex >= 0)
+		g_aNextBoss.Erase(iIndex);
+}
+
+void NextBoss_SetSpecialClass(TFClassType nClass)
+{
+	g_bNextBossSpecialClass = true;
+	g_nNextBossSpecialClass = nClass;
+}
+
+void NextBoss_SetNextBoss()
+{
+	//Get every non-specs and randomize incase we have to pick random player
 	ArrayList aClients = new ArrayList();
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
-		if (IsClientInGame(iClient) && GetClientTeam(iClient) > 1)
+		if (IsClientInGame(iClient) && TF2_GetClientTeam(iClient) > TFTeam_Spectator)
 			aClients.Push(iClient);
 	
-	//Randomize incase we have to pick random player
 	aClients.Sort(Sort_Random, Sort_Integer);
 	
-	//Find main boss
-	int iMainBoss = 0;
-	int iArray = 0;
-	while (g_aNextBoss.Length > iArray && iMainBoss == 0)
-	{
-		//Get "main" boss
-		NextBoss nextStruct;
-		g_aNextBoss.GetArray(iArray, nextStruct);
-		iMainBoss = GetClientOfUserId(nextStruct.iUserId);	//Should return 0 if invalid userid
-		
-		iArray++;
-	}
+	bool bForceSet;
+	int iMainBoss;
 	
-	//If next player not force set as boss, get one from queue
-	if (iMainBoss <= 0 || iMainBoss > MaxClients || !IsClientInGame(iMainBoss))
+	//Check if there any client bosses force set for this round
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		iMainBoss = Queue_GetPlayerFromRank(1);
-		if (iMainBoss <= 0 || iMainBoss > MaxClients || !IsClientInGame(iMainBoss))
+		if (IsClientInGame(iClient))
 		{
-			PrintToChatAll("%s%s Unable to find player in queue to become boss! %sPicking random player...", TEXT_TAG, TEXT_ERROR, TEXT_COLOR);
-			iMainBoss = aClients.Get(0);
+			SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iClient);
+			if (nextBoss.bForceNext)
+			{
+				NextBoss_SetBoss(nextBoss, aClients);
+				bForceSet = true;
+			}
 		}
 	}
 	
-	//Check if next boss is not force set
-	if (g_aNextBoss.Length == 0)
+	//If there no force set, pick one from highest queue
+	if (!bForceSet)
 	{
-		char sBoss[MAX_TYPE_CHAR];
+		iMainBoss = NextBoss_GetNextClient(aClients);
 		ArrayList aMultiBoss;
 		
-		if (GetRandomFloat(0.0, 1.0) <= g_ConfigConvar.LookupFloat("vsh_boss_chance_saxton"))
-		{
-			//Saxton Hale
-			NextBoss nextStruct;
-			Format(nextStruct.sBoss, sizeof(nextStruct.sBoss), "CSaxtonHale");
-			g_aNextBoss.PushArray(nextStruct);
-		}
-		else if (Preferences_Get(iMainBoss, Preferences_MultiBoss)
+		//Roll for multi boss
+		if (Preferences_Get(iMainBoss, Preferences_MultiBoss)
 			&& GetRandomFloat(0.0, 1.0) <= g_ConfigConvar.LookupFloat("vsh_boss_chance_multi")
 			&& (aMultiBoss = NextBoss_GetRandomMulti()))
 		{
-			//Random multiple bosses
-			int iLength = aMultiBoss.Length;
-			for (int i = 0; i < iLength; i++)
+			int iRank = 1;
+			int iMultiBossLength = aMultiBoss.Length;
+			for (int i = 0; i < iMultiBossLength; i++)
 			{
-				aMultiBoss.GetString(i, sBoss, sizeof(sBoss));
-				
-				NextBoss nextStruct;
-				Format(nextStruct.sBoss, sizeof(nextStruct.sBoss), sBoss);
-				g_aNextBoss.PushArray(nextStruct);
+				int iClient = -1;
+				while (iClient == -1)
+				{
+					iClient = NextBoss_GetNextClient(aClients, iRank);
+					
+					if (!Preferences_Get(iClient, Preferences_MultiBoss))
+					{
+						//Client dont want to play as multi boss, skip
+						iClient = -1;
+						iRank++;
+					}
+					else
+					{
+						//Set client to play as multi boss
+						SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iClient);
+						
+						char sBossType[MAX_TYPE_CHAR];
+						aMultiBoss.GetString(0, sBossType, sizeof(sBossType));
+						
+						nextBoss.SetBoss(sBossType);
+						NextBoss_SetBoss(nextBoss, aClients);
+					}
+				}
 			}
 		}
 		else
 		{
-			NextBoss_GetRandomNormal(sBoss, sizeof(sBoss));
-			
+			//Set client to play as normal boss
+			SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iMainBoss);
+			NextBoss_SetBoss(nextBoss, aClients);
+		}
+	}
+	else
+	{
+		//Fill any boss for next round, but with missing client
+		int iLength = g_aNextBoss.Length;
+		for (int i = 0; i < iLength; i++)
+		{
 			NextBoss nextStruct;
-			Format(nextStruct.sBoss, sizeof(nextStruct.sBoss), sBoss);
-			g_aNextBoss.PushArray(nextStruct);
+			g_aNextBoss.GetArray(i, nextStruct);
+			
+			if (!nextStruct.bForceNext)
+				continue;
+			
+			nextStruct.iClient = NextBoss_GetNextClient(aClients);
+			g_aNextBoss.SetArray(i, nextStruct);
+			
+			SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(nextStruct.iClient);
+			NextBoss_SetBoss(nextBoss, aClients);
 		}
 	}
 	
-	int iRank = 1;
-	int iBossCount = g_aNextBoss.Length;
-	//Loop though and check if all client, boss and modifiers has been set
-	for (int i = 0; i < iBossCount; i++)
-	{
-		NextBoss nextStruct;
-		g_aNextBoss.GetArray(i, nextStruct);
-		
-		//Check if client has been selected yet, and still in game
-		int iClient = GetClientOfUserId(nextStruct.iUserId);
-		if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
-		{
-			iClient = -1;
-			while (iClient == -1 && aClients.Length > 0)
-			{
-				iClient = Queue_GetPlayerFromRank(iRank);
-				
-				//If cant find in list, get player from array sorted at random
-				if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
-					iClient = aClients.Get(0);
-				
-				//If were not at first boss to set, we assume there duo boss going on, dont select one with pref disabled
-				else if (i > 0 && !Preferences_Get(iClient, Preferences_MultiBoss))
-					iClient = -1;
-				
-				if (0 < iClient <= MaxClients && IsClientInGame(iClient))
-				{
-					nextStruct.iUserId = GetClientUserId(iClient);
-					
-					//Erase client in list
-					int iIndex = aClients.FindValue(iClient);
-					if (iIndex >= 0) aClients.Erase(iIndex);
-				}
-				
-				iRank++;
-			}
-		}
-		
-		//Get random non-duo boss
-		if (StrEmpty(nextStruct.sBoss))
-			NextBoss_GetRandomNormal(nextStruct.sBoss, sizeof(nextStruct.sBoss));
-		
-		//Get random modifiers
-		if (StrEmpty(nextStruct.sModifiers))
-			NextBoss_GetRandomModifiers(nextStruct.sModifiers, sizeof(nextStruct.sModifiers));
-		
-		g_aNextBoss.SetArray(i, nextStruct);
-	}
-	
-	//Loop again to actually set boss
-	for (int i = 0; i < iBossCount; i++)
-	{
-		NextBoss nextStruct;
-		g_aNextBoss.GetArray(i, nextStruct);
-		
-		int iClient = GetClientOfUserId(nextStruct.iUserId);
-		if (iClient <= 0 || iClient > MaxClients || !IsClientInGame(iClient))
-		{
-			char sError[256];
-			Format(sError, sizeof(sError), "[VSH] INVALID NEXT BOSS CLIENT %d, USERID %d", iClient, nextStruct.iUserId);
-			PluginStop(true, sError);
-			return;
-		}
-		
-		//Set boss
-		SetBoss(iClient, nextStruct.sBoss, nextStruct.sModifiers);
-		
-		// Reset their points
-		Queue_ResetPlayer(iClient);
-		
-		// Enable special round if triggered
-		if (g_bPlayerTriggerSpecialRound[iClient])
-		{
-			g_bSpecialRound = true;
-			g_bPlayerTriggerSpecialRound[iClient] = false;
-		}
-	}
-	
-	//Whipe all next boss data
-	g_aNextBoss.Clear();
 	delete aClients;
 	
 	//Get amount of valid bosses after set
 	int iBosses = 0;
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
+	{
 		if (SaxtonHale_IsValidBoss(iClient, false))
+		{
 			iBosses++;
+			
+			if (!iMainBoss)
+				iMainBoss = iClient;
+		}
+	}
 	
 	if (iBosses == 0)
 	{
@@ -191,21 +201,16 @@ void PickNextBoss()
 		}
 	}
 	
-	// Check if special round is set after setting boss
-	if (g_bSpecialRound || g_nSpecialRoundNextClass != TFClass_Unknown)
+	if (g_bNextBossSpecialClass || g_nNextBossSpecialClass != TFClass_Unknown)
 	{
+		if (g_nNextBossSpecialClass == TFClass_Unknown)
+			g_nNextBossSpecialClass = view_as<TFClassType>(GetRandomInt(1, sizeof(g_strClassName)-1));
 		
-		TFClassType nSpecialRoundClass;
-		if (g_nSpecialRoundNextClass != TFClass_Unknown)
-			nSpecialRoundClass = g_nSpecialRoundNextClass;
-		else
-			nSpecialRoundClass = view_as<TFClassType>(GetRandomInt(1, sizeof(g_strClassName)-1));
+		ClassLimit_SetSpecialRound(g_nNextBossSpecialClass);
+		PrintToChatAll("%s%s SPECIAL ROUND: %N versus %s", TEXT_TAG, TEXT_COLOR, iMainBoss, g_strClassName[g_nNextBossSpecialClass]);
 		
-		ClassLimit_SetSpecialRound(nSpecialRoundClass);
-		PrintToChatAll("%s%s SPECIAL ROUND: %N versus %s", TEXT_TAG, TEXT_COLOR, iMainBoss, g_strClassName[nSpecialRoundClass]);
-		
-		g_bSpecialRound = false;
-		g_nSpecialRoundNextClass = TFClass_Unknown;
+		g_bNextBossSpecialClass = false;
+		g_nNextBossSpecialClass = TFClass_Unknown;
 	}
 	else	//If not, disable special round
 	{
@@ -218,68 +223,77 @@ void PickNextBoss()
 	CreateTimer(flPickBossTime, Timer_RoundStartSound, iMainBoss);
 }
 
-void SetBoss(int iClient, char[] sBossType, char[] sModifiersType)
+int NextBoss_GetNextClient(ArrayList aClients, int iRank = 1)
 {
+	int iClient = Queue_GetPlayerFromRank(iRank);
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
+		return iClient;
+	
+	if (aClients.Length > 0)
 	{
-		SaxtonHaleBase boss = SaxtonHaleBase(iClient);
-		
-		// Allow them to join the boss team
-		Client_AddFlag(iClient, ClientFlags_BossTeam);
-		TF2_ForceTeamJoin(iClient, TFTeam_Boss);
-
-		boss.CallFunction("CreateBoss", sBossType);
-		
-		//Give every bosses able to scare scout by default
-		CScareRage scareAbility = boss.CallFunction("FindAbility", "CScareRage");
-		if (scareAbility == INVALID_ABILITY) //If boss don't have scare rage ability, give him one
-			scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
-		scareAbility.nSetClass = TFClass_Scout;
-		scareAbility.flRadiusClass = 800.0;
-		scareAbility.iStunFlagsClass = TF_STUNFLAGS_SMALLBONK;
-		
-		//Select Modifiers
-		if (!StrEqual(sModifiersType, "CModifiersNone") && !StrEmpty(sModifiersType))
-			boss.CallFunction("CreateModifiers", sModifiersType);
-		
-		TF2_RespawnPlayer(iClient);
-		
-		//Display to client what boss you are for 10 seconds
-		MenuBoss_DisplayInfo(iClient, sBossType, 10);
+		PrintToChatAll("%s%s Unable to find player in queue to become boss! %sPicking random player...", TEXT_TAG, TEXT_ERROR, TEXT_COLOR);
+		return aClients.Get(0);
 	}
+	
+	PluginStop(true, "[VSH] FAILED TO FIND CLIENT TO SET BOSS!!!!");
+	return 0;
 }
 
-stock void GetNextBossName(NextBoss nextStruct, char[] sBuffer, int iLength)
+void NextBoss_SetBoss(SaxtonHaleNextBoss nextBoss, ArrayList aClients)
 {
-	char sBossName[256], sModifiersName[256];
+	//Fill random boss and not modifier if not set
+	char sBossType[MAX_TYPE_CHAR], sModifierType[MAX_TYPE_CHAR];
+	nextBoss.GetBoss(sBossType, sizeof(sBossType));
+	nextBoss.GetModifier(sModifierType, sizeof(sModifierType));
 	
-	int iClient = GetClientOfUserId(nextStruct.iUserId);
-	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
-		Format(sBuffer, iLength, "%s%N as ", sBuffer, iClient);
+	if (StrEmpty(sBossType))
+		NextBoss_GetRandomNormal(sBossType, sizeof(sBossType));
 	
-	//If boss not set, display as "random (modifiers) boss"
-	if (StrEmpty(nextStruct.sBoss))
+	if (StrEmpty(sModifierType))
+		NextBoss_GetRandomModifiers(sModifierType, sizeof(sModifierType));
+	
+	// Allow them to join the boss team
+	Client_AddFlag(nextBoss.iClient, ClientFlags_BossTeam);
+	TF2_ForceTeamJoin(nextBoss.iClient, TFTeam_Boss);
+	
+	SaxtonHaleBase boss = SaxtonHaleBase(nextBoss.iClient);
+	boss.CallFunction("CreateBoss", sBossType);
+	
+	//Give every bosses able to scare scout by default
+	CScareRage scareAbility = boss.CallFunction("FindAbility", "CScareRage");
+	if (scareAbility == INVALID_ABILITY) //If boss don't have scare rage ability, give him one
+		scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
+	
+	scareAbility.nSetClass = TFClass_Scout;
+	scareAbility.flRadiusClass = 800.0;
+	scareAbility.iStunFlagsClass = TF_STUNFLAGS_SMALLBONK;
+	
+	//Select Modifiers
+	if (!StrEqual(sModifierType, "CModifiersNone") && !StrEmpty(sModifierType))
+		boss.CallFunction("CreateModifiers", sModifierType);
+	
+	TF2_RespawnPlayer(nextBoss.iClient);
+	
+	//Display to client what boss you are for 10 seconds
+	MenuBoss_DisplayInfo(nextBoss.iClient, sBossType, 10);
+	
+	//Enable special round if triggered
+	if (nextBoss.bSpecialClass)
 	{
-		Format(sBuffer, iLength, "%sRandom ", sBuffer);
-		Format(sBossName, sizeof(sBossName), "Boss");
+		if (nextBoss.nSpecialClass == TFClass_Unknown && g_nNextBossSpecialClass == TFClass_Unknown)
+			g_nNextBossSpecialClass = view_as<TFClassType>(GetRandomInt(1, sizeof(g_strClassName)-1));
+		else if (nextBoss.nSpecialClass != TFClass_Unknown)
+			g_nNextBossSpecialClass = nextBoss.nSpecialClass;
 	}
-	else
-	{
-		SaxtonHaleBase boss = SaxtonHaleBase(0);
-		boss.CallFunction("SetBossType", nextStruct.sBoss);
-		boss.CallFunction("GetBossName", sBossName, sizeof(sBossName));
-	}
+
+	//Reset player queue
+	Queue_ResetPlayer(nextBoss.iClient);
+	int iIndex = aClients.FindValue(nextBoss.iClient);
+	if (iIndex >= MaxClients)
+		aClients.Erase(iIndex);
 	
-	if (!StrEmpty(nextStruct.sModifiers) && !StrEqual(nextStruct.sModifiers, "CModifiersNone"))
-	{
-		SaxtonHaleBase boss = SaxtonHaleBase(0);
-		boss.CallFunction("SetModifiersType", nextStruct.sModifiers);
-		boss.CallFunction("GetModifiersName", sModifiersName, sizeof(sModifiersName));
-		
-		Format(sBuffer, iLength, "%s%s ", sBuffer, sModifiersName);
-	}
-	
-	Format(sBuffer, iLength, "%s%s", sBuffer, sBossName);
+	//Clear next boss data
+	NextBoss_Delete(nextBoss);
 }
 
 stock void NextBoss_AddMulti(ArrayList aBosses)
@@ -319,6 +333,13 @@ stock void NextBoss_RemoveMulti(const char[] sBoss)
 
 stock void NextBoss_GetRandomNormal(char[] sBoss, int iLength)
 {
+	//Saxton Hale get higher chance to appear
+	if (GetRandomFloat(0.0, 1.0) <= g_ConfigConvar.LookupFloat("vsh_boss_chance_saxton"))
+	{
+		Format(sBoss, iLength, "CSaxtonHale");
+		return;
+	}
+	
 	//Get list of all bosses
 	ArrayList aBosses = FuncClass_GetAllType(VSHClassType_Boss);
 	

--- a/addons/sourcemod/scripting/vsh/nextboss.sp
+++ b/addons/sourcemod/scripting/vsh/nextboss.sp
@@ -278,12 +278,12 @@ void NextBoss_SetBoss(SaxtonHaleNextBoss nextBoss, ArrayList aClients)
 	MenuBoss_DisplayInfo(nextBoss.iClient, sBossType, 10);
 	
 	//Enable special round if triggered
-	if (nextBoss.bSpecialClass)
+	if (nextBoss.bSpecialClassRound)
 	{
-		if (nextBoss.nSpecialClass == TFClass_Unknown && g_nNextBossSpecialClass == TFClass_Unknown)
+		if (nextBoss.nSpecialClassType == TFClass_Unknown && g_nNextBossSpecialClass == TFClass_Unknown)
 			g_nNextBossSpecialClass = view_as<TFClassType>(GetRandomInt(1, sizeof(g_strClassName)-1));
-		else if (nextBoss.nSpecialClass != TFClass_Unknown)
-			g_nNextBossSpecialClass = nextBoss.nSpecialClass;
+		else if (nextBoss.nSpecialClassType != TFClass_Unknown)
+			g_nNextBossSpecialClass = nextBoss.nSpecialClassType;
 	}
 
 	//Reset player queue


### PR DESCRIPTION
Bumps version to 1.3.2

This allows subplugin to force anyone to become specific boss, modifier or special round class using `SaxtonHaleNextBoss` methodmap, while refactoring some places to make it work and less ugly for `SaxtonHaleNextBoss`. Im still unhappy with `bSpecialClass` and `nSpecialClass` property name though, wanted to find better name for it