### PR TITLE
Fix bugs related to announcer minion's weapons

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -37,6 +37,7 @@
 #define MAXLEN_CONFIG_VALUEARRAY		1024	//Config: Max string buffer size for groups of values
 
 #define TF_MAXPLAYERS					32
+#define MAX_ATTRIBUTES_SENT 			20
 
 #define ATTRIB_MELEE_RANGE_MULTIPLIER	264
 #define ATTRIB_BIDERECTIONAL			276
@@ -123,14 +124,6 @@ enum FlamethrowerState
 	FlamethrowerState_StartFiring,
 	FlamethrowerState_Firing,
 	FlamethrowerState_Airblast,
-};
-
-enum MinigunState
-{
-	MinigunState_Idle = 0,
-	MinigunState_Lowering,
-	MinigunState_Shooting,
-	MinigunState_Spinning,
 };
 
 enum

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -37,11 +37,6 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 
 		strcopy(g_sClientBossType[this.iClient], sizeof(g_sClientBossType[]), type);
 
-		if (g_hClientBossModelTimer[this.iClient] != null)
-			delete g_hClientBossModelTimer[this.iClient];
-
-		g_hClientBossModelTimer[this.iClient] = CreateTimer(0.2, Timer_ApplyBossModel, this.iClient, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
-
 		g_sClientBossRageMusic[this.iClient] = "";
 		g_bClientBossWeighDownForce[this.iClient] = false;
 		g_flClientBossWeighDownTimer[this.iClient] = 0.0;
@@ -54,6 +49,12 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 			Call_PushCell(this);
 			Call_Finish();
 		}
+		
+		if (g_hClientBossModelTimer[this.iClient] != null)
+			delete g_hClientBossModelTimer[this.iClient];
+		
+		if (this.bModel)
+			g_hClientBossModelTimer[this.iClient] = CreateTimer(0.2, Timer_ApplyBossModel, this.iClient, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 		
 		if (TF2_GetPlayerClass(this.iClient) == this.nClass)
 		{


### PR DESCRIPTION
Fix #162

Instead of fixing weapons after switching teams by using `TF2_RegeneratePlayer` (touching respully locker), change `m_iTeamNum` to new team on weapon and cosmetics. This fix some weapons destroying itself.

For attributes, `TF2Attrib_ListDefIndices` returns list of attribs that were given "manually" (not from `items_game.txt` or from loadout), so essentially only attribs from config making it an easy fix.

These fix also seems to fix minigun spinup itself, so our dirty fix is no longer needed. However restoring ammos on switching teams was gone, but i don't think it a big deal.

Also unrelated to weapons, fixed player models (aka redsun skins) instantly removed after getting shot from announcer.