### PR TITLE
Fix Vagineer sometimes not being able to deploy sentries

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -217,7 +217,9 @@ methodmap CVagineer < SaxtonHaleBase
 			int iSentry = MaxClients+1;
 			while((iSentry = FindEntityByClassname(iSentry, "obj_sentrygun")) > MaxClients)
 			{
-				if (GetEntPropEnt(iSentry, Prop_Send, "m_hBuilder") == this.iClient)
+				//Wait until the sentry is fully built to drain HP so it doesn't explode while being carried
+				//m_iState: 0 is being carried or in the process of building, 1 is idle (can be either enabled or disabled), 2 is shooting at a target or being wrangled, 3 is in the process of upgrading
+				if (GetEntPropEnt(iSentry, Prop_Send, "m_hBuilder") == this.iClient && GetEntProp(iSentry, Prop_Send, "m_iState") > 0)
 				{
 					SetVariantInt(1);
 					AcceptEntityInput(iSentry, "RemoveHealth");


### PR DESCRIPTION
If Vagineer raged and took a couple of seconds at most to deploy his sentry, it would explode as health drain worked on unplaced buildings too. This pull request fixes that.