### PR TITLE
Another Pyrocar rework

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_float_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_float_jump.sp
@@ -120,9 +120,9 @@ methodmap CFloatJump < SaxtonHaleBase
 		//Default values, these can be changed if needed
 		ability.iMaxJumpCharge = 200;
 		ability.iJumpChargeBuild = 4;
-		ability.flMaxDistance = 725.0;
+		ability.flMaxDistance = 750.0;
 		ability.flMaxHeight = 500.0;
-		ability.flCooldown = 7.5;
+		ability.flCooldown = 7.0;
 		ability.flDuration = 1.0;
 		ability.flGravity = 0.3;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -213,13 +213,13 @@ methodmap CPyroCar < SaxtonHaleBase
 			//Give victim less healing while damaged by pyrocar
 			if (!g_hPyrocarHealTimer[victim])
 			{
-				TF2Attrib_SetByDefIndex(victim, ATTRIB_LESSHEALING, 0.35);
+				TF2Attrib_SetByDefIndex(victim, ATTRIB_LESSHEALING, 0.3);
 				TF2Attrib_ClearCache(victim);
 			}
 			else
 			{
 				KillTimer(g_hPyrocarHealTimer[victim]);
-				g_hPyrocarHealTimer[victim] = CreateTimer(0.6, Timer_RemoveLessHealing, GetClientSerial(victim));
+				g_hPyrocarHealTimer[victim] = CreateTimer(0.75, Timer_RemoveLessHealing, GetClientSerial(victim));
 			}
 			
 			//Deal constant damage for flamethrower

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -201,7 +201,7 @@ methodmap CPyroCar < SaxtonHaleBase
 			
 		float flHealingRate = 1.0;
 		if (TF2_IsPlayerInCondition(this.iClient, TFCond_Milked) && this.iClient != attacker && TF2_FindAttribute(attacker, ATTRIB_LESSHEALING, flHealingRate))
-			SDKHooks_TakeDamage(attacker, attacker, attacker, RoundToNearest(10 - flHealingRate/damage));
+			SDKHooks_TakeDamage(attacker, attacker, attacker, damage - flHealingRate/damage);
 		
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -1,7 +1,7 @@
 #define ITEM_NEON_ANNIHILATOR			813
 #define ITEM_BACKBURNER					40
 #define ATTRIB_LESSHEALING				734
