### PR TITLE
Tide Turner gains 75% charge meter on melee hit

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1156,6 +1156,8 @@
 		
 		"1099"	//Tide Turner
 		{
+			"desp"			"Tide Turner: {positive}Refills 75% of your charge meter on melee hit"
+			
 			"spawn"	//Called on spawn
 			{
 				"Tags_AddCond"
@@ -1164,6 +1166,31 @@
 					
 					"cond"			"16"	//Minicrit
 					"duration"		"-1.0"	//Perma
+				}
+			}
+			
+			"attackdamage"
+			{
+				"filter"
+				{
+					"victimuber"	"0"
+					"attackweapon"	"melee"	//Only consider melee hits
+				}
+				
+				"params"
+				{
+					"passive"		"1"		//Allow this function to call on any damages
+				}
+				
+				"Tags_SetEntProp"	//Add 75% charge meter
+				{
+					"target"		"client"
+					"type"			"float"
+					"prop"			"m_flChargeMeter"
+					
+					"math"			"add"
+					"value"			"75.0"
+					"max"			"100.0"
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_weapon.sp
@@ -6,7 +6,7 @@ static Menu g_hMenuWeaponSlot[sizeof(g_strClassName)][MENU_MAX_SLOT];
 
 void MenuWeapon_Refresh()
 {
-	char buffer[512];
+	char buffer[1024];
 	
 	delete g_hMenuWeaponMain;
 	for (int iClass = 1; iClass < sizeof(g_strClassName); iClass++)
@@ -19,7 +19,7 @@ void MenuWeapon_Refresh()
 	
 	// Create menus loaded from config
 	
-	char sClassDesp[sizeof(g_strClassName)][MENU_MAX_SLOT][512];
+	char sClassDesp[sizeof(g_strClassName)][MENU_MAX_SLOT][1024];
 	
 	//Get list of every weapons in config to add desp
 	int iLength = g_ConfigIndex.Length;


### PR DESCRIPTION
Tide Turner have a stat `Melee kills refill 75% of your charge meter`, so lets use the VSH way and convert kills into hits instead.

Hopefully shouldn't make it too strong as player need to do melee hits against boss without getting killed, and only usefulness is full turn control compared to Chargin' Targe and Splendid Screen.