### PR TITLE
Another pyrocar rework

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_float_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_float_jump.sp
@@ -122,7 +122,7 @@ methodmap CFloatJump < SaxtonHaleBase
 		ability.iJumpChargeBuild = 4;
 		ability.flMaxDistance = 750.0;
 		ability.flMaxHeight = 500.0;
-		ability.flCooldown = 7.0;
+		ability.flCooldown = 8.0;
 		ability.flDuration = 1.0;
 		ability.flGravity = 0.3;
 	}
@@ -199,8 +199,8 @@ methodmap CFloatJump < SaxtonHaleBase
 				return;
 			
 			float flCooldownTime = (this.flCooldown*(float(this.iJumpCharge)/float(this.iMaxJumpCharge)));
-			if (flCooldownTime < 4.0)
-				flCooldownTime = 4.0;
+			if (flCooldownTime < 5.0)
+				flCooldownTime = 5.0;
 			
 			g_flFloatJumpCooldownWait[this.iClient] = GetGameTime()+flCooldownTime;
 			

--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_hop.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_hop.sp
@@ -95,8 +95,8 @@ methodmap CRageHop < SaxtonHaleBase
 		ability.flRageHopMaxHeight = 500.0;
 		ability.flRageHopMaxDistance = 1.2;
 		
-		ability.flBombDamage = 24.0;
-		ability.flBombRadius = 250.0;
+		ability.flBombDamage = 23.0;
+		ability.flBombRadius = 275.0;
 		
 		ability.flDuration = 8.0;
 	}
@@ -125,7 +125,7 @@ methodmap CRageHop < SaxtonHaleBase
 			//Calculate velocity and apply damage multiplier
 			float flFinalBombDamage = (g_vecPeakVel[this.iClient] + 110.0) / 100.0 * -this.flBombDamage;
 			if (flFinalBombDamage < 30.0) flFinalBombDamage = 30.0;
-			if (flFinalBombDamage > 150.0) flFinalBombDamage = 150.0;
+			if (flFinalBombDamage > 140.0) flFinalBombDamage = 140.0;
 			
 			if (this.bSuperRage)
 			{
@@ -175,7 +175,7 @@ methodmap CRageHop < SaxtonHaleBase
 			TF2_AddCondition(this.iClient, TFCond_MegaHeal, g_flDuration[this.iClient]);
 		}
 		
-		TF2Attrib_SetByDefIndex(this.iClient, ATTRIB_AIRCONTROL, 10.0);
+		TF2Attrib_SetByDefIndex(this.iClient, ATTRIB_AIRCONTROL, 8.0);
 		g_vecPeakVel[this.iClient] = 0.0;
 		
 		char sSound[PLATFORM_MAX_PATH];


### PR DESCRIPTION
**-Flamethrower now fires in quick bursts (has 5 ammo that regens in 1 second once all the ammo has been used)**
**-Damage increased by 33% to compensate**
-Regen penalty to enemies now lasts 1 second but provides 60% penalty instead of 70%
-Shortened flamethrower range
-Gravity jump cooldown increased by 1 second
-Bounce jump damage reduced by ~10% but explosion range increased by 10%