### PR TITLE
Ranks and Dome changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2144,7 +2144,7 @@
 		"vsh_boss_chance_multi"     "0.15"              //% chance for next boss to be Multiple bosses (0.0 - 1.0)
 		"vsh_boss_chance_modifiers" "0.15"              //% chance for next boss to have random modifiers (0.0 - 1.0)
 		"vsh_boss_ping_limit"       "200"               //Max ping/latency to allow player play as boss
-		"vsh_boss_rank_health"      "0.05"              //Percentage loss per rank to reduce boss healh
+		"vsh_boss_rank_health"      "0.04"              //Percentage loss per rank to reduce boss healh
 		
 		"vsh_cookies_preferences"   "1"                 //Should preferences use cookies to store? (Disable if you want to store preferences somewhere else)
 		"vsh_cookies_queue"         "1"                 //Should queue use cookies to store? (Disable if you want to store queue somewhere else)
@@ -2164,7 +2164,7 @@
 		"vsh_dome_enable"           "1"                 //Enable dome?
 		"vsh_dome_centre"           ""                  //Map centre pos for Dome/CP (always leave it blank here)
 		"vsh_dome_cp_radius"        "250"               //If vsh_dome_centre specified, new radius from CP to capture
-		"vsh_dome_cp_unlock"        "60"                //Time in second to unlock CP on round start
+		"vsh_dome_cp_unlock"        "30"                //Time in second to unlock CP on round start
 		"vsh_dome_cp_unlockplayer"  "5"                 //Time in second to add on every player to unlock CP on round start
 		"vsh_dome_cp_captime"       "15"                //How long to capture CP
 		"vsh_dome_cp_bossrate"      "2"                 //Capture value for boss
@@ -2173,6 +2173,6 @@
 		"vsh_dome_color_blu"        "0 0 255 255"       //Color of dome in RGBA if red owns the capture point
 		"vsh_dome_radius_start"     "3500"              //Start radius of dome
 		"vsh_dome_radius_end"       "0"                 //End radius of dome
-		"vsh_dome_speed_duration"   "120"               //How long it takes in second for dome to fully shrink, without any slowdown
+		"vsh_dome_speed_duration"   "180"               //How long it takes in second for dome to fully shrink, without any slowdown
 	}
 }

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -89,7 +89,7 @@ enum ClientFlags ( <<=1 )
 enum Preferences ( <<=1 )
 {
 	Preferences_PickAsBoss = 1,
-	Preferences_None1,
+	Preferences_Rank,
 	Preferences_MultiBoss,
 	Preferences_Music,
 	Preferences_Revival,
@@ -207,7 +207,7 @@ enum
 
 char g_strPreferencesName[][] = {
 	"Boss Selection",
-	"",
+	"Rank Mode",
 	"Multi Boss",
 	"Music",
 	"Revival"
@@ -1218,7 +1218,12 @@ public void OnClientDisconnect(int iClient)
 	if (boss.bValid && !boss.bMinion && Rank_IsEnabled())
 	{
 		//Ur not going anywhere kiddo
-		Rank_SetCurrent(iClient, Rank_GetCurrent(iClient) - 1, true);
+		int iRank = Rank_GetCurrent(iClient) - 1;
+		if (iRank >= 0)
+		{
+			PrintToChatAll("%s %s%N%s's rank has %sdecreased%s to %s%d%s!", TEXT_TAG, TEXT_DARK, iClient, TEXT_COLOR, TEXT_NEGATIVE, TEXT_COLOR, TEXT_DARK, iRank, TEXT_COLOR);
+			Rank_SetCurrent(iClient, iRank, true);
+		}
 	}
 	
 	if (boss.bValid)

--- a/addons/sourcemod/scripting/vsh/command.sp
+++ b/addons/sourcemod/scripting/vsh/command.sp
@@ -35,8 +35,6 @@ public void Command_Init()
 	Command_Create("queue", Command_AddQueuePoints);
 	Command_Create("point", Command_AddQueuePoints);
 	Command_Create("special", Command_ForceSpecialRound);
-	Command_Create("cap", Command_EnableCap);
-	Command_Create("cp", Command_EnableCap);
 	Command_Create("dome", Command_ForceDome);
 	Command_Create("rage", Command_SetRage);
 }
@@ -401,29 +399,6 @@ public Action Command_ForceSpecialRound(int iClient, int iArgs)
 		return Plugin_Handled;
 	}
 
