### PR TITLE
Market Gardener always deal 1000 damage

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -860,7 +860,7 @@
 		
 		"416"	//Market Gardener
 		{
-			"desp"			"Market Gardener: {positive}Airborne hits deal ~5% of the boss's health, {negative}no crits"
+			"desp"			"Market Gardener: {positive}Airborne hits deal 1000 damage, {negative}no crits"
 			"minicrit"		"0"
 			"crit"			"0"
 			
@@ -874,10 +874,7 @@
 				
 				"params"
 				{
-					"perplayer"		"50.0"		//50 dmg per player
-					"min"			"300.0"		//Min 300 dmg
-					"max"			"1000.0"	//Max 1000 dmg
-				
+					"set"			"1000.0"	//Set damage to 1000
 					"damagetype"	"crit"		//Force crit
 				}
 				


### PR DESCRIPTION
Never really like the idea of scaling damage by player count or boss max health, have damage number constant so it doesn't matter on player count. If 1000 is too much, can be nerfed to 750.