### PR TITLE
Nuke caber

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1248,7 +1248,7 @@
 					"target"		"melee"
 					"type"			"float"
 					"prop"			"m_flModelScale"
-					"value"			"3.0"
+					"value"			"2.0"
 				}
 			}
 			
@@ -1262,6 +1262,15 @@
 				"params"
 				{
 					"multiply"		"3.0"	//Multiply explosion damage by 3
+				}
+			}
+			
+			"takedamage"
+			{
+				"filter"
+				{
+					"attackweapon"	"melee"
+					"damagetype"	"blast"	//Only when hit by melee blast damage
 				}
 				
 				"Tags_Explode"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -155,8 +155,12 @@
 //Tags_Explode            - Creates explosion at target
 //- damage                  - Explosion damage
 //- radius                  - Radius of explosion
+//- particle                - Optional particle effect. Set to a generic explosion particle by default
+//- sound                   - Optional sound of the explosion, up to 16 sounds can be specified. Set to air strike explosion sounds by default. Does not support custom sounds
 //
 //Tags_KillWeapon         - Unequips and destroy weapon target
+//
+//Tags_ForceSuicide       - Forces the target to suicide
 
 
 
@@ -1234,20 +1238,54 @@
 		
 		"307"	//Ullapool Caber
 		{
-			"desp"			"Ullapool Caber: {positive}100% explosion damage bonus, {negative}marked-for-death while active"
-			"attrib"		"414 ; 1.0"
+			"desp"			"Ullapool Caber: {neutral}Explosion deals massive damage as a true last resort killing yourself in the process, {negative}marked-for-death while active"
+			"attrib"		"414 ; 1.0 ; 207 ; 11.0"
+			
+			"spawn"
+			{
+				"Tags_SetEntProp"	//Make the caber fucking massive
+				{
+					"target"		"melee"
+					"type"			"float"
+					"prop"			"m_flModelScale"
+					"value"			"3.0"
+				}
+			}
 			
 			"attackdamage"
 			{
 				"filter"
 				{
-					"victimuber"	"0"
-					"damagetype"	"blast"
+					"damagetype"	"blast"	//Only when the caber detonates
 				}
 				
 				"params"
 				{
-					"multiply"		"2.0"	//Multiply explosion damage by 2
+					"multiply"		"3.0"	//Multiply explosion damage by 3
+				}
+				
+				"Tags_Explode"
+				{
+					"damage"		"0.0"	//We don't want the explosion to do any damage, we only want the effects from it
+					"radius"		"0.0"
+					"particle"		"fluidSmokeExpl_ring"
+					
+					//Choose one of these sounds at random
+					"sound"			"ambient/explosions/explode_1.wav"
+					"sound"			"ambient/explosions/explode_2.wav"
+					"sound"			"ambient/explosions/explode_3.wav"
+					"sound"			"ambient/explosions/explode_4.wav"
+					"sound"			"ambient/explosions/explode_5.wav"
+					"sound"			"ambient/explosions/explode_6.wav"
+					"sound"			"ambient/explosions/explode_7.wav"
+					"sound"			"ambient/explosions/explode_8.wav"
+					"sound"			"ambient/explosions/explode_9.wav"
+				}
+				
+				"Tags_ForceSuicide"
+				{
+					"target"		"client"	//To ensure the demoman fucking dies, even when ubered
+					"delay"			"0.1"		//Needs a small delay so the target doesn't die twice
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -32,6 +32,7 @@
 #define MAX_BUTTONS 					26
 #define MAX_TYPE_CHAR					32		//Max char size of methodmaps name
 #define MAXLEN_CONFIG_VALUE 			256		//Max config string buffer size
+#define MAXLEN_CONFIG_ALLVALUES			1024	//Max config buffer size for groups of values
 
 #define TF_MAXPLAYERS					32
 

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -31,8 +31,10 @@
 
 #define MAX_BUTTONS 					26
 #define MAX_TYPE_CHAR					32		//Max char size of methodmaps name
-#define MAXLEN_CONFIG_VALUE 			256		//Max config string buffer size
-#define MAXLEN_CONFIG_ALLVALUES			1024	//Max config buffer size for groups of values
+
+#define MAX_CONFIG_ARRAY				16		//Config: Max array size for multiple values of a single parameter
+#define MAXLEN_CONFIG_VALUE 			256		//Config: Max string buffer size for individual values
+#define MAXLEN_CONFIG_VALUEARRAY		1024	//Config: Max string buffer size for groups of values
 
 #define TF_MAXPLAYERS					32
 

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -783,11 +783,19 @@ public void Tags_Explode(int iClient, int iTarget, TagsParams tParams)
 	float flDamage = tParams.GetFloat("damage");
 	float flRadius = tParams.GetFloat("radius");
 	
+	//If no particle was specified, pick a generic explosion particle
+	char sParticle[MAXLEN_CONFIG_VALUE];
+	if (!tParams.GetString("particle", sParticle, sizeof(sParticle)))
+		Format(sParticle, sizeof(sParticle), "ExplosionCore_MidAir");
+	
+	//If no sounds were specified, pick a generic explosion sound. If multiple sounds were specified, pick a random one
+	char sSound[MAXLEN_CONFIG_VALUE];
+	if (!tParams.GetStringRandom("sound", sSound, sizeof(sSound)))
+		Format(sSound, sizeof(sSound), "weapons/airstrike_small_explosion_0%i.wav", GetRandomInt(1,3));
+	
 	float vecPos[3];
 	GetEntPropVector(iTarget, Prop_Send, "m_vecOrigin", vecPos);
-	char sSound[255];
-	Format(sSound, sizeof(sSound), "weapons/airstrike_small_explosion_0%i.wav", GetRandomInt(1,3));
-	TF2_Explode(iClient, vecPos, flDamage, flRadius, "ExplosionCore_MidAir", sSound);
+	TF2_Explode(iClient, vecPos, flDamage, flRadius, sParticle, sSound);
 }
 
 public void Tags_KillWeapon(int iClient, int iTarget, TagsParams tParams)
@@ -805,6 +813,15 @@ public void Tags_KillWeapon(int iClient, int iTarget, TagsParams tParams)
 			return;
 		}
 	}
+}
+
+public void Tags_ForceSuicide(int iClient, int iTarget, TagsParams tParams)
+{
+	if (iTarget <= 0 || iTarget > MaxClients || !IsClientInGame(iTarget) || !IsPlayerAlive(iTarget))
+		return;
+	
+	//Pretty straight-forward, isn't it?
+	ForcePlayerSuicide(iTarget);
 }
 
 //---------------------------

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -791,7 +791,7 @@ public void Tags_Explode(int iClient, int iTarget, TagsParams tParams)
 	//If no sounds were specified, pick a generic explosion sound. If multiple sounds were specified, pick a random one
 	char sSound[MAXLEN_CONFIG_VALUE];
 	if (!tParams.GetStringRandom("sound", sSound, sizeof(sSound)))
