### PR TITLE
Fix boss able to keep some cosmetics

### DIFF
--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -56,26 +56,8 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		if (this.bModel)
 			g_hClientBossModelTimer[this.iClient] = CreateTimer(0.2, Timer_ApplyBossModel, this.iClient, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 		
-		if (TF2_GetPlayerClass(this.iClient) == this.nClass)
-		{
-			//Player is about to play as same class unchanged, strip weapon and cosmetics for GiveNamedItem to regenerate
-			
-			TF2_RemoveAllWeapons(this.iClient);
-			
-			int iEntity = MaxClients+1;
-			while ((iEntity = FindEntityByClassname(iEntity, "tf_wearable*")) > MaxClients)
-				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
-					RemoveEntity(iEntity);
-			
-			iEntity = MaxClients+1;
-			while ((iEntity = FindEntityByClassname(iEntity, "tf_powerup_bottle")) > MaxClients)
-				if (GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity") == this.iClient || GetEntPropEnt(iEntity, Prop_Send, "moveparent") == this.iClient)
-					RemoveEntity(iEntity);
-		}
-		else if (this.nClass != TFClass_Unknown)
-		{
+		if (this.nClass != TFClass_Unknown)
 			TF2_SetPlayerClass(this.iClient, this.nClass);
-		}
 		
 		return view_as<SaxtonHaleBase>(this);
 	}

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -691,7 +691,9 @@ public Action Event_PlayerInventoryUpdate(Event event, const char[] sName, bool 
 
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
 	if (GetClientTeam(iClient) <= 1) return;
-
+	
+	TF2_CheckClientWeapons(iClient);
+	
 	if (SaxtonHale_IsValidAttack(iClient))
 	{
 		/*Balance specific weapons*/

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -317,6 +317,17 @@ stock void TF2_CheckClientWeapons(int iClient)
 				TF2_RemoveWearable(iClient, iWearable);
 		}
 	}
+	
+	//MvM Canteen
+	int iPowerupBottle = MaxClients+1;
+	while ((iPowerupBottle = FindEntityByClassname(iPowerupBottle, "tf_powerup_bottle*")) > MaxClients)
+	{
+		if (GetEntPropEnt(iPowerupBottle, Prop_Send, "m_hOwnerEntity") == iClient || GetEntPropEnt(iPowerupBottle, Prop_Send, "moveparent") == iClient)
+		{
+			if (GiveNamedItem(iClient, "tf_powerup_bottle", GetEntProp(iPowerupBottle, Prop_Send, "m_iItemDefinitionIndex")) >= Plugin_Handled)
+				TF2_RemoveWearable(iClient, iPowerupBottle);
+		}
+	}
 }
 
 stock int TF2_GetAmmo(int iClient, int iSlot)

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -290,6 +290,35 @@ stock void TF2_RemoveItemInSlot(int client, int slot)
 	}
 }
 
+stock void TF2_CheckClientWeapons(int iClient)
+{
+	//Weapons
+	for (int iSlot = WeaponSlot_Primary; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
+	{
+		int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
+		if (iWeapon > MaxClients)
+		{
+			char sClassname[256];
+			GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+			if (GiveNamedItem(iClient, sClassname, GetEntProp(iWeapon, Prop_Send, "m_iItemDefinitionIndex")) >= Plugin_Handled)
+				TF2_RemoveItemInSlot(iClient, iSlot);
+		}
+	}
+	
+	//Cosmetics
+	int iWearable = MaxClients+1;
+	while ((iWearable = FindEntityByClassname(iWearable, "tf_wearable*")) > MaxClients)
+	{
+		if (GetEntPropEnt(iWearable, Prop_Send, "m_hOwnerEntity") == iClient || GetEntPropEnt(iWearable, Prop_Send, "moveparent") == iClient)
+		{
+			char sClassname[256];
+			GetEntityClassname(iWearable, sClassname, sizeof(sClassname));
+			if (GiveNamedItem(iClient, sClassname, GetEntProp(iWearable, Prop_Send, "m_iItemDefinitionIndex")) >= Plugin_Handled)
+				TF2_RemoveWearable(iClient, iWearable);
+		}
+	}
+}
+
 stock int TF2_GetAmmo(int iClient, int iSlot)
 {
 	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);


### PR DESCRIPTION
If player respawns but with same cosmetic (including all-class for multi classes) `GiveNamedItem` does not get called as TF2 does not need to create another one. Always check client's weapon and cosmetic on inventory update, and remove if needed.