### PR TITLE
More small tweaks to Über Ranger

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -274,9 +274,7 @@ methodmap CMinionRanger < SaxtonHaleBase
 	
 	public void OnSpawn()
 	{
-		char sMedigunAttribs[128];
-		Format(sMedigunAttribs, sizeof(sMedigunAttribs), "");
-		this.CallFunction("CreateWeapon", 211, "tf_weapon_medigun", 10, TFQual_Collectors, sMedigunAttribs);
+		this.CallFunction("CreateWeapon", 211, "tf_weapon_medigun", 10, TFQual_Collectors, "");
 		
 		char sSawAttribs[128];
 		Format(sSawAttribs, sizeof(sSawAttribs), "2 ; 1.25 ; 5 ; 1.2 ; 17 ; 0.25 ; 252 ; 0.5 ; 259 ; 1.0");

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -276,9 +276,9 @@ methodmap CMinionRanger < SaxtonHaleBase
 	{
 		this.CallFunction("CreateWeapon", 211, "tf_weapon_medigun", 10, TFQual_Collectors, "");
 		
-		char sSawAttribs[128];
-		Format(sSawAttribs, sizeof(sSawAttribs), "2 ; 1.25 ; 5 ; 1.2 ; 17 ; 0.25 ; 252 ; 0.5 ; 259 ; 1.0");
-		int iWeapon = this.CallFunction("CreateWeapon", 37, "tf_weapon_bonesaw", 10, TFQual_Collectors, sSawAttribs);
+		char sAttribs[128];
+		Format(sAttribs, sizeof(sAttribs), "2 ; 1.25 ; 5 ; 1.2 ; 17 ; 0.25 ; 252 ; 0.5 ; 259 ; 1.0");
+		int iWeapon = this.CallFunction("CreateWeapon", 37, "tf_weapon_bonesaw", 10, TFQual_Collectors, sAttribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
 		


### PR DESCRIPTION
- Mini Rangers' medi guns no longer have a reduced healing rate so they can actively heal each other
    - The main boss will have a passive 50% healing reduction instead

- Removed the slower brave jump charge rate from both Über and Mini Rangers, for ease of mind
- Slightly increased the brave jump height for Mini Rangers, as half max height value does not mean half max height in practice
- Removed salmon from the Mini Ranger colour pool