### PR TITLE
Move Rescue Ranger explosion to Short Circuit

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1529,50 +1529,17 @@
 			"crit"			"1"
 		}
 		
-		"997"	//Rescue Ranger
+		"528"	//Short Circuit
 		{
-			"desp"			"Rescue Ranger: {positive}Bolts explode on impact, {negative}max 130 metal hold"
-			"attrib"		"81 ; 0.65"
-			
-			"spawn"
-			{
-				"Tags_SetEntProp"	//Properly set max metal on spawn
-				{
-					"target"		"client"
-					"type"			"int"
-					"prop"			"m_iAmmo"
-					"element"		"3"			//Metal is in m_iAmmo array at element 3
-					"value"			"130"
-				}
-			}
+			"desp"			"Short Circuit: {positive}Ball explode on impact"
 			
 			"projectile"	//Called when projectile touches something
 			{
 				"Tags_Explode"
 				{
 					"target"		"projectile"
-					"damage"		"60.0"
-					"radius"		"50.0"
-				}
-			}
-		}
-		
-		"528"	//Short Circuit
-		{
-			"desp"			"Short Circuit: {positive}Alt-fire drains rage on hit"
-			
-			"attackdamage"
-			{
-				"filter"
-				{
-					"victimuber"	"0"
-					"damagetype"	"shock"	//Ball shock damage
-				}
-				
-				"Tags_RemoveRage"
-				{
-					"target"		"victim"	//victim boss whos taken damage
-					"amount"		"100"
+					"damage"		"45.0"
+					"radius"		"120.0"
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -158,7 +158,7 @@
 //- particle                - Optional particle effect. Set to a generic explosion particle by default
 //- sound                   - Optional sound of the explosion, up to 16 sounds can be specified. Set to air strike explosion sounds by default. Does not support custom sounds
 //
-//Tags_KillWeapon         - Unequips and destroy weapon target
+//Tags_DestroyEntity      - Destroy entity target
 //
 //Tags_ForceSuicide       - Forces the target to suicide
 
@@ -1541,6 +1541,11 @@
 					"damage"		"45.0"
 					"radius"		"120.0"
 				}
+				
+				"Tags_DestroyEntity"	//Destroy projectile to not call touch again
+				{
+					"target"		"projectile"
+				}
 			}
 		}
 		
@@ -1837,7 +1842,7 @@
 					"duration"		"1.0"	//1 second
 				}
 				
-				"Tags_KillWeapon"	//Kill razorback as 1 time use
+				"Tags_DestroyEntity"	//Kill razorback as 1 time use
 				{
 					"target"		"secondary"
 				}

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -813,9 +813,9 @@ public void Tags_Explode(int iClient, int iTarget, TagsParams tParams)
 	TF2_Explode(iClient, vecPos, flDamage, flRadius, sParticle, sSound);
 }
 
-public void Tags_KillWeapon(int iClient, int iTarget, TagsParams tParams)
+public void Tags_DestroyEntity(int iClient, int iTarget, TagsParams tParams)
 {
-	//Find slot from given target
+	//Check if target is a weapon
 	for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 	{
 		if (TF2_GetItemInSlot(iClient, iSlot) == iTarget)
@@ -828,6 +828,9 @@ public void Tags_KillWeapon(int iClient, int iTarget, TagsParams tParams)
 			return;
 		}
 	}
+	
+	//Not a weapon, remove as normal
+	RemoveEntity(iTarget);
 }
 
 public void Tags_ForceSuicide(int iClient, int iTarget, TagsParams tParams)


### PR DESCRIPTION
This makes rocket jumping requires 65 metal from short circuit's ball, making it more costly to use it, hopefully making it less spammable.

Rescue Ranger lose it's explosion on impact and max 130 metal, leaving weapon as no changes for VSH.
Short Circuit lose it's rage drain from ball in favor of explosion on impact.