### PR TITLE
Increase Demopan rage dmg requirement from 2500 to 3000

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
@@ -73,7 +73,7 @@ methodmap CDemoPan < SaxtonHaleBase
 		boss.iBaseHealth = 800;
 		boss.iHealthPerPlayer = 800;
 		boss.nClass = TFClass_DemoMan;
-		boss.iMaxRageDamage = 2500;
+		boss.iMaxRageDamage = 3000;
 		
 		g_flDemoPanPreviousKill[boss.iClient] = 0.0;
 	}


### PR DESCRIPTION
Instakill charge clearly shows it more stronger than scare rage.