-		Format(sSound, sizeof(sSound), "weapons/airstrike_small_explosion_0%i.wav", GetRandomInt(1,3));
+		Format(sSound, sizeof(sSound), "weapons/airstrike_small_explosion_0%d.wav", GetRandomInt(1, 3));
 	
 	float vecPos[3];
 	GetEntPropVector(iTarget, Prop_Send, "m_vecOrigin", vecPos);

--- a/addons/sourcemod/scripting/vsh/tags/tags_params.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_params.sp
@@ -12,7 +12,7 @@ methodmap TagsParams < StringMap
 		
 		do	//Loop through every params
 		{
-			char sParamName[MAXLEN_CONFIG_VALUE], sParamValue[MAXLEN_CONFIG_VALUE], sBuffer[MAXLEN_CONFIG_VALUE];
+			char sParamName[MAXLEN_CONFIG_VALUE], sParamValue[MAXLEN_CONFIG_ALLVALUES], sBuffer[MAXLEN_CONFIG_ALLVALUES];
 			kv.GetSectionName(sParamName, sizeof(sParamName));
 			kv.GetString(NULL_STRING, sParamValue, sizeof(sParamValue));
 			StrToLower(sParamName);	//Convert string to lowercase, KeyValues rarely read 1st letter as uppercase...
@@ -50,11 +50,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return false;
 		
-		char sValue[MAXLEN_CONFIG_VALUE];
+		char sValue[MAXLEN_CONFIG_ALLVALUES];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return false;
 		
-		char sValues[32][32];
+		char sValues[16][MAXLEN_CONFIG_VALUE];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return false;
 		
@@ -67,11 +67,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_VALUE];
+		char sValue[MAXLEN_CONFIG_ALLVALUES];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[32][32];
+		char sValues[16][MAXLEN_CONFIG_VALUE];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -81,6 +81,23 @@ methodmap TagsParams < StringMap
 			aBuffer.PushString(sValues[i]);
 		
 		return aBuffer;
+	}
+	
+	public bool GetStringRandom(const char[] sKey, char[] sBuffer, int iLength)
+	{
+		if (this == null) return false;
+		
+		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		if (!this.GetString(sKey, sValue, sizeof(sValue)))
+			return false;
+		
+		char sValues[16][MAXLEN_CONFIG_VALUE];
+		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
+		if (iCount == 0) return false;
+		
+		//Copy a random value in the array
+		Format(sBuffer, iLength, sValues[GetRandomInt(0, iCount-1)]);
+		return true;
 	}
 	
 	public any GetInt(const char[] sKey, any iValue = 0)
@@ -109,11 +126,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_VALUE];
+		char sValue[MAXLEN_CONFIG_ALLVALUES];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[32][12];
+		char sValues[16][12];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -151,11 +168,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_VALUE];
+		char sValue[MAXLEN_CONFIG_ALLVALUES];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[32][12];
+		char sValues[16][12];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -200,11 +217,11 @@ methodmap TagsParams < StringMap
 			snapshot.GetKey(i, sKey, ikeyLength);
 			
 			//Get key value
-			char sValue[MAXLEN_CONFIG_VALUE];
+			char sValue[MAXLEN_CONFIG_ALLVALUES];
 			this.GetString(sKey, sValue, sizeof(sValue));
 			
 			//If already exists, add as an "array"
-			char sBuffer[MAXLEN_CONFIG_VALUE];
+			char sBuffer[MAXLEN_CONFIG_ALLVALUES];
 			if (tParams.GetString(sKey, sBuffer, sizeof(sBuffer)))
 				Format(sValue, sizeof(sValue), "%s ; %s", sBuffer, sValue);
 			

--- a/addons/sourcemod/scripting/vsh/tags/tags_params.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_params.sp
@@ -12,7 +12,7 @@ methodmap TagsParams < StringMap
 		
 		do	//Loop through every params
 		{
-			char sParamName[MAXLEN_CONFIG_VALUE], sParamValue[MAXLEN_CONFIG_ALLVALUES], sBuffer[MAXLEN_CONFIG_ALLVALUES];
+			char sParamName[MAXLEN_CONFIG_VALUE], sParamValue[MAXLEN_CONFIG_VALUEARRAY], sBuffer[MAXLEN_CONFIG_VALUEARRAY];
 			kv.GetSectionName(sParamName, sizeof(sParamName));
 			kv.GetString(NULL_STRING, sParamValue, sizeof(sParamValue));
 			StrToLower(sParamName);	//Convert string to lowercase, KeyValues rarely read 1st letter as uppercase...
@@ -50,11 +50,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return false;
 		
-		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		char sValue[MAXLEN_CONFIG_VALUEARRAY];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return false;
 		
-		char sValues[16][MAXLEN_CONFIG_VALUE];
+		char sValues[MAX_CONFIG_ARRAY][MAXLEN_CONFIG_VALUE];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return false;
 		
@@ -67,11 +67,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		char sValue[MAXLEN_CONFIG_VALUEARRAY];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[16][MAXLEN_CONFIG_VALUE];
+		char sValues[MAX_CONFIG_ARRAY][MAXLEN_CONFIG_VALUE];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -87,11 +87,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return false;
 		
-		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		char sValue[MAXLEN_CONFIG_VALUEARRAY];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return false;
 		
-		char sValues[16][MAXLEN_CONFIG_VALUE];
+		char sValues[MAX_CONFIG_ARRAY][MAXLEN_CONFIG_VALUE];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return false;
 		
@@ -126,11 +126,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		char sValue[MAXLEN_CONFIG_VALUEARRAY];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[16][12];
+		char sValues[MAX_CONFIG_ARRAY][12];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -168,11 +168,11 @@ methodmap TagsParams < StringMap
 	{
 		if (this == null) return null;
 		
-		char sValue[MAXLEN_CONFIG_ALLVALUES];
+		char sValue[MAXLEN_CONFIG_VALUEARRAY];
 		if (!this.GetString(sKey, sValue, sizeof(sValue)))
 			return null;
 		
-		char sValues[16][12];
+		char sValues[MAX_CONFIG_ARRAY][12];
 		int iCount = ExplodeString(sValue, " ; ", sValues, sizeof(sValues), sizeof(sValues[]));
 		if (iCount == 0) return null;
 		
@@ -217,11 +217,11 @@ methodmap TagsParams < StringMap
 			snapshot.GetKey(i, sKey, ikeyLength);
 			
 			//Get key value
-			char sValue[MAXLEN_CONFIG_ALLVALUES];
+			char sValue[MAXLEN_CONFIG_VALUEARRAY];
 			this.GetString(sKey, sValue, sizeof(sValue));
 			
 			//If already exists, add as an "array"
-			char sBuffer[MAXLEN_CONFIG_ALLVALUES];
+			char sBuffer[MAXLEN_CONFIG_VALUEARRAY];
 			if (tParams.GetString(sKey, sBuffer, sizeof(sBuffer)))
 				Format(sValue, sizeof(sValue), "%s ; %s", sBuffer, sValue);
 			


### PR DESCRIPTION
This change focuses on what the caber is supposed to be: a weapon to use when you have no other options.

For the simple part, all this really does is amplify what the caber already does: you deal more damage with it and never survive damage from it (and by never I really mean it), while adding fitting visual and sound effects to it. Explosion radius is unchanged.

A couple of things for the config were also changed to support this and maybe other things in the future:
- **Tags_Explode** now has custom `particle` and `sound` parameters, if the tag is used but these parameters aren't specified it'll use the same visual/sound effects it always has.
    - The `sound` parameter supports up to 16 non-custom sounds and will play one of them at random for the explosion.
- **Tags_ForceSuicide** has been added, it just kills the target.