### PR TITLE
Baby Face's Blaster: increase damage req to 400

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -546,8 +546,8 @@
 
 		"772"	//Baby Face Blaster
 		{
-			"desp"			"Baby Face Blaster: {negative}Boost takes 400 damage to fully charge and is reset on stun"
-			"attrib"		"793 ; 1.0 ; 418 ; 0.0"		//Replacing boost meter with hype meter increases damage requirement for max speed to 400
+			"desp"			"Baby Face Blaster: {negative}Boost takes up to 400 damage to fully charge and is reset on stun"
+			"attrib"		"793 ; 1.0 ; 418 ; 0.0"		//Replacing boost meter with hype meter increases damage requirement for max speed to around 400
 			
 			"think"	//used to be from TF2_OnConditionAdded, but prob more easier if going for this way
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -546,7 +546,8 @@
 
 		"772"	//Baby Face Blaster
 		{
-			"desp"			"Baby Face Blaster: {negative}Boost is reset on stun"
+			"desp"			"Baby Face Blaster: {negative}Boost takes 400 damage to fully charge and is reset on stun"
+			"attrib"		"793 ; 1.0 ; 418 ; 0.0"		//Replacing boost meter with hype meter increases damage requirement for max speed to 400
 			
 			"think"	//used to be from TF2_OnConditionAdded, but prob more easier if going for this way
 			{
@@ -561,6 +562,20 @@
 					"type"			"float"
 					"prop"			"m_flHypeMeter"
 					"value"			"0.0"
+				}
+				
+				"Tags_AddCond"
+				{
+					"cond"			"32"	//Speed boost
+					"duration"		"0.0"	//No duration, really just to recalculate speed
+				}
+			}
+			
+			"attackdamage"
+			{
+				"params"
+				{
+					"passive"		"1"		//Meter builds with any weapon so speed has to be recalculated on every hit
 				}
 				
 				"Tags_AddCond"


### PR DESCRIPTION
In VSH, this weapon's charge meter is much easier to build as the threats for its downside simply do not exist, making the default speed gain feel annoying and undeserved.

Instead of trying to reinvent the wheel, the speed boost will remain a feature of the weapon, it'll just be a bit harder to get. :)