### PR TITLE
Disallow heavies from getting effects from the "lunchbox" function when they throw food instead of eating it

### DIFF
--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -93,7 +93,9 @@ void Tags_OnThink(int iClient)
 				if (iAmmo == 0 && !g_bTagsLunchbox[iClient])
 				{
 					g_bTagsLunchbox[iClient] = true;
-					TagsCore_CallAll(iClient, TagsCall_Lunchbox);
+					
+					if (TF2_IsPlayerInCondition(iClient, TFCond_Taunting))
+						TagsCore_CallAll(iClient, TagsCall_Lunchbox);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the dalokoh's bar giving heavies infinite ammo at a trivial cost.