### PR TITLE
Allow Vagineer to have more than one sentry up on rage

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -187,6 +187,7 @@ methodmap CVagineer < SaxtonHaleBase
 		
 		SetVariantInt(iSentryHealth);
 		AcceptEntityInput(iEntity, "SetHealth");	//Sets sentry health
+		SDK_RemoveObject(this.iClient, iEntity);	//Make the boss not the sentry's original owner so he gets to potentially build more of them
 		
 		return Plugin_Continue;
 	}
@@ -203,21 +204,20 @@ methodmap CVagineer < SaxtonHaleBase
 	
 	public void OnRage()
 	{
-		FakeClientCommand(this.iClient, "destroy 2 0");
 		SetEntProp(this.iClient, Prop_Send, "m_iAmmo", 130, 4, 3);
 		FakeClientCommand(this.iClient, "build 2 0");
 	}
 	
 	public void OnThink()
-	{		
+	{
 		Hud_AddText(this.iClient, "Use your rage to build sentry at a safe place!");
 		
-		int iSentry = MaxClients+1;
-		while((iSentry = FindEntityByClassname(iSentry, "obj_sentrygun")) > MaxClients)
+		if (g_flVagineerSentryHealthDecay[this.iClient] < GetGameTime() - 0.01)
 		{
-			if (GetEntPropEnt(iSentry, Prop_Send, "m_hBuilder") == this.iClient)
-			{				
-				if (g_flVagineerSentryHealthDecay[this.iClient] < GetGameTime() - 0.01)
+			int iSentry = MaxClients+1;
+			while((iSentry = FindEntityByClassname(iSentry, "obj_sentrygun")) > MaxClients)
+			{
+				if (GetEntPropEnt(iSentry, Prop_Send, "m_hBuilder") == this.iClient)
 				{
 					SetVariantInt(1);
 					AcceptEntityInput(iSentry, "RemoveHealth");

--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -230,6 +230,19 @@ methodmap CVagineer < SaxtonHaleBase
 		}
 	}
 	
+	public void Destroy()
+	{
+		int iSentry = MaxClients+1;
+		while((iSentry = FindEntityByClassname(iSentry, "obj_sentrygun")) > MaxClients)
+		{
+			if (GetEntPropEnt(iSentry, Prop_Send, "m_hBuilder") == this.iClient)
+			{
+				SetVariantInt(999999);
+				AcceptEntityInput(iSentry, "RemoveHealth");
+			}
+		}
+	}
+		
 	public void Precache()
 	{
 		PrepareSound(VAGINEER_KILL_SOUND);


### PR DESCRIPTION
Right now, if Vagineer rages while already having an active sentry, it'll be destroyed so another one can be built. That's pretty harsh for the boss as his rage doesn't have much going on defensively besides a little-ranged stun and with this happening commonly in a panic-raging scenario, he's usually getting shredded.

This PR makes it so the previous sentry won't be destroyed while allowing ownership of multiple sentries.