### PR TITLE
Fix the airblast visual bug

### DIFF
--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -230,6 +230,20 @@ void Tags_OnButton(int iClient, int &iButtons)
 		int iActiveWep = GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon");
 		if (iActiveWep > MaxClients && iPrimary == iActiveWep)
 			iButtons &= ~IN_ATTACK2;
+		
+		if (g_nTagsAirblastState[iClient] == FlamethrowerState_Airblast)
+		{
+			if (iButtons & IN_ATTACK)
+			{
+				g_nTagsAirblastState[iClient] = FlamethrowerState_Firing;
+				SetEntProp(iPrimary, Prop_Send, "m_iWeaponState", FlamethrowerState_Firing);
+			}
+			else
+			{
+				g_nTagsAirblastState[iClient] = FlamethrowerState_Idle;
+				SetEntProp(iPrimary, Prop_Send, "m_iWeaponState", FlamethrowerState_Idle);
+			}
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -231,6 +231,7 @@ void Tags_OnButton(int iClient, int &iButtons)
 		if (iActiveWep > MaxClients && iPrimary == iActiveWep)
 			iButtons &= ~IN_ATTACK2;
 		
+		//Change the m_iWeaponState to a proper value after the airblast to prevent the visual bug
 		if (g_nTagsAirblastState[iClient] == FlamethrowerState_Airblast)
 		{
 			if (iButtons & IN_ATTACK)


### PR DESCRIPTION
`m_iWeaponState` remained at 3 (FlamethrowerState_Airblast) if pyro airblasted while he was holding M1. This caused airblast particles to appear with flame particles for everyone but the pyro, as long as he was holding M1.