### PR TITLE
Update dome position for vsh_lobster_shore

### DIFF
--- a/addons/sourcemod/configs/vsh/maps.cfg
+++ b/addons/sourcemod/configs/vsh/maps.cfg
@@ -116,8 +116,8 @@
 		}
 		"vsh_lobster_shore"
 		{
-			"vsh_dome_centre"		"-1504 64 120"
-			"vsh_dome_radius_start"	"3500"
+			"vsh_dome_centre"		"-1312 -1504 56"
+			"vsh_dome_radius_start"	"4000"
 		}
 		"vsh_manncohq"
 		{


### PR DESCRIPTION
This moves CP more closer to red spawn, so red players cant camp underneath one of the tiny spot while next to CP
![20200624194217_1](https://user-images.githubusercontent.com/33488710/85614728-1d663600-b653-11ea-9abf-fce8551ef6cc.jpg)
