### PR TITLE
Use trigger_capture_area keyvalues to enforce fixed capture times

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2141,7 +2141,7 @@
 		"vsh_dome_cp_radius"        "250"               //If vsh_dome_centre specified, new radius from CP to capture
 		"vsh_dome_cp_unlock"        "60"                //Time in second to unlock CP on round start
 		"vsh_dome_cp_unlockplayer"  "5"                 //Time in second to add on every player to unlock CP on round start
-		"vsh_dome_cp_caprate"       "15"                //How long to capture CP
+		"vsh_dome_cp_captime"       "15"                //How long to capture CP
 		"vsh_dome_cp_bossrate"      "2"                 //Capture value for boss
 		"vsh_dome_color_neu"        "192 192 192 255"   //Color of dome in RGBA if nobody owns the capture point
 		"vsh_dome_color_red"        "255 0 0 255"       //Color of dome in RGBA if red owns the capture point

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -28,12 +28,6 @@
 				"linux"		"@_ZN9CTFPlayer12RemoveObjectEP11CBaseObject"
 				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x7C\x21\x00\x00"
 			}
-			"CTriggerAreaCapture::SetCapTimeRemaining"
-			{
-				"library"	"server"
-				"linux"		"@_ZN19CTriggerAreaCapture19SetCapTimeRemainingEf"
-				"windows"	"\x55\x8B\xEC\xF3\x0F\x10\x45\x08\x56\x8B\xF1\xC7\x45\x08\x00\x00\x00\x00"
-			}
 			"CWeaponMedigun::AllowedToHealTarget"
 			{
 				"library"	"server"
@@ -49,20 +43,6 @@
 		}
 		"Functions"
 		{
-			"CTriggerAreaCapture::SetCapTimeRemaining"
-			{
-				"signature"	"CTriggerAreaCapture::SetCapTimeRemaining"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"entity"
-				"arguments"
-				{
-					"flTime"
-					{
-						"type"	"float"
-					}
-				}
-			}
 			"CWeaponMedigun::AllowedToHealTarget"
 			{
 				"signature"	"CWeaponMedigun::AllowedToHealTarget"

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -12,7 +12,6 @@
 static bool g_bDomeCustomPos;	//Whenever if capture point is in custom pos
 static float g_vecDomeCP[3];	//Pos of CP
 static int g_iDomeTriggerRef;	//Trigger to control touch
-static float g_flDomeCPTimeRemaining;	//Time left to capture this CP
 static bool g_bDomeCapturing[TF_MAXPLAYERS+1];
 
 //Dome prop
@@ -92,22 +91,11 @@ public void Dome_MasterSpawn(int iMaster)
 public void Dome_TriggerSpawn(int iTrigger)
 {
 	//Set time to cap to whatever in convar
-	DispatchKeyValueFloat(iTrigger, "area_time_to_cap", g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate") / 2.0);
+	DispatchKeyValueFloat(iTrigger, "area_time_to_cap", g_ConfigConvar.LookupFloat("vsh_dome_cp_captime") / 2.0);
+	//If mp_capstyle is set to 1, team_numcap_ keyvalues are used in the captime calculations
+	DispatchKeyValue(iTrigger, "team_numcap_2", "1");
+	DispatchKeyValue(iTrigger, "team_numcap_3", "1");
 	g_iDomeTriggerRef = EntIndexToEntRef(iTrigger);
-}
-
-public Action Dome_SetCapTimeRemaining(int iTrigger, float &flTime)
-{
-	//CTriggerAreaCapture::SetCapTimeRemaining sometimes start capture time incorrectly, set it properly
-	if (g_flDomeCPTimeRemaining == 0.0 && flTime > 0.0)
-	{
-		flTime = g_ConfigConvar.LookupFloat("vsh_dome_cp_caprate");
-		g_flDomeCPTimeRemaining = flTime;
-		return Plugin_Changed;
-	}
-	
-	g_flDomeCPTimeRemaining = flTime;
-	return Plugin_Continue;
 }
 
 public Action Dome_TriggerTouch(int iTrigger, int iToucher)

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -33,7 +33,7 @@ void Dome_Init()
 	g_ConfigConvar.Create("vsh_dome_cp_radius", "250", "If vsh_dome_centre specified, new radius from CP to capture");
 	g_ConfigConvar.Create("vsh_dome_cp_unlock", "60", "Time in second to unlock CP on round start", _, true, 0.0);
 	g_ConfigConvar.Create("vsh_dome_cp_unlockplayer", "5", "Time in second to add on every player to unlock CP on round start", _, true, 0.0);
-	g_ConfigConvar.Create("vsh_dome_cp_caprate", "15", "How long to capture CP", _, true, 0.0);
+	g_ConfigConvar.Create("vsh_dome_cp_captime", "15", "How long to capture CP", _, true, 0.0);
 	g_ConfigConvar.Create("vsh_dome_cp_bossrate", "3", "Capture value for boss", _, true, 1.0);
 	g_ConfigConvar.Create("vsh_dome_color_neu", "192 192 192 255", "Color of dome in RGBA if nobody owns the capture point");
 	g_ConfigConvar.Create("vsh_dome_color_red", "255 0 0 255", "Color of dome in RGBA if red owns the capture point");

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -162,17 +162,8 @@ void SDK_Init()
 	else
 		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
 	
-	// This hook allows to change capture time remaining
-	Handle hHook = DHookCreateFromConf(hGameData, "CTriggerAreaCapture::SetCapTimeRemaining");
-	if (hHook == null)
-		LogMessage("Failed to create hook: CTriggerAreaCapture::SetCapTimeRemaining!");
-	else
-		DHookEnableDetour(hHook, false, Hook_SetCapTimeRemaining);
-	
-	delete hHook;
-	
 	// This hook allows to allow/block medigun heals
-	hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
+	Handle hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
 	if (hHook == null)
 		LogMessage("Failed to create hook: CWeaponMedigun::AllowedToHealTarget!");
 	else
@@ -291,20 +282,6 @@ public void Hook_GiveNamedItemRemoved(int iHookId)
 			return;
 		}
 	}
-}
-
-public MRESReturn Hook_SetCapTimeRemaining(int iTrigger, Handle hParams)
-{
-	float flTime = DHookGetParam(hParams, 1);
-	
-	Action action = Dome_SetCapTimeRemaining(iTrigger, flTime);
-	if (action >= Plugin_Changed)
-	{
-		DHookSetParam(hParams, 1, flTime);
-		return MRES_ChangedHandled;
-	}
-	
-	return MRES_Ignored;
 }
 
 public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle hParams)


### PR DESCRIPTION
Seems like using ``CTriggerAreaCapture::SetCapTimeRemaining`` to set the cap time can cause some visual bugs and is overall not a very good way of doing this.

Using ``team_numcap_2`` and ``team_numcap_3`` keyvalues on ``trigger_capture_area`` is a much better approach.
Also renamed ``vsh_dome_cp_caprate`` cvar to ``vsh_dome_cp_captime`` while I was at it.