### PR TITLE
Telefrag damage 4242 → 9001

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2141,7 +2141,7 @@
 	"cvars"
 	{
 		"vsh_force_load"            "-1"                //Force enable VSH on map start? (-1 for default, 0 for force unload, 1 for force load)
-		"vsh_telefrag_damage"       "9001.0"            //Damage amount to boss from telefrag
+		"vsh_telefrag_damage"       "8000"              //Damage amount to boss from telefrag
 		"vsh_rps_enable"            "0"                 //Allow everyone use Rock Paper Scissors Taunt?
 		
 		"vsh_boss_chance_saxton"    "0.30"              //% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2141,7 +2141,7 @@
 	"cvars"
 	{
 		"vsh_force_load"            "-1"                //Force enable VSH on map start? (-1 for default, 0 for force unload, 1 for force load)
-		"vsh_telefrag_damage"       "4242.0"            //Damage amount to boss from telefrag
+		"vsh_telefrag_damage"       "9001.0"            //Damage amount to boss from telefrag
 		"vsh_rps_enable"            "0"                 //Allow everyone use Rock Paper Scissors Taunt?
 		
 		"vsh_boss_chance_saxton"    "0.30"              //% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)


### PR DESCRIPTION
Changes from VSH:Legacy's telefrag damage wasn't necessary, telefrag isn't reliable source of damage and should be noticeable when it happens.