-	ReplyToCommand(iClient, "%s%s You do not have permission to use this command.", TEXT_TAG, TEXT_ERROR);
-	return Plugin_Handled;
-}
-
-public Action Command_EnableCap(int iClient, int iArgs)
-{
-	if (!g_bEnabled) return Plugin_Continue;
-
-	if (Client_HasFlag(iClient, ClientFlags_Admin))
-	{
-		if (GameRules_GetPropFloat("m_flCapturePointEnableTime") > GetGameTime())
-		{
-			GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
-			PrintToChatAll("%s%s %N force unlocked capture point!", TEXT_TAG, TEXT_COLOR, iClient);
-		}
-		else
-		{
-			ReplyToCommand(iClient, "%s%s Capture point is already unlocked", TEXT_TAG, TEXT_ERROR);
-		}
-		
-		return Plugin_Handled;
-	}
-	
 	ReplyToCommand(iClient, "%s%s You do not have permission to use this command.", TEXT_TAG, TEXT_ERROR);
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -127,7 +127,7 @@ void Dome_RoundStart()
 	g_bDomeCustomPos = false;
 	
 	g_iDomeEntRef = 0;
-	g_nDomeTeamOwner = TFTeam_Unassigned;
+	Dome_SetTeam(TFTeam_Unassigned);
 	
 	g_flDomeStart = 0.0;
 	g_flDomeRadius = 0.0;
@@ -135,10 +135,7 @@ void Dome_RoundStart()
 	g_hDomeTimerBleed = null;
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
-	{
-		g_flDomePlayerTime[iClient] = 0.0;
 		g_bDomePlayerOutside[iClient] = false;
-	}
 	
 	//CP hud is in the way from our VSH hud, move em to better place
 	int iObjectiveRessource = TF2_GetObjectiveResource();

--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -1,5 +1,4 @@
-//#define DOME_PROP_RADIUS 185.0	//Small prop
-#define DOME_PROP_RADIUS 10000.0	//Huge prop, exactly 10k weeeeeeeeeeee
+#define DOME_PROP_RADIUS 10000.0	//Dome prop radius, exactly 10k weeeeeeeeeeee
 
 #define DOME_FADE_START_MULTIPLIER 0.7
 #define DOME_FADE_ALPHA_MAX 64
@@ -42,6 +41,8 @@ void Dome_Init()
 	g_ConfigConvar.Create("vsh_dome_radius_end", "0", "End radius of dome", _, true, 0.0);
 	g_ConfigConvar.Create("vsh_dome_speed_duration", "120", "How long it takes in second for dome to fully shrink, without any slowdown", _, true, 0.0);
 	
+	HookEntityOutput("tf_logic_arena", "OnCapEnabled", Dome_OnCapEnabled);
+	
 	HookEntityOutput("team_control_point", "OnOwnerChangedToTeam1", Dome_BlockOutput);
 	HookEntityOutput("team_control_point", "OnOwnerChangedToTeam2", Dome_BlockOutput);
 	HookEntityOutput("team_control_point", "OnCapReset", Dome_BlockOutput);
@@ -54,15 +55,6 @@ void Dome_Init()
 
 void Dome_MapStart()
 {
-	/*
-	//Small prop
-	AddFileToDownloadsTable("models/kirillian/brsphere.dx80.vtx");
-	AddFileToDownloadsTable("models/kirillian/brsphere.dx90.vtx");
-	AddFileToDownloadsTable("models/kirillian/brsphere.mdl");
-	AddFileToDownloadsTable("models/kirillian/brsphere.sw.vtx");
-	AddFileToDownloadsTable("models/kirillian/brsphere.vvd");
-	*/
-
 	//Huge prop
 	AddFileToDownloadsTable("models/kirillian/brsphere_huge.dx80.vtx");
 	AddFileToDownloadsTable("models/kirillian/brsphere_huge.dx90.vtx");
@@ -117,6 +109,11 @@ public Action Dome_TriggerTouch(int iTrigger, int iToucher)
 		return Plugin_Handled;
 	
 	return Plugin_Continue;
+}
+
+public Action Dome_OnCapEnabled(const char[] output, int caller, int activator, float delay)
+{
+	Dome_Start();
 }
 
 public Action Dome_BlockOutput(const char[] output, int caller, int activator, float delay)

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -252,7 +252,7 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 		Format(sMessage, sizeof(sMessage), "%s %s with %d health!", sMessage, sBuffer, boss.iMaxHealth);
 	
 		//Get rank
-		if (GetMainBoss() == iClient && Rank_GetCurrent(iClient) > 0)
+		if (Rank_IsHealthEnabled() && Rank_GetCurrent(iClient) > 0)
 			Format(sMessage, sizeof(sMessage), "%s\nRank %d (-%.0f%%%% health)", sMessage, Rank_GetCurrent(iClient), Rank_GetPrecentageLoss(iClient) * 100.0);
 	}
 	
@@ -277,22 +277,7 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 	//Display chat on who is next boss
 	int iNextPlayer = Queue_GetPlayerFromRank(1);
 	if (0 < iNextPlayer <= MaxClients && IsClientInGame(iNextPlayer))
-	{
-		char sFormat[512];
-		Format(sFormat, sizeof(sFormat), "%s================%s\nYou are about to be the next boss!\n", TEXT_DARK, TEXT_COLOR);
-		
-		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iNextPlayer);
-		
-		if (nextBoss.bSpecialClassRound)
-			Format(sFormat, sizeof(sFormat), "%sYour round will be a special class round, rank %s%d%s will not change.", sFormat, TEXT_DARK, Rank_GetPlayerRequirement(iNextPlayer), TEXT_COLOR);
-		else if (Rank_IsAllowed(iNextPlayer))
-			Format(sFormat, sizeof(sFormat), "%sYou are currently at rank %s%d%s.", sFormat, TEXT_DARK, Rank_GetCurrent(iNextPlayer), TEXT_COLOR);
-		else
-			Format(sFormat, sizeof(sFormat), "%sYou need %s%d%s enemy players to have your rank %s%d%s changed.", sFormat, TEXT_DARK, Rank_GetPlayerRequirement(iNextPlayer), TEXT_COLOR, TEXT_DARK, Rank_GetCurrent(iNextPlayer), TEXT_COLOR);
-		
-		Format(sFormat, sizeof(sFormat), "%s%s\n================", sFormat, TEXT_DARK);
-		PrintToChat(iNextPlayer, sFormat);
-	}
+		Rank_DisplayNextClient(iNextPlayer);
 }
 
 public Action Event_RoundEnd(Event event, const char[] sName, bool bDontBroadcast)
@@ -478,11 +463,8 @@ public Action Event_RoundEnd(Event event, const char[] sName, bool bDontBroadcas
 
 public void Event_PointCaptured(Event event, const char[] sName, bool bDontBroadcast)
 {
-	int iCP = event.GetInt("cp");
 	TFTeam nTeam = view_as<TFTeam>(event.GetInt("team"));
-	
 	Dome_SetTeam(nTeam);
-	Dome_Start(iCP);
 }
 
 public void Event_BroadcastAudio(Event event, const char[] sName, bool bDontBroadcast)

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -111,11 +111,10 @@ public Action Event_RoundArenaStart(Event event, const char[] sName, bool bDontB
 {
 	if (!g_bEnabled || GameRules_GetProp("m_bInWaitingForPlayers")) return;
 
-	//Play one round of arena
+	//Play one round of arena, and force unlock/enable dome
 	if (g_iTotalRoundPlayed <= 0)
 	{
-		Dome_SetTeam(TFTeam_Unassigned);
-		Dome_Start();
+		GameRules_SetPropFloat("m_flCapturePointEnableTime", 0.0);
 		return;
 	}
 

--- a/addons/sourcemod/scripting/vsh/menu/menu_admin.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_admin.sp
@@ -12,7 +12,6 @@ void MenuAdmin_Init()
 	g_hMenuAdminMain.AddItem("config", "Refresh VSH Config (!vshrefresh)");
 	g_hMenuAdminMain.AddItem("queue", "Add Queue (!vshqueue)");
 	g_hMenuAdminMain.AddItem("special", "Force Special Round (!vshspecial)");
-	g_hMenuAdminMain.AddItem("cap", "Force Unlock Capture Point (!vshcap)");
 	g_hMenuAdminMain.AddItem("dome", "Force Start Dome (!vshdome)");
 	g_hMenuAdminMain.AddItem("boss", "Set Next Boss & Modifiers (!vshsetboss)");
 	g_hMenuAdminMain.AddItem("rage", "Set Rage (!vshrage)");
@@ -77,8 +76,6 @@ public int MenuAdmin_SelectMain(Menu hMenu, MenuAction action, int iClient, int 
 		MenuAdmin_DisplayQueue(iClient);
 	else if (StrEqual(sSelect, "special"))
 		MenuAdmin_DisplaySpecial(iClient);
-	else if (StrEqual(sSelect, "cap"))
-		ClientCommand(iClient, "vsh_cap");
 	else if (StrEqual(sSelect, "dome"))
 		ClientCommand(iClient, "vsh_dome");
 	else if (StrEqual(sSelect, "boss"))

--- a/addons/sourcemod/scripting/vsh/rank.sp
+++ b/addons/sourcemod/scripting/vsh/rank.sp
@@ -1,4 +1,5 @@
 static bool g_bRankEnabled = false;
+static bool g_bRankHealth = false;
 static int g_iRank[TF_MAXPLAYERS+1];
 
 void Rank_Init()
@@ -10,28 +11,57 @@ void Rank_Init()
 
 void Rank_RoundStart()
 {
-	Rank_SetEnable(false);
+	g_bRankEnabled = false;
+	g_bRankHealth = false;
 	
-	//Get main boss
-	int iBoss = GetMainBoss();
-	if (iBoss <= 0 || iBoss > MaxClients || !IsClientInGame(iBoss))
-		return;
-	
-	// Enable rank if allows to
-	if (Rank_IsAllowed(iBoss))
+	// Enable health if main boss, rank is loaded and pref enabled
+	int iClient = GetMainBoss();
+	if (0 < iClient <= MaxClients && Rank_GetCurrent(iClient) >= 0 && Preferences_Get(iClient, Preferences_Rank))
 	{
-		Rank_SetEnable(true);
-		SaxtonHaleBase boss = SaxtonHaleBase(iBoss);
-		int iHealth = boss.CallFunction("CalculateMaxHealth");
-		boss.iMaxHealth = iHealth;
-		boss.iHealth = iHealth;
+		g_bRankHealth = true;
+		
+		// Allow rank increase/decrease if not special round and enough players
+		if (!ClassLimit_IsSpecialRoundOn() && g_iTotalAttackCount >= Rank_GetPlayerRequirement(iClient))
+			g_bRankEnabled = true;
 	}
+	
+	//Refresh max health
+	for (int i = 1; i <= MaxClients; i++)
+	{
+		SaxtonHaleBase boss = SaxtonHaleBase(i);
+		if (boss.bValid)
+		{
+			int iHealth = boss.CallFunction("CalculateMaxHealth");
+			boss.iMaxHealth = iHealth;
+			boss.iHealth = iHealth;
+		}
+	}
+}
+
+public void Rank_DisplayNextClient(int iClient)
+{
+	char sFormat[512];
+	Format(sFormat, sizeof(sFormat), "%s================%s\nYou are about to be the next boss!\n", TEXT_DARK, TEXT_COLOR);
+	
+	SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(iClient);
+	
+	if (nextBoss.bSpecialClassRound)
+		Format(sFormat, sizeof(sFormat), "%sYour round will be a special class round, your rank %s%d%s will not change.", sFormat, TEXT_DARK, Rank_GetCurrent(iClient), TEXT_COLOR);
+	else if (!Preferences_Get(iClient, Preferences_Rank))
+		Format(sFormat, sizeof(sFormat), "%sYour rank preference is disabled, your rank %s%d%s will not change.", sFormat, TEXT_DARK, Rank_GetCurrent(iClient), TEXT_COLOR);
+	else if (g_iTotalAttackCount < Rank_GetPlayerRequirement(iClient))
+		Format(sFormat, sizeof(sFormat), "%sYou need %s%d%s enemy players to have your rank %s%d%s changed.", sFormat, TEXT_DARK, Rank_GetPlayerRequirement(iClient), TEXT_COLOR, TEXT_DARK, Rank_GetCurrent(iClient), TEXT_COLOR);
+	else
+		Format(sFormat, sizeof(sFormat), "%sYou are currently at rank %s%d%s.", sFormat, TEXT_DARK, Rank_GetCurrent(iClient), TEXT_COLOR);
+	
+	Format(sFormat, sizeof(sFormat), "%s%s\n================", sFormat, TEXT_DARK);
+	PrintToChat(iClient, sFormat);
 }
 
 public Action Rank_CalculateMaxHealth(SaxtonHaleBase boss, int &iHealth)
 {
 	//Cut down health if enabled
-	if (!boss.bMinion && 0 < GetMainBoss())
+	if (!boss.bMinion && g_bRankHealth)
 	{
 		iHealth = RoundToNearest(float(iHealth) * (1.0 - Rank_GetPrecentageLoss(boss.iClient)));
 		return Plugin_Changed;
@@ -40,12 +70,12 @@ public Action Rank_CalculateMaxHealth(SaxtonHaleBase boss, int &iHealth)
 	return Plugin_Continue;
 }
 
-stock int Rank_GetCurrent(int iClient)
+int Rank_GetCurrent(int iClient)
 {
 	return g_iRank[iClient];
 }
 
-stock void Rank_SetCurrent(int iClient, int iRank, bool bUpdate = false)
+void Rank_SetCurrent(int iClient, int iRank, bool bUpdate = false)
 {
 	g_iRank[iClient] = iRank;
 	
@@ -53,24 +83,22 @@ stock void Rank_SetCurrent(int iClient, int iRank, bool bUpdate = false)
 		Cookies_SaveRank(iClient, iRank);
 }
 
-stock bool Rank_IsEnabled()
+bool Rank_IsEnabled()
 {
 	return g_bRankEnabled;
 }
 
-stock void Rank_SetEnable(bool bValue)
+void Rank_SetEnable(bool bValue)
 {
 	g_bRankEnabled = bValue;
 }
 
-stock bool Rank_IsAllowed(int iClient)
+bool Rank_IsHealthEnabled()
 {
-	return Rank_GetCurrent(iClient) != -1								//Is his current rank loaded
-		&& (GetMainBoss() != iClient || !ClassLimit_IsSpecialRoundOn())	//If boss, is special round not on
-		&& g_iTotalAttackCount >= Rank_GetPlayerRequirement(iClient);	//Is there enough attack players
+	return g_bRankHealth;
 }
 
-stock int Rank_GetPlayerRequirement(int iClient)
+int Rank_GetPlayerRequirement(int iClient)
 {
 	int iPlayerRequirement = 5 + Rank_GetCurrent(iClient);
 	if (iPlayerRequirement > 20) iPlayerRequirement = 20;
@@ -78,7 +106,7 @@ stock int Rank_GetPlayerRequirement(int iClient)
 	return iPlayerRequirement;
 }
 
-stock float Rank_GetPrecentageLoss(int iClient)
+float Rank_GetPrecentageLoss(int iClient)
 {
 	float flPrecentage = float(Rank_GetCurrent(iClient)) * g_ConfigConvar.LookupFloat("vsh_boss_rank_health");
 	if (flPrecentage > 0.99)


### PR DESCRIPTION
Ranks:
- Reduce percentage loss for every rank from 5% to 4%
- Readd preference to enable/disable rank, disabling rank will allow you to play with full health without affecting current rank.
- Display in chat when boss left server causing rank to lower down.

Dome:
- CP unlock now force start a neutral dome.
- Reduce time it takes for CP to unlock from `60 + (5 * N)` to `30 + (5 * N)` where `N` is number of attack players.
- Increase time takes for dome to fully shrink from 120 seconds to 180 seconds.
- Remove admin command to unlock CP, as it now does same effect as starting dome.