### PR TITLE
Blacklist Vaccinator

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1595,42 +1595,8 @@
 		
 		"998"	//Vaccinator
 		{
-			"desp"			"Vaccinator: {positive}Bullet resistance gives yourself uber, blast gives a damage bonus and fire a gives speed bonus, {negative}no area of range effect"
-			
-			"spawn"
-			{
-				"block"		"medic-secondary-uber"	//Block uber start function
-			}
-				
-			"uber"
-			{
-				"block"		"medic-secondary-aoe"	//Block aoe function
-				
-				"Tags_AddCondVaccinator"
-				{
-					"target"		"client"		//Give conds to medic itself
-					"bullet"		"57"			//Uber
-					"blast"			"12"			//Damage buff
-					"fire"			"32"			//Speed boost
-					"duration"		"2.5"			//2.5 seconds for cond
-				}
-			}
-			
-			"attackdamage"
-			{
-				//Damage buff (cond 12) actually does nothing, just unused. Damage therefore need to manually be increased
-				"filter"
-				{
-					"victimuber"	"0"
-					"cond"			"12"
-				}
-				
-				"params"
-				{
-					"passive"		"1"				//Enable damage multiplier for all weapons
-					"multiply"		"2.0"
-				}
-			}
+			"desp"			"Vaccinator: {neutral}Replaced with Medigun"
+			"restricted"	"1"
 		}
 		
 		"173"	//Vita-Saw


### PR DESCRIPTION
Vaccinator had been rebalanced for like, 8 times for over a year, and none of them works well with confusing stats.
Best to blacklist it off until there a better idea, if there ever will be one