-#define PYROCAR_BACKBURNER_ATTRIBUTES	"24 ; 1.0 ; 37 ; 0.2 ; 59 ; 1.0 ; 72 ; 0.0 ; 112 ; 0.625 ; 178 ; 0.01 ; 181 ; 1.0 ; 252 ; 0.5 ; 259 ; 1.0 ; 356 ; 1.0 ; 839 ; 2.8 ; 841 ; 0 ; 843 ; 8.5 ; 844 ; 1850.0 ; 862 ; 0.4 ; 863 ; 0.01 ; 865 ; 85 ; 214 ; %d"
+#define PYROCAR_BACKBURNER_ATTRIBUTES	"24 ; 1.0 ; 37 ; 0.25 ; 59 ; 1.0 ; 72 ; 0.0 ; 112 ; 0.6 ; 178 ; 0.01 ; 181 ; 1.0 ; 252 ; 0.5 ; 259 ; 1.0 ; 356 ; 1.0 ; 839 ; 2.8 ; 841 ; 0 ; 843 ; 8.5 ; 844 ; 1850.0 ; 862 ; 0.4 ; 863 ; 0.01 ; 865 ; 85 ; 214 ; %d"
 
 static char g_strPyrocarRoundStart[][] =  {
 	"vsh_rewrite/pyrocar/pyrocar_intro.mp3", 
@@ -95,7 +95,7 @@ methodmap CPyroCar < SaxtonHaleBase
 		StrCat(sInfo, length, "\n ");
 		StrCat(sInfo, length, "\nRage");
 		StrCat(sInfo, length, "\n- Hops repeatedly dealing explosive damage near the impact for 8 seconds");
-		StrCat(sInfo, length, "\n- You additionally gain defensive buff and immunity to knockback");
+		StrCat(sInfo, length, "\n- Rage also grants you defensive buff and immunity to knockback");
 		StrCat(sInfo, length, "\n- 200%% Rage: Increases explosion damage and extends the duration to 12 seconds");
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -1,7 +1,7 @@
 #define ITEM_NEON_ANNIHILATOR			813
 #define ITEM_BACKBURNER					40
 #define ATTRIB_LESSHEALING				734
-#define PYROCAR_BACKBURNER_ATTRIBUTES	"24 ; 1.0 ; 37 ; 0.25 ; 59 ; 1.0 ; 72 ; 0.0 ; 112 ; 0.6 ; 178 ; 0.01 ; 181 ; 1.0 ; 252 ; 0.5 ; 259 ; 1.0 ; 356 ; 1.0 ; 839 ; 2.8 ; 841 ; 0 ; 843 ; 8.5 ; 844 ; 1850.0 ; 862 ; 0.4 ; 863 ; 0.01 ; 865 ; 85 ; 214 ; %d"
+#define PYROCAR_BACKBURNER_ATTRIBUTES	"24 ; 1.0 ; 37 ; 0.25 ; 59 ; 1.0 ; 72 ; 0.0 ; 112 ; 0.6 ; 178 ; 0.01 ; 181 ; 1.0 ; 252 ; 0.5 ; 259 ; 1.0 ; 356 ; 1.0 ; 839 ; 2.8 ; 841 ; 0 ; 843 ; 8.5 ; 844 ; 2000.0 ; 862 ; 0.45 ; 863 ; 0.01 ; 865 ; 85 ; 214 ; %d"
 
 static char g_strPyrocarRoundStart[][] =  {
 	"vsh_rewrite/pyrocar/pyrocar_intro.mp3", 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -201,7 +201,7 @@ methodmap CPyroCar < SaxtonHaleBase
 			
 		float flHealingRate = 1.0;
 		if (TF2_IsPlayerInCondition(this.iClient, TFCond_Milked) && this.iClient != attacker && TF2_FindAttribute(attacker, ATTRIB_LESSHEALING, flHealingRate))
-			Client_AddHealth(attacker, RoundToNearest(damage - flHealingRate/damage));
+			SDKHooks_TakeDamage(attacker, attacker, attacker, RoundToNearest(10 - flHealingRate/damage));
 		
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -1,12 +1,17 @@
+#define ATTRIB_LESSHEALING				734
+
 stock void Client_AddHealth(int iClient, int iAdditionalHeal, int iMaxOverHeal=0)
 {
 	int iMaxHealth = SDK_GetMaxHealth(iClient);
 	int iHealth = GetEntProp(iClient, Prop_Send, "m_iHealth");
 	int iTrueMaxHealth = iMaxHealth+iMaxOverHeal;
-
+	
+	float flHealingRate = 1.0;
+	TF2_FindAttribute(iClient, ATTRIB_LESSHEALING, flHealingRate);
+	
 	if (iHealth < iTrueMaxHealth)
 	{
-		iHealth += iAdditionalHeal;
+		iHealth += RoundToNearest(float(iAdditionalHeal) * flHealingRate);
 		if (iHealth > iTrueMaxHealth) iHealth = iTrueMaxHealth;
 		SetEntProp(iClient, Prop_Send, "m_iHealth", iHealth);
 	}


### PR DESCRIPTION
Shortened Pyrocar's flamethrower range to 2000 (from 2450)
Rage now grants Pyrocar a defensive buff plus knockback immunity in addition to the current rage plus 1000% air control
Slightly increased explosive damage from the rage
Slightly increased float speed and slightly reduced cooldown
The healing penalty to the current target now applies to madmilk and half-zatoshi
Flamethrower damage increased from 15 to 16
Max ammo is now 50 and regens 30
Updated Pyrocar's description