### PR TITLE
Make Bonk Boy's Sandman deal crit to stunned players

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
@@ -101,7 +101,7 @@ public MRESReturn WeaponBall_BallImpact(int iEntity, Handle hParams)
 	g_flWeaponBallStunTime[iVictim] = flTime;
 	g_iWeaponBallThrower[iVictim] = iThrower;
 	
-	SDKHook(iVictim, SDKHook_OnTakeDamage, WeaponBall_OnTakeDamage);
+	SDKHook(iVictim, SDKHook_OnTakeDamageAlive, WeaponBall_OnTakeDamage);
 	HookEvent("player_death", WeaponBall_PlayerDeath, EventHookMode_Pre);
 	RequestFrame(WeaponBall_UnhookBallDamage, GetClientUserId(iVictim));
 }
@@ -132,7 +132,7 @@ public MRESReturn WeaponBall_BallTouch(int iEntity, Handle hReturn, Handle hPara
 		return;
 	
 	//Deal damage
-	SDKHooks_TakeDamage(iBuilding, iThrower, iThrower, flTime * 120.0);
+	SDKHooks_TakeDamage(iBuilding, iThrower, iThrower, flTime * 120.0, DMG_CRIT);
 	
 	//Stun building
 	TF2_StunBuilding(iBuilding, flTime * 8.0);
@@ -175,9 +175,7 @@ public Action WeaponBall_OnTakeDamage(int victim, int &attacker, int &inflictor,
 		if (g_flWeaponBallStunTime[victim] > 0.85)
 		{
 			//Home run baby
-			damagetype |= DMG_CRIT;
-			damage = 1337.0 / 3.0;
-			
+			damage = 1337.0;
 			TF2_StunPlayer(victim, 10.0, _, TF_STUNFLAGS_BIGBONK, attacker);
 		}
 		else if (g_flWeaponBallStunTime[victim] > 0.10)
@@ -207,7 +205,7 @@ public void WeaponBall_UnhookBallDamage(int iUserId)
 {
 	int iClient = GetClientOfUserId(iUserId);
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
-		SDKUnhook(iClient, SDKHook_OnTakeDamage, WeaponBall_OnTakeDamage);
+		SDKUnhook(iClient, SDKHook_OnTakeDamageAlive, WeaponBall_OnTakeDamage);
 	
 	UnhookEvent("player_death", WeaponBall_PlayerDeath, EventHookMode_Pre);
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -96,7 +96,8 @@ methodmap CBonkBoy < SaxtonHaleBase
 		StrCat(sInfo, length, "\nAbilities");
 		StrCat(sInfo, length, "\n- Faster movement speed and extra jump height");
 		StrCat(sInfo, length, "\n- Dash Jump");
-		StrCat(sInfo, length, "\n- Sandman with fast recharge balls, able to hold 3 max");
+		StrCat(sInfo, length, "\n- Sandman deals crit to stunned players");
+		StrCat(sInfo, length, "\n- Fast recharge balls, able to hold 3 max");
 		StrCat(sInfo, length, "\n- Medium range ball stuns player and building, moonshot instakills");
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
@@ -109,7 +110,7 @@ methodmap CBonkBoy < SaxtonHaleBase
 	public void OnSpawn()
 	{
 		char attribs[256];
-		Format(attribs, sizeof(attribs), "2 ; 3.54 ; 252 ; 0.5 ; 259 ; 1.0 ; 38 ; 1.0 ; 278 ; 0.33 ; 524 ; 1.2 ; 551 ; 1.0");
+		Format(attribs, sizeof(attribs), "2 ; 3.54 ; 252 ; 0.5 ; 259 ; 1.0 ; 38 ; 1.0 ; 278 ; 0.33 ; 437 ; 65536.0 ; 524 ; 1.2 ; 551 ; 1.0");
 		int iWeapon = this.CallFunction("CreateWeapon", 44, "tf_weapon_bat_wood", 1, TFQual_Collectors, attribs);
 		if (iWeapon > MaxClients)
 			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
@@ -123,6 +124,7 @@ methodmap CBonkBoy < SaxtonHaleBase
 		
 		38: Launches a ball that slows opponents
 		278: increase in recharge rate
+		437: 100% critical hit vs stunned players
 		524: greater jump height when active
 		551: special_taunt
 		*/


### PR DESCRIPTION
Bonk Boy is weak against large health players at close range, so lets have this combo to prevent it, sandman melee deals crit against stunned players.

Using `100% critical hit vs stunned players` attribute also affects sandman ball, and since ball stuns player, it always deal crit. So ball damage had to be adjusted a bit to not deal such huge damage.

This may make bonk boy too strong now, but lets see how this goes and find which one needs to be nerfed