### PR TITLE
Add boss multi class type

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -89,6 +89,7 @@ enum SaxtonHaleClassType
 	VSHClassType_Boss,      /**< Boss */
 	VSHClassType_Ability,   /**< Ability */
 	VSHClassType_Modifier,  /**< Modifier */
+	VSHClassType_BossMulti,	/**< Multi Boss */
 };
 
 /**
@@ -135,16 +136,6 @@ native ArrayList SaxtonHale_GetAllClass();
  * @return                  Newly created ArrayList of registered class name, filtered by class type
  */
 native ArrayList SaxtonHale_GetAllClassType(SaxtonHaleClassType nClassType);
-
-/**
- * Registers multi bosses to be played togther
- *
- * @note Make sure SaxtonHale_RegisterClass is used first to register each bosses
- *
- * @param ...               Methodmap class name to registers for multi bosses
- * @error                   Class name already registered, or less than 2 bosses passed
- */
-native void SaxtonHale_RegisterMultiBoss(const char[] ...);
 
 /**
  * List of sounds to get from bosses
@@ -517,6 +508,17 @@ methodmap SaxtonHaleNextBoss
 	// @param sBossType     String value to set, NULL_STRING for random boss
 	public native void SetBoss(const char[] sBossType);
 	
+	//Gets current boss multi type
+	//
+	// @param sMultiType    String value to get, NULL_STRING if not specified yet
+	// @param iLength       Size of string
+	public native void GetBossMulti(char[] sMultiType, int iLength);
+	
+	//Sets new boss multi type
+	//
+	// @param sMultiType    String value to set, NULL_STRING for random boss
+	public native void SetBossMulti(const char[] sMultiType);
+	
 	//Gets current modifier type
 	//
 	// @param sModifierType String value to get, NULL_STRING if not specified yet
@@ -789,6 +791,9 @@ native void SaxtonHale_RegisterAbility(const char[] sAbilityType);
 
 #pragma deprecated Use SaxtonHale_UnregisterClass instead
 native void SaxtonHale_UnregisterAbility(const char[] sAbilityType);
+
+#pragma deprecated No longer supported, use SaxtonHale_RegisterClass instead
+native void SaxtonHale_RegisterMultiBoss(const char[] ...);
 
 #pragma deprecated Use SaxtonHaleNextBoss property bSpecialClass and nSpecialClass instead
 native bool SaxtonHale_ForceSpecialRound(int iClient = 0, TFClassType nClass = TFClass_Unknown);

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -465,10 +465,14 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	FuncNative_AskLoad();
 	Native_AskLoad();
 	Property_AskLoad();
-	
+
+#if !defined __sourcepawn_methodmap__
+	Format(error, err_max, "This plugin should be compiled with SourcePawn Public Methodmap to be compiled correctly!");
+	return APLRes_Failure;
+#else
 	RegPluginLibrary("saxtonhale");
-	
 	return APLRes_Success;
+#endif
 }
 
 public void OnPluginStart()

--- a/addons/sourcemod/scripting/vsh/base_bossmulti.sp
+++ b/addons/sourcemod/scripting/vsh/base_bossmulti.sp
@@ -1,0 +1,57 @@
+static char g_sClientBossMultiType[TF_MAXPLAYERS+1][64];
+
+methodmap SaxtonHaleBossMulti < SaxtonHaleBase
+{
+	public SaxtonHaleBase CreateBossMulti(const char[] type)
+	{
+		if (type[0])
+		{
+			strcopy(g_sClientBossMultiType[this.iClient], sizeof(g_sClientBossMultiType[]), type);
+		}
+		else
+		{
+			//Empty? get default multi boss
+			this.CallFunction("GetBossMultiType", g_sClientBossMultiType[this.iClient], sizeof(g_sClientBossMultiType[]));
+		}
+		
+		//Call boss multi constructor function
+		if (this.StartFunction(g_sClientBossMultiType[this.iClient], g_sClientBossMultiType[this.iClient]))
+		{
+			Call_PushCell(this);
+			Call_Finish();
+		}
+		
+		return view_as<SaxtonHaleBase>(this);
+	}
+	
+	public void SetBossMultiType(const char[] type)
+	{
+		strcopy(g_sClientBossMultiType[this.iClient], sizeof(g_sClientBossMultiType[]), type);
+	}
+	
+	public void GetBossMultiType(char[] type, int length)
+	{
+		//If we dont have any, allow bosses use it default multi type
+		if (!StrEmpty(g_sClientBossMultiType[this.iClient]))
+			strcopy(type, length, g_sClientBossMultiType[this.iClient]);
+	}
+	
+	public bool IsBossMultiType(const char[] type)
+	{
+		return StrEqual(g_sClientBossMultiType[this.iClient], type);
+	}
+
+	public void GetBossMultiName(char[] sName, int length)
+	{
+		Format(sName, length, "Unknown Boss Multi Name");
+	}
+	
+	public void Destroy()
+	{
+		//Call destroy function now, since boss type get reset before called
+		if (this.StartFunction(g_sClientBossMultiType[this.iClient], "Destroy"))
+			Call_Finish();
+		
+		strcopy(g_sClientBossMultiType[this.iClient], sizeof(g_sClientBossMultiType[]), "");
+	}
+};

--- a/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
@@ -1,10 +1,5 @@
 #define BLUTARCH_MODEL		"models/player/kirillian/boss/boss_blutarch_v2.mdl"
 
-static char g_strBlutarchRoundStart[][] = {
-	"vo/halloween_mann_brothers/sf13_mannbros_argue09.mp3",
-	"vo/halloween_mann_brothers/sf13_mannbros_argue14.mp3",
-};
-
 static char g_strBlutarchWin[][] = {
 	"vo/halloween_mann_brothers/sf13_blutarch_win04.mp3",
 	"vo/halloween_mann_brothers/sf13_blutarch_win11.mp3",
@@ -22,13 +17,7 @@ static char g_strBlutarchLose[][] = {
 	"vo/halloween_mann_brothers/sf13_blutarch_lose04.mp3",
 	"vo/halloween_mann_brothers/sf13_blutarch_lose07.mp3",
 };
-/*
-static char g_strBlutarchSpell[][] = {
-	"vo/halloween_mann_brothers/sf13_blutarch_misc01.mp3",
-	"vo/halloween_mann_brothers/sf13_blutarch_spells04.mp3",
-	"vo/halloween_mann_brothers/sf13_blutarch_spells05.mp3",
-};
-*/
+
 static char g_strBlutarchRage[][] = {
 	"vo/halloween_mann_brothers/sf13_blutarch_spells04.mp3",
 	"vo/halloween_mann_brothers/sf13_blutarch_spells05.mp3",
@@ -62,6 +51,16 @@ methodmap CBlutarch < SaxtonHaleBase
 		boss.iMaxRageDamage = 2500;
 	}
 	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CMannBrothers");
+	}
+	
+	public bool IsBossHidden()
+	{
+		return true;
+	}
+	
 	public void GetBossName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Blutarch");
@@ -79,22 +78,6 @@ methodmap CBlutarch < SaxtonHaleBase
 		StrCat(sInfo, length, "\nRage");
 		StrCat(sInfo, length, "\n- Summons a Meteor spell");
 		StrCat(sInfo, length, "\n- 200%% Rage: Summons 3 Meteor spells");
-	}
-	
-	public void OnSpawn()
-	{
-		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0");
-		int iWeapon = this.CallFunction("CreateWeapon", 574, "tf_weapon_knife", 100, TFQual_Haunted, attribs);
-		if (iWeapon > MaxClients)
-			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
-		/*
-		Wanga Prick attributes:
-		
-		2: damage bonus
-		252: reduction in push force taken from damage
-		259: Deals 3x falling damage to the player you land on
-		*/
 	}
 	
 	public void OnDeath(Event eventInfo)
@@ -128,7 +111,6 @@ methodmap CBlutarch < SaxtonHaleBase
 	{
 		switch (iSoundType)
 		{
-			case VSHSound_RoundStart: strcopy(sSound, length, g_strBlutarchRoundStart[GetRandomInt(0,sizeof(g_strBlutarchRoundStart)-1)]);
 			case VSHSound_Win: strcopy(sSound, length, g_strBlutarchWin[GetRandomInt(0,sizeof(g_strBlutarchWin)-1)]);
 			case VSHSound_Lose: strcopy(sSound, length, g_strBlutarchLose[GetRandomInt(0,sizeof(g_strBlutarchLose)-1)]);
 			case VSHSound_Rage: strcopy(sSound, length, g_strBlutarchRage[GetRandomInt(0,sizeof(g_strBlutarchRage)-1)]);
@@ -137,30 +119,13 @@ methodmap CBlutarch < SaxtonHaleBase
 		}
 	}
 	
-	/*
-	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
-	{
-		if (strcmp(sType, "CWeaponSpells") == 0 && GetRandomInt(0, 1))
-			strcopy(sSound, length, g_strBlutarchSpell[GetRandomInt(0,sizeof(g_strBlutarchSpell)-1)]);
-	}
-	*/
-	
-	public Action OnSoundPlayed(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
-	{
-		if (strncmp(sample, "vo/", 3) == 0 && strncmp(sample, "vo/halloween_mann_brothers/", 27) != 0)
-			return Plugin_Handled;
-		return Plugin_Continue;
-	}
-	
 	public void Precache()
 	{
 		PrecacheModel(BLUTARCH_MODEL);
 		
-		for (int i = 0; i < sizeof(g_strBlutarchRoundStart); i++) PrecacheSound(g_strBlutarchRoundStart[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchWin); i++) PrecacheSound(g_strBlutarchWin[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchDeath); i++) PrecacheSound(g_strBlutarchDeath[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchLose); i++) PrecacheSound(g_strBlutarchLose[i]);
-		//for (int i = 0; i < sizeof(g_strBlutarchSpell); i++) PrecacheSound(g_strBlutarchSpell[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchRage); i++) PrecacheSound(g_strBlutarchRage[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchLastMan); i++) PrecacheSound(g_strBlutarchLastMan[i]);
 		for (int i = 0; i < sizeof(g_strBlutarchBackstabbed); i++) PrecacheSound(g_strBlutarchBackstabbed[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyromancer_scalded.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyromancer_scalded.sp
@@ -5,50 +5,6 @@
 
 static const float RAGE_DURATION = 8.0;
 
-static char g_strPyromancerRoundStart[][] = 
-{
-	"vo/pyro_laughevil01.mp3",
-	"vo/pyro_laughevil02.mp3",
-	"vo/pyro_laughevil03.mp3",
-	"vo/pyro_laughevil04.mp3"
-};
-
-static char g_strPyromancerRage[][] = 
-{
-	"vo/pyro_battlecry01.mp3",
-	"vo/pyro_battlecry02.mp3",
-};
-
-static char g_strPyromancerKill[][] = 
-{
-	"vo/pyro_cheers01.mp3",
-	"vo/pyro_goodjob01.mp3"
-};
-
-static char g_strPyromancerJump[][] = 
-{
-	"vo/pyro_jeers01.mp3",
-	"vo/pyro_jeers02.mp3"
-};
-
-static char g_strPrecacheCosmetics[][] =
-{
-	"models/player/items/pyro/pyro_pyromancers_mask.mdl",
-	"models/player/items/pyro/hwn_pyro_misc1.mdl",
-	"models/player/items/pyro/sore_eyes.mdl",
-	"models/workshop/player/items/pyro/hw2013_dragonbutt/hw2013_dragonbutt.mdl"
-};
-
-static int g_iCosmetics[] =
-{
-	316,
-	550,
-	387,
-	30225
-};
-
-static int g_iPrecacheCosmetics[4];
-
 static float g_flFlamethrowerRemoveTime[TF_MAXPLAYERS+1];
 
 static CRageAddCond addCond;
@@ -70,6 +26,11 @@ methodmap CScaldedPyromancer < SaxtonHaleBase
 		boss.nClass = TFClass_Pyro;
 		boss.iMaxRageDamage = 1700;
 		g_flFlamethrowerRemoveTime[boss.iClient] = 0.0;
+	}
+	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CPyromancers");
 	}
 	
 	public bool IsBossHidden()
@@ -110,26 +71,6 @@ methodmap CScaldedPyromancer < SaxtonHaleBase
 		20: crit vs burning players
 		252: reduction in push force taken from damage
 		*/
-		
-		for (int i = 0; i < sizeof(g_iCosmetics); i++)
-		{
-			int iWearable = this.CallFunction("CreateWeapon", g_iCosmetics[i], "tf_wearable", 1, TFQual_Collectors, "");
-			if (iWearable > MaxClients)
-			{
-				SetEntProp(iWearable, Prop_Send, "m_nModelIndexOverrides", g_iPrecacheCosmetics[i]);
-				
-				if (i == 0) //Pyromancer's Mask
-				{
-					SetEntProp(iWearable, Prop_Send, "m_nSkin", 2);
-					SetEntityRenderColor(iWearable, 0, 0, 255, 200);
-				}
-				
-				if (i == 3) //Cauterizer's Caudal Appendage
-				{
-					SetEntityRenderColor(iWearable, 0, 0, 255, 255);
-				}
-			}
-		}
 	}
 	
 	public void OnRage()
@@ -200,40 +141,5 @@ methodmap CScaldedPyromancer < SaxtonHaleBase
 			if (iMeleeWep > MaxClients)
 				SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iMeleeWep);
 		}
-	}
-	
-	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
-	{
-		switch (iSoundType)
-		{
-			case VSHSound_RoundStart: strcopy(sSound, length, g_strPyromancerRoundStart[GetRandomInt(0,sizeof(g_strPyromancerRoundStart)-1)]);
-			case VSHSound_Rage: strcopy(sSound, length, g_strPyromancerRage[GetRandomInt(0,sizeof(g_strPyromancerRage)-1)]);
-			case VSHSound_Lastman: strcopy(sSound, length, g_strPyromancerRage[0]);
-			case VSHSound_Win: strcopy(sSound, length, g_strPyromancerKill[0]);
-			case VSHSound_Lose: strcopy(sSound, length, g_strPyromancerJump[0]);
-			case VSHSound_Backstab: strcopy(sSound, length, g_strPyromancerJump[1]);
-		}
-	}
-	
-	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
-	{
-		if (strcmp(sType, "CBraveJump") == 0)
-			strcopy(sSound, length, g_strPyromancerJump[GetRandomInt(0,sizeof(g_strPyromancerJump)-1)]);
-	}	
-	
-	public void GetSoundKill(char[] sSound, int length, TFClassType nClass)
-	{
-		strcopy(sSound, length, g_strPyromancerKill[GetRandomInt(0,sizeof(g_strPyromancerKill)-1)]);
-	}
-	
-	public void Precache()
-	{
-		for (int i = 0; i < sizeof(g_iCosmetics); i++)
-			g_iPrecacheCosmetics[i] = PrecacheModel(g_strPrecacheCosmetics[i]);
-	
-		for (int i = 0; i < sizeof(g_strPyromancerRoundStart); i++) PrecacheSound(g_strPyromancerRoundStart[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerRage); i++) PrecacheSound(g_strPyromancerRage[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerKill); i++) PrecacheSound(g_strPyromancerKill[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerJump); i++) PrecacheSound(g_strPyromancerJump[i]);
 	}
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyromancer_scorched.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyromancer_scorched.sp
@@ -5,58 +5,12 @@
 
 static const float RAGE_DURATION = 8.0;
 
-static char g_strPyromancerRoundStart[][] = 
-{
-	"vo/pyro_laughevil01.mp3",
-	"vo/pyro_laughevil02.mp3",
-	"vo/pyro_laughevil03.mp3",
-	"vo/pyro_laughevil04.mp3"
-};
-
-static char g_strPyromancerRage[][] = 
-{
-	"vo/pyro_battlecry01.mp3",
-	"vo/pyro_battlecry02.mp3",
-};
-
-static char g_strPyromancerKill[][] = 
-{
-	"vo/pyro_cheers01.mp3",
-	"vo/pyro_goodjob01.mp3"
-};
-
-static char g_strPyromancerJump[][] = 
-{
-	"vo/pyro_jeers01.mp3",
-	"vo/pyro_jeers02.mp3"
-};
-
-static char g_strPrecacheCosmetics[][] =
-{
-	"models/player/items/pyro/pyro_pyromancers_mask.mdl",
-	"models/player/items/pyro/hwn_pyro_misc1.mdl",
-	"models/player/items/pyro/sore_eyes.mdl",
-	"models/workshop/player/items/pyro/hw2013_dragonbutt/hw2013_dragonbutt.mdl"
-};
-
-static int g_iCosmetics[] =
-{
-	316,
-	550,
-	387,
-	30225
-};
-
-static int g_iPrecacheCosmetics[4];
-
-static CRageAddCond addCond;
-
 methodmap CScorchedPyromancer < SaxtonHaleBase
 {
 	public CScorchedPyromancer(CScorchedPyromancer boss)
 	{
 		boss.CallFunction("CreateAbility", "CBraveJump");
-		addCond = boss.CallFunction("CreateAbility", "CRageAddCond");
+		CRageAddCond addCond = boss.CallFunction("CreateAbility", "CRageAddCond");
 		addCond.flRageCondDuration = RAGE_DURATION;
 		addCond.AddCond(TFCond_Buffed);
 		
@@ -64,6 +18,11 @@ methodmap CScorchedPyromancer < SaxtonHaleBase
 		boss.iHealthPerPlayer = 750;
 		boss.nClass = TFClass_Pyro;
 		boss.iMaxRageDamage = 1700;
+	}
+	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CPyromancers");
 	}
 	
 	public bool IsBossHidden()
@@ -103,26 +62,6 @@ methodmap CScorchedPyromancer < SaxtonHaleBase
 		208: ignite target on hit
 		252: reduction in push force taken from damage
 		*/
-		
-		for (int i = 0; i < sizeof(g_iCosmetics); i++)
-		{
-			int iWearable = this.CallFunction("CreateWeapon", g_iCosmetics[i], "tf_wearable", 1, TFQual_Collectors, "");
-			if (iWearable > MaxClients)
-			{
-				SetEntProp(iWearable, Prop_Send, "m_nModelIndexOverrides", g_iPrecacheCosmetics[i]);
-				
-				if (i == 0) //Pyromancer's Mask
-				{
-					SetEntProp(iWearable, Prop_Send, "m_nSkin", 2);
-					SetEntityRenderColor(iWearable, 255, 0, 0, 200);
-				}
-				
-				if (i == 3) //Cauterizer's Caudal Appendage
-				{
-					SetEntityRenderColor(iWearable, 255, 0, 0, 255);
-				}
-			}
-		}
 	}
 	
 	public void OnRage()
@@ -147,40 +86,5 @@ methodmap CScorchedPyromancer < SaxtonHaleBase
 	public void OnThink()
 	{
 		Hud_AddText(this.iClient, "HINT: Stay near the other Pyromancer so they can crit ignited players!");
-	}
-	
-	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
-	{
-		switch (iSoundType)
-		{
-			case VSHSound_RoundStart: strcopy(sSound, length, g_strPyromancerRoundStart[GetRandomInt(0,sizeof(g_strPyromancerRoundStart)-1)]);
-			case VSHSound_Rage: strcopy(sSound, length, g_strPyromancerRage[GetRandomInt(0,sizeof(g_strPyromancerRage)-1)]);
-			case VSHSound_Lastman: strcopy(sSound, length, g_strPyromancerRage[0]);
-			case VSHSound_Win: strcopy(sSound, length, g_strPyromancerKill[0]);
-			case VSHSound_Lose: strcopy(sSound, length, g_strPyromancerJump[0]);
-			case VSHSound_Backstab: strcopy(sSound, length, g_strPyromancerJump[1]);
-		}
-	}
-	
-	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
-	{
-		if (strcmp(sType, "CBraveJump") == 0)
-			strcopy(sSound, length, g_strPyromancerJump[GetRandomInt(0,sizeof(g_strPyromancerJump)-1)]);
-	}	
-	
-	public void GetSoundKill(char[] sSound, int length, TFClassType nClass)
-	{
-		strcopy(sSound, length, g_strPyromancerKill[GetRandomInt(0,sizeof(g_strPyromancerKill)-1)]);
-	}
-	
-	public void Precache()
-	{
-		for (int i = 0; i < sizeof(g_iCosmetics); i++)
-			g_iPrecacheCosmetics[i] = PrecacheModel(g_strPrecacheCosmetics[i]);
-	
-		for (int i = 0; i < sizeof(g_strPyromancerRoundStart); i++) PrecacheSound(g_strPyromancerRoundStart[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerRage); i++) PrecacheSound(g_strPyromancerRage[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerKill); i++) PrecacheSound(g_strPyromancerKill[i]);
-		for (int i = 0; i < sizeof(g_strPyromancerJump); i++) PrecacheSound(g_strPyromancerJump[i]);
 	}
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -1,10 +1,5 @@
 #define REDMOND_MODEL		"models/player/kirillian/boss/boss_redmond_v2.mdl"
 
-static char g_strRedmondRoundStart[][] = {
-	"vo/halloween_mann_brothers/sf13_mannbros_argue09.mp3",
-	"vo/halloween_mann_brothers/sf13_mannbros_argue13.mp3",
-};
-
 static char g_strRedmondWin[][] = {
 	"vo/halloween_mann_brothers/sf13_redmond_win05.mp3",
 	"vo/halloween_mann_brothers/sf13_redmond_win08.mp3",
@@ -23,12 +18,7 @@ static char g_strRedmondLose[][] = {
 	"vo/halloween_mann_brothers/sf13_redmond_lose07.mp3",
 	"vo/halloween_mann_brothers/sf13_redmond_lose08.mp3",
 };
-/*
-static char g_strRedmondSpell[][] = {
-	"vo/halloween_mann_brothers/sf13_redmond_spells02.mp3",
-	"vo/halloween_mann_brothers/sf13_redmond_spells06.mp3",
-};
-*/
+
 static char g_strRedmondRage[][] = {
 	"vo/halloween_mann_brothers/sf13_redmond_spells02.mp3",
 	"vo/halloween_mann_brothers/sf13_redmond_spells06.mp3",
@@ -61,6 +51,16 @@ methodmap CRedmond < SaxtonHaleBase
 		boss.iMaxRageDamage = 2500;
 	}
 	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CMannBrothers");
+	}
+	
+	public bool IsBossHidden()
+	{
+		return true;
+	}
+	
 	public void GetBossName(char[] sName, int length)
 	{
 		strcopy(sName, length, "Redmond");
@@ -79,22 +79,6 @@ methodmap CRedmond < SaxtonHaleBase
 		StrCat(sInfo, length, "\nRage");
 		StrCat(sInfo, length, "\n- Summons a MONOCULUS! spell");
 		StrCat(sInfo, length, "\n- 200%% Rage: Summons 3 MONOCULUS! spells");
-	}
-	
-	public void OnSpawn()
-	{
-		char attribs[128];
-		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0");
-		int iWeapon = this.CallFunction("CreateWeapon", 574, "tf_weapon_knife", 100, TFQual_Haunted, attribs);
-		if (iWeapon > MaxClients)
-			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
-		/*
-		Wanga Prick attributes:
-		
-		2: damage bonus
-		252: reduction in push force taken from damage
-		259: Deals 3x falling damage to the player you land on
-		*/
 	}
 	
 	public void OnDeath(Event eventInfo)
@@ -146,7 +130,6 @@ methodmap CRedmond < SaxtonHaleBase
 	{
 		switch (iSoundType)
 		{
-			case VSHSound_RoundStart: strcopy(sSound, length, g_strRedmondRoundStart[GetRandomInt(0,sizeof(g_strRedmondRoundStart)-1)]);
 			case VSHSound_Win: strcopy(sSound, length, g_strRedmondWin[GetRandomInt(0,sizeof(g_strRedmondWin)-1)]);
 			case VSHSound_Lose: strcopy(sSound, length, g_strRedmondLose[GetRandomInt(0,sizeof(g_strRedmondLose)-1)]);
 			case VSHSound_Rage: strcopy(sSound, length, g_strRedmondRage[GetRandomInt(0,sizeof(g_strRedmondRage)-1)]);
@@ -154,29 +137,14 @@ methodmap CRedmond < SaxtonHaleBase
 			case VSHSound_Backstab: strcopy(sSound, length, g_strRedmondBackstabbed[GetRandomInt(0,sizeof(g_strRedmondBackstabbed)-1)]);
 		}
 	}
-	/*
-	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
-	{
-		if (strcmp(sType, "CWeaponSpells") == 0 && GetRandomInt(0, 1))
-			strcopy(sSound, length, g_strRedmondSpell[GetRandomInt(0,sizeof(g_strRedmondSpell)-1)]);
-	}
-	*/
-	public Action OnSoundPlayed(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
-	{
-		if (strncmp(sample, "vo/", 3) == 0)//Block voicelines
-			return Plugin_Handled;
-		return Plugin_Continue;
-	}
-	
+		
 	public void Precache()
 	{
 		PrecacheModel(REDMOND_MODEL);
 		
-		for (int i = 0; i < sizeof(g_strRedmondRoundStart); i++) PrecacheSound(g_strRedmondRoundStart[i]);
 		for (int i = 0; i < sizeof(g_strRedmondWin); i++) PrecacheSound(g_strRedmondWin[i]);
 		for (int i = 0; i < sizeof(g_strRedmondDeath); i++) PrecacheSound(g_strRedmondDeath[i]);
 		for (int i = 0; i < sizeof(g_strRedmondLose); i++) PrecacheSound(g_strRedmondLose[i]);
-		//for (int i = 0; i < sizeof(g_strRedmondSpell); i++) PrecacheSound(g_strRedmondSpell[i]);
 		for (int i = 0; i < sizeof(g_strRedmondRage); i++) PrecacheSound(g_strRedmondRage[i]);
 		for (int i = 0; i < sizeof(g_strRedmondLastMan); i++) PrecacheSound(g_strRedmondLastMan[i]);
 		for (int i = 0; i < sizeof(g_strRedmondBackstabbed); i++) PrecacheSound(g_strRedmondBackstabbed[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -1,6 +1,5 @@
 #define SEELDIER_MODEL						"models/player/kirillian/boss/seeldier_fix.mdl"
 #define SEELDIER_SEE_SND					"vsh_rewrite/seeldier/see.wav"
-#define SEE_BOSSES_INTRO_SND				"vsh_rewrite/seeman/intro.wav"
 
 methodmap CSeeldier < SaxtonHaleBase
 {
@@ -13,6 +12,16 @@ methodmap CSeeldier < SaxtonHaleBase
 		boss.iHealthPerPlayer = 700;
 		boss.nClass = TFClass_Soldier;
 		boss.iMaxRageDamage = 2000;
+	}
+	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CSeeManSeeldier");
+	}
+	
+	public bool IsBossHidden()
+	{
+		return true;
 	}
 	
 	public void GetBossName(char[] sName, int length)
@@ -99,11 +108,8 @@ methodmap CSeeldier < SaxtonHaleBase
 	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
 	{
 		//C on every sounds
-		switch (iSoundType)
-		{
-			case VSHSound_RoundStart: strcopy(sSound, length, SEE_BOSSES_INTRO_SND);
-			default: strcopy(sSound, length, SEELDIER_SEE_SND);
-		}
+		if (iSoundType != VSHSound_RoundStart)
+			strcopy(sSound, length, SEELDIER_SEE_SND);
 	}
 	
 	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
@@ -128,7 +134,6 @@ methodmap CSeeldier < SaxtonHaleBase
 	
 	public void Precache()
 	{
-		PrepareSound(SEE_BOSSES_INTRO_SND);
 		PrecacheModel(SEELDIER_MODEL);
 		PrepareSound(SEELDIER_SEE_SND);
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
@@ -1,7 +1,6 @@
 #define SEEMAN_MODEL						"models/player/kirillian/boss/seeman_fix.mdl"
 #define SEEMAN_RAGE_SND						"vsh_rewrite/seeman/rage.wav"
 #define SEEMAN_SEE_SND						"vsh_rewrite/seeman/see.wav"
-#define SEE_BOSSES_INTRO_SND				"vsh_rewrite/seeman/intro.wav"
 
 methodmap CSeeMan < SaxtonHaleBase
 {
@@ -26,6 +25,16 @@ methodmap CSeeMan < SaxtonHaleBase
 		rageCond.flRageCondDuration = 3.0;
 		rageCond.flRageCondSuperRageMultiplier = 1.0;
 		rageCond.AddCond(TFCond_UberchargedCanteen);
+	}
+	
+	public void GetBossMultiType(char[] sType, int length)
+	{
+		strcopy(sType, length, "CSeeManSeeldier");
+	}
+	
+	public bool IsBossHidden()
+	{
+		return true;
 	}
 	
 	public void GetBossName(char[] sName, int length)
@@ -83,11 +92,8 @@ methodmap CSeeMan < SaxtonHaleBase
 	
 	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
 	{
-		switch (iSoundType)
-		{
-			case VSHSound_RoundStart: strcopy(sSound, length, SEE_BOSSES_INTRO_SND);
-			default: strcopy(sSound, length, SEEMAN_SEE_SND);
-		}
+		if (iSoundType != VSHSound_RoundStart)
+			strcopy(sSound, length, SEEMAN_SEE_SND);
 	}
 	
 	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
@@ -120,7 +126,6 @@ methodmap CSeeMan < SaxtonHaleBase
 	{
 		PrepareSound(SEEMAN_SEE_SND);
 		PrepareSound(SEEMAN_RAGE_SND);
-		PrepareSound(SEE_BOSSES_INTRO_SND);
 		PrecacheModel(SEEMAN_MODEL);
 		
 		AddFileToDownloadsTable("models/player/kirillian/boss/seeman_fix.mdl");

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_mannbrothers.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_mannbrothers.sp
@@ -21,6 +21,20 @@ methodmap CMannBrothers < SaxtonHaleBase
 		strcopy(sName, length, "Mann Brothers");
 	}
 	
+	public void GetBossMultiInfo(char[] sInfo, int length)
+	{
+		StrCat(sInfo, length, "\nMelee deals 124 damage");
+		StrCat(sInfo, length, "\nHealth: Low");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nAbilities");
+		StrCat(sInfo, length, "\n- Spells: alt-attack to use spell for 20%% of rage");
+		StrCat(sInfo, length, "\n- Redmond use Bats spell, Blutarch use Teleport spell");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nRage");
+		StrCat(sInfo, length, "\n- Redmond summons a Meteor spell, Blutarch summons a MONOCULUS! spell");
+		StrCat(sInfo, length, "\n- 200%% Rage: Summons 3 spells");
+	}
+	
 	public void OnSpawn()
 	{
 		char attribs[128];

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_mannbrothers.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_mannbrothers.sp
@@ -1,0 +1,57 @@
+static char g_strMannBrothersRoundStart[][] = {
+	"vo/halloween_mann_brothers/sf13_mannbros_argue09.mp3",
+	"vo/halloween_mann_brothers/sf13_mannbros_argue13.mp3",
+	"vo/halloween_mann_brothers/sf13_mannbros_argue14.mp3",
+};
+
+methodmap CMannBrothers < SaxtonHaleBase
+{
+	public CMannBrothers(CMannBrothers boss)
+	{
+	}
+	
+	public void GetBossMultiList(ArrayList aList)
+	{
+		aList.PushString("CBlutarch");
+		aList.PushString("CRedmond");
+	}
+	
+	public void GetBossMultiName(char[] sName, int length)
+	{
+		strcopy(sName, length, "Mann Brothers");
+	}
+	
+	public void OnSpawn()
+	{
+		char attribs[128];
+		Format(attribs, sizeof(attribs), "2 ; 3.1 ; 252 ; 0.5 ; 259 ; 1.0");
+		int iWeapon = this.CallFunction("CreateWeapon", 574, "tf_weapon_knife", 100, TFQual_Haunted, attribs);
+		if (iWeapon > MaxClients)
+			SetEntPropEnt(this.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
+		/*
+		Wanga Prick attributes:
+		
+		2: damage bonus
+		252: reduction in push force taken from damage
+		259: Deals 3x falling damage to the player you land on
+		*/
+	}
+	
+	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
+	{
+		if (iSoundType == VSHSound_RoundStart)
+			strcopy(sSound, length, g_strMannBrothersRoundStart[GetRandomInt(0,sizeof(g_strMannBrothersRoundStart)-1)]);
+	}
+	
+	public Action OnSoundPlayed(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
+	{
+		if (strncmp(sample, "vo/", 3) == 0 && strncmp(sample, "vo/halloween_mann_brothers/", 27) != 0)
+			return Plugin_Handled;
+		return Plugin_Continue;
+	}
+	
+	public void Precache()
+	{
+		for (int i = 0; i < sizeof(g_strMannBrothersRoundStart); i++) PrecacheSound(g_strMannBrothersRoundStart[i]);
+	}
+};

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_pyromancers.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_pyromancers.sp
@@ -1,0 +1,125 @@
+static char g_strPyromancerRoundStart[][] = 
+{
+	"vo/pyro_laughevil01.mp3",
+	"vo/pyro_laughevil02.mp3",
+	"vo/pyro_laughevil03.mp3",
+	"vo/pyro_laughevil04.mp3"
+};
+
+static char g_strPyromancerRage[][] = 
+{
+	"vo/pyro_battlecry01.mp3",
+	"vo/pyro_battlecry02.mp3",
+};
+
+static char g_strPyromancerKill[][] = 
+{
+	"vo/pyro_cheers01.mp3",
+	"vo/pyro_goodjob01.mp3"
+};
+
+static char g_strPyromancerJump[][] = 
+{
+	"vo/pyro_jeers01.mp3",
+	"vo/pyro_jeers02.mp3"
+};
+
+static char g_strPrecacheCosmetics[][] =
+{
+	"models/player/items/pyro/pyro_pyromancers_mask.mdl",
+	"models/player/items/pyro/hwn_pyro_misc1.mdl",
+	"models/player/items/pyro/sore_eyes.mdl",
+	"models/workshop/player/items/pyro/hw2013_dragonbutt/hw2013_dragonbutt.mdl"
+};
+
+static int g_iCosmetics[] =
+{
+	316,
+	550,
+	387,
+	30225
+};
+
+static int g_iPrecacheCosmetics[4];
+
+methodmap CPyromancers < SaxtonHaleBase
+{
+	public CPyromancers(CPyromancers boss)
+	{
+		boss.CallFunction("CreateAbility", "CBraveJump");
+	}
+	
+	public void GetBossMultiList(ArrayList aList)
+	{
+		aList.PushString("CScaldedPyromancer");
+		aList.PushString("CScorchedPyromancer");
+	}
+	
+	public bool IsBossMultiHidden()
+	{
+		return true;
+	}
+	
+	public void GetBossMultiName(char[] sName, int length)
+	{
+		strcopy(sName, length, "Pyromancers");
+	}
+	
+	public void OnSpawn()
+	{
+		for (int i = 0; i < sizeof(g_iCosmetics); i++)
+		{
+			int iWearable = this.CallFunction("CreateWeapon", g_iCosmetics[i], "tf_wearable", 1, TFQual_Collectors, "");
+			if (iWearable > MaxClients)
+			{
+				SetEntProp(iWearable, Prop_Send, "m_nModelIndexOverrides", g_iPrecacheCosmetics[i]);
+				
+				if (i == 0) //Pyromancer's Mask
+				{
+					SetEntProp(iWearable, Prop_Send, "m_nSkin", 2);
+					SetEntityRenderColor(iWearable, 0, 0, 255, 200);
+				}
+				
+				if (i == 3) //Cauterizer's Caudal Appendage
+				{
+					SetEntityRenderColor(iWearable, 0, 0, 255, 255);
+				}
+			}
+		}
+	}
+	
+	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
+	{
+		switch (iSoundType)
+		{
+			case VSHSound_RoundStart: strcopy(sSound, length, g_strPyromancerRoundStart[GetRandomInt(0,sizeof(g_strPyromancerRoundStart)-1)]);
+			case VSHSound_Rage: strcopy(sSound, length, g_strPyromancerRage[GetRandomInt(0,sizeof(g_strPyromancerRage)-1)]);
+			case VSHSound_Lastman: strcopy(sSound, length, g_strPyromancerRage[0]);
+			case VSHSound_Win: strcopy(sSound, length, g_strPyromancerKill[0]);
+			case VSHSound_Lose: strcopy(sSound, length, g_strPyromancerJump[0]);
+			case VSHSound_Backstab: strcopy(sSound, length, g_strPyromancerJump[1]);
+		}
+	}
+	
+	public void GetSoundAbility(char[] sSound, int length, const char[] sType)
+	{
+		if (strcmp(sType, "CBraveJump") == 0)
+			strcopy(sSound, length, g_strPyromancerJump[GetRandomInt(0,sizeof(g_strPyromancerJump)-1)]);
+	}	
+	
+	public void GetSoundKill(char[] sSound, int length, TFClassType nClass)
+	{
+		strcopy(sSound, length, g_strPyromancerKill[GetRandomInt(0,sizeof(g_strPyromancerKill)-1)]);
+	}
+	
+	public void Precache()
+	{
+		for (int i = 0; i < sizeof(g_iCosmetics); i++)
+			g_iPrecacheCosmetics[i] = PrecacheModel(g_strPrecacheCosmetics[i]);
+	
+		for (int i = 0; i < sizeof(g_strPyromancerRoundStart); i++) PrecacheSound(g_strPyromancerRoundStart[i]);
+		for (int i = 0; i < sizeof(g_strPyromancerRage); i++) PrecacheSound(g_strPyromancerRage[i]);
+		for (int i = 0; i < sizeof(g_strPyromancerKill); i++) PrecacheSound(g_strPyromancerKill[i]);
+		for (int i = 0; i < sizeof(g_strPyromancerJump); i++) PrecacheSound(g_strPyromancerJump[i]);
+	}
+}

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_pyromancers.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_pyromancers.sp
@@ -65,6 +65,21 @@ methodmap CPyromancers < SaxtonHaleBase
 		strcopy(sName, length, "Pyromancers");
 	}
 	
+	public void GetBossMultiInfo(char[] sInfo, int length)
+	{
+		StrCat(sInfo, length, "\nMelee deals 80 damage.");
+		StrCat(sInfo, length, "\nHealth: Low");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nAbilities");
+		StrCat(sInfo, length, "\n- Boost Jump");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nRage");
+		StrCat(sInfo, length, "\n- Scalded grants a degreaser for 8 seconds");
+		StrCat(sInfo, length, "\n- 200%% Rage: Scalded grants a buffed backburner with quick-switch for 8 seconds");
+		StrCat(sInfo, length, "\n- Scorched ignite all players within 500 units");
+		StrCat(sInfo, length, "\n- 200%% Rage: Scorched ignite all players on the map");
+	}
+	
 	public void OnSpawn()
 	{
 		for (int i = 0; i < sizeof(g_iCosmetics); i++)

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_seemanseeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_seemanseeldier.sp
@@ -1,0 +1,30 @@
+#define SEE_BOSSES_INTRO_SND				"vsh_rewrite/seeman/intro.wav"
+
+methodmap CSeeManSeeldier < SaxtonHaleBase
+{
+	public CSeeManSeeldier(CSeeManSeeldier bossmulti)
+	{
+	}
+	
+	public void GetBossMultiList(ArrayList aList)
+	{
+		aList.PushString("CSeeMan");
+		aList.PushString("CSeeldier");
+	}
+	
+	public void GetBossMultiName(char[] sName, int length)
+	{
+		strcopy(sName, length, "SeeMan and Seeldier");
+	}
+	
+	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
+	{
+		if (iSoundType == VSHSound_RoundStart)
+			strcopy(sSound, length, SEE_BOSSES_INTRO_SND);
+	}
+	
+	public void Precache()
+	{
+		PrepareSound(SEE_BOSSES_INTRO_SND);
+	}
+};

--- a/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_seemanseeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bossesmulti/bossmulti_seemanseeldier.sp
@@ -17,6 +17,21 @@ methodmap CSeeManSeeldier < SaxtonHaleBase
 		strcopy(sName, length, "SeeMan and Seeldier");
 	}
 	
+	public void GetBossMultiInfo(char[] sInfo, int length)
+	{
+		StrCat(sInfo, length, "\nMelee deals 124 damage");
+		StrCat(sInfo, length, "\nHealth: Low");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nAbilities");
+		StrCat(sInfo, length, "\n- Brave Jump");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\nRage");
+		StrCat(sInfo, length, "\n- Seeman frozen with Übercharge for 3 seconds with many small explosions around boss");
+		StrCat(sInfo, length, "\n- 200%% Rage: Seeman instakill nuke at end of rage");
+		StrCat(sInfo, length, "\n- Seeldlier summons 3 mini seeldiers");
+		StrCat(sInfo, length, "\n- 200%% Rage: Seeldlier summons 6 mini seeldiers");
+	}
+	
 	public void GetSound(char[] sSound, int length, SaxtonHaleSound iSoundType)
 	{
 		if (iSoundType == VSHSound_RoundStart)

--- a/addons/sourcemod/scripting/vsh/command.sp
+++ b/addons/sourcemod/scripting/vsh/command.sp
@@ -15,6 +15,7 @@ public void Command_Init()
 	Command_Create("class", Command_Weapon);
 	Command_Create("weapon", Command_Weapon);
 	Command_Create("boss", Command_Boss);
+	Command_Create("multiboss", Command_MultiBoss);
 	Command_Create("modifiers", Command_Modifiers);
 	Command_Create("next", Command_HaleNext);
 	Command_Create("credits", Command_Credits);
@@ -115,7 +116,21 @@ public Action Command_Boss(int iClient, int iArgs)
 		return Plugin_Handled;
 	}
 
-	MenuBoss_DisplayBossList(iClient, MenuBoss_CallbackInfo);
+	MenuBoss_DisplayList(iClient, VSHClassType_Boss, MenuBoss_CallbackInfo);
+	return Plugin_Handled;
+}
+
+public Action Command_MultiBoss(int iClient, int iArgs)
+{
+	if (!g_bEnabled) return Plugin_Continue;
+
+	if (iClient == 0)
+	{
+		ReplyToCommand(iClient, "This Command can only be used ingame");
+		return Plugin_Handled;
+	}
+
+	MenuBoss_DisplayList(iClient, VSHClassType_BossMulti, MenuBoss_CallbackInfo);
 	return Plugin_Handled;
 }
 
@@ -129,7 +144,7 @@ public Action Command_Modifiers(int iClient, int iArgs)
 		return Plugin_Handled;
 	}
 
-	MenuBoss_DisplayModifiersList(iClient, MenuBoss_CallbackInfo);
+	MenuBoss_DisplayList(iClient, VSHClassType_Modifier, MenuBoss_CallbackInfo);
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/vsh/function/func_call.sp
+++ b/addons/sourcemod/scripting/vsh/function/func_call.sp
@@ -21,6 +21,17 @@ void FuncCall_Start(SaxtonHaleBase boss, FuncStack funcStack)
 		if (funcStack.nParamType[iParam] == Param_String || funcStack.nParamType[iParam] == Param_Array)
 			funcStack.GetArray(iParam+1, array[iParam]);
 	
+	//Call base_bossmulti
+	if (!FuncCall_Call(boss, "SaxtonHaleBossMulti", funcStack, array, iArraySize))
+		return;
+	
+	//Call multi boss specifc
+	SaxtonHaleBossMulti saxtonBossMulti = view_as<SaxtonHaleBossMulti>(boss);
+	saxtonBossMulti.GetBossMultiType(sBuffer, sizeof(sBuffer));
+	if (!StrEmpty(sBuffer))
+		if (!FuncCall_Call(boss, sBuffer, funcStack, array, iArraySize))
+			return;
+	
 	//Call base_boss
 	if (!FuncCall_Call(boss, "SaxtonHaleBoss", funcStack, array, iArraySize))
 		return;

--- a/addons/sourcemod/scripting/vsh/function/func_native.sp
+++ b/addons/sourcemod/scripting/vsh/function/func_native.sp
@@ -241,12 +241,6 @@ public any FuncNative_RegisterClass(Handle hPlugin, int iNumParams)
 	
 	if (!FuncClass_Register(sClass, hPlugin, nClassType))
 		ThrowNativeError(SP_ERROR_NATIVE, "Methodmap Class (%s) already registered", sClass);
-	
-	switch (nClassType)
-	{
-		case VSHClassType_Boss: MenuBoss_AddInfoBoss(sClass);
-		case VSHClassType_Modifier: MenuBoss_AddInfoModifiers(sClass);
-	}
 }
 
 //void SaxtonHale_UnregisterClass(const char[] sClass);
@@ -263,7 +257,6 @@ public any FuncNative_UnregisterClass(Handle hPlugin, int iNumParams)
 		ThrowNativeError(SP_ERROR_NATIVE, "Unregister core class (%s) is not allowed", sClass);
 	
 	FuncClass_Unregister(sClass);
-	MenuBoss_RemoveInfo(sClass);
 	NextBoss_RemoveMulti(sClass);
 }
 

--- a/addons/sourcemod/scripting/vsh/menu.sp
+++ b/addons/sourcemod/scripting/vsh/menu.sp
@@ -19,6 +19,7 @@ void Menu_Init()
 	g_hMenuMain.SetTitle("[VSH REWRITE] - %s.%s", PLUGIN_VERSION, PLUGIN_VERSION_REVISION);
 	g_hMenuMain.AddItem("class", "Class & Weapon Menu (!vshclass)");
 	g_hMenuMain.AddItem("boss", "Bosses Info (!vshboss)");
+	g_hMenuMain.AddItem("bossmulti", "Multi Bosses Info (!vshmultiboss)");
 	g_hMenuMain.AddItem("modifiers", "Modifiers Info (!vshmodifiers)");
 	g_hMenuMain.AddItem("queue", "Queue List (!vshnext)");
 	g_hMenuMain.AddItem("preference", "Settings (!vshsettings)");
@@ -72,9 +73,11 @@ public int Menu_SelectMain(Menu hMenu, MenuAction action, int iClient, int iSele
 	if (StrEqual(sSelect, "class"))
 		MenuWeapon_DisplayMain(iClient);
 	else if (StrEqual(sSelect, "boss"))
-		MenuBoss_DisplayBossList(iClient, MenuBoss_CallbackInfo);
+		MenuBoss_DisplayList(iClient, VSHClassType_Boss, MenuBoss_CallbackInfo);
+	else if (StrEqual(sSelect, "bossmulti"))
+		MenuBoss_DisplayList(iClient, VSHClassType_BossMulti, MenuBoss_CallbackInfo);
 	else if (StrEqual(sSelect, "modifiers"))
-		MenuBoss_DisplayModifiersList(iClient, MenuBoss_CallbackInfo);
+		MenuBoss_DisplayList(iClient, VSHClassType_Modifier, MenuBoss_CallbackInfo);
 	else if (StrEqual(sSelect, "queue"))
 		Menu_DisplayQueue(iClient);
 	else if (StrEqual(sSelect, "preference"))

--- a/addons/sourcemod/scripting/vsh/menu/menu_boss.sp
+++ b/addons/sourcemod/scripting/vsh/menu/menu_boss.sp
@@ -10,29 +10,58 @@ enum struct MenuBossSelect
 	int iClient;
 	char sBossType[MAX_TYPE_CHAR];
 	char sModifierType[MAX_TYPE_CHAR];
+	char sBossMultiType[MAX_TYPE_CHAR];
+}
+
+enum struct MenuBossListInfo
+{
+	char sTitle[32];
+	char sSetType[MAX_TYPE_CHAR];
+	char sIsHidden[MAX_TYPE_CHAR];
+	char sGetName[MAX_TYPE_CHAR];
+	char sGetInfo[512];
 }
 
 //Callback when selecting boss/modifiers list
 typedef MenuBossListCallback = function void (int iClient, const char[] sType);
 
+static SaxtonHaleClassType g_nMenuBossClassType[TF_MAXPLAYERS+1];	//Current class type using
 static MenuBossListCallback g_fMenuBossCallback[TF_MAXPLAYERS+1];	//Callback function to use once client selected boss/modifiers
 
-static StringMap g_mMenuInfo; 		//Menu handles of boss/modifers info
 static MenuBossSelect g_menuBossSelect[TF_MAXPLAYERS+1];
+static MenuBossListInfo g_menuBossListInfo[view_as<int>(SaxtonHaleClassType)];
 
 void MenuBoss_Init()
 {
-	g_mMenuInfo = new StringMap();
+	g_menuBossListInfo[VSHClassType_Boss].sTitle = "Boss Menu";
+	g_menuBossListInfo[VSHClassType_Boss].sSetType = "SetBossType";
+	g_menuBossListInfo[VSHClassType_Boss].sIsHidden = "IsBossHidden";
+	g_menuBossListInfo[VSHClassType_Boss].sGetName = "GetBossName";
+	g_menuBossListInfo[VSHClassType_Boss].sGetInfo = "GetBossInfo";
+	
+	g_menuBossListInfo[VSHClassType_Modifier].sTitle = "Modifiers Menu";
+	g_menuBossListInfo[VSHClassType_Modifier].sSetType = "SetModifiersType";
+	g_menuBossListInfo[VSHClassType_Modifier].sIsHidden = "IsModifiersHidden";
+	g_menuBossListInfo[VSHClassType_Modifier].sGetName = "GetModifiersName";
+	g_menuBossListInfo[VSHClassType_Modifier].sGetInfo = "GetModifiersInfo";
+	
+	g_menuBossListInfo[VSHClassType_BossMulti].sTitle = "Multi Boss Menu";
+	g_menuBossListInfo[VSHClassType_BossMulti].sSetType = "SetBossMultiType";
+	g_menuBossListInfo[VSHClassType_BossMulti].sIsHidden = "IsBossMultiHidden";
+	g_menuBossListInfo[VSHClassType_BossMulti].sGetName = "GetBossMultiName";
+	g_menuBossListInfo[VSHClassType_BossMulti].sGetInfo = "GetBossMultiInfo";
 }
 
+// --------------------
+
 /*
- * Display list of bosses/modifiers
+ * Display list of classes
  */
 
-void MenuBoss_DisplayBossList(int iClient, MenuBossListCallback callback, int iFlags = 0)
+void MenuBoss_DisplayList(int iClient, SaxtonHaleClassType nClassType, MenuBossListCallback callback, int iFlags = 0)
 {
 	Menu hMenuList = new Menu(MenuBoss_SelectList);
-	hMenuList.SetTitle("Boss Menu\n---");
+	hMenuList.SetTitle("%s\n---", g_menuBossListInfo[nClassType].sTitle);
 	hMenuList.AddItem("back", "<- back");
 	
 	if (iFlags & MenuBossFlags_Random)
@@ -41,77 +70,42 @@ void MenuBoss_DisplayBossList(int iClient, MenuBossListCallback callback, int iF
 	if (iFlags & MenuBossFlags_None)
 		hMenuList.AddItem("none", "None");
 	
-	//Loop through every bosses
-	ArrayList aBosses = FuncClass_GetAllType(VSHClassType_Boss);
-	aBosses.Sort(Sort_Ascending, Sort_String);
-	int iLength = aBosses.Length;
+	//Loop through every classes by type
+	ArrayList aClasses = FuncClass_GetAllType(nClassType);
+	aClasses.Sort(Sort_Ascending, Sort_String);
+	int iLength = aClasses.Length;
 	for (int i = 0; i < iLength; i++)
 	{
 		//Get boss type
 		char sBossType[MAX_TYPE_CHAR];
-		aBosses.GetString(i, sBossType, sizeof(sBossType));
+		aClasses.GetString(i, sBossType, sizeof(sBossType));
 		
 		SaxtonHaleBase boss = SaxtonHaleBase(0);
-		boss.CallFunction("SetBossType", sBossType);
+		boss.CallFunction(g_menuBossListInfo[nClassType].sSetType, sBossType);
 		
-		//If disallow hidden bosses, check that
-		if (!(iFlags & MenuBossFlags_Hidden) && boss.CallFunction("IsBossHidden"))
+		//If disallow hidden class, check that
+		if (!(iFlags & MenuBossFlags_Hidden) && boss.CallFunction(g_menuBossListInfo[nClassType].sIsHidden))
 			continue;
 		
 		//Get boss name
 		char sName[512];
-		boss.CallFunction("GetBossName", sName, sizeof(sName));
+		boss.CallFunction(g_menuBossListInfo[nClassType].sGetName, sName, sizeof(sName));
 		
 		//Add to menu
 		hMenuList.AddItem(sBossType, sName);
 	}
 	
-	delete aBosses;
+	delete aClasses;
+	g_nMenuBossClassType[iClient] = nClassType;
 	g_fMenuBossCallback[iClient] = callback;
 	hMenuList.Display(iClient, MENU_TIME_FOREVER);
 }
 
-void MenuBoss_DisplayModifiersList(int iClient, MenuBossListCallback callback, int iFlags = 0)
-{
-	Menu hMenuList = new Menu(MenuBoss_SelectList);
-	hMenuList.SetTitle("Modifiers Menu\n---");
-	hMenuList.AddItem("back", "<- back");
-	
-	if (iFlags & MenuBossFlags_Random)
-		hMenuList.AddItem("random", "Random");
-	
-	if (iFlags & MenuBossFlags_None)
-		hMenuList.AddItem("none", "None");
-	
-	//Loop through every modifiers
-	ArrayList aModifiers = FuncClass_GetAllType(VSHClassType_Modifier);
-	aModifiers.Sort(Sort_Ascending, Sort_String);
-	int iLength = aModifiers.Length;
-	for (int i = 0; i < iLength; i++)
-	{
-		//Get boss type
-		char sModifiersType[MAX_TYPE_CHAR];
-		aModifiers.GetString(i, sModifiersType, sizeof(sModifiersType));
-		
-		SaxtonHaleBase boss = SaxtonHaleBase(0);
-		boss.CallFunction("SetModifiersType", sModifiersType);
-		
-		//If disallow hidden modifiers, check that
-		if (!(iFlags & MenuBossFlags_Hidden) && boss.CallFunction("IsModifiersHidden"))
-			continue;
-		
-		//Get modifiers name
-		char sName[512];
-		boss.CallFunction("GetModifiersName", sName, sizeof(sName));
-		
-		//Add to menu
-		hMenuList.AddItem(sModifiersType, sName);
-	}
-	
-	delete aModifiers;
-	g_fMenuBossCallback[iClient] = callback;
-	hMenuList.Display(iClient, MENU_TIME_FOREVER);
-}
+// --------------------
+
+/*
+ * Display list of bosses/modifiers
+ */
 
 public int MenuBoss_SelectList(Menu hMenu, MenuAction action, int iClient, int iSelect)
 {
@@ -134,68 +128,6 @@ public int MenuBoss_SelectList(Menu hMenu, MenuAction action, int iClient, int i
 }
 
 /*
- * Add/Remove bosses/modifiers info menu
- */
-
-void MenuBoss_AddInfoBoss(const char[] sBossType)
-{
-	char sName[512], sInfo[512];
-	
-	SaxtonHaleBase boss = SaxtonHaleBase(0);
-	boss.CallFunction("SetBossType", sBossType);
-	boss.CallFunction("GetBossName", sName, sizeof(sName));
-	
-	//Create menu info for boss
-	Menu hMenuBossInfo = new Menu(MenuBoss_SelectBossInfo);
-	
-	//Get Boss info to set title
-	boss.CallFunction("GetBossInfo", sInfo, sizeof(sInfo));
-	if (StrEmpty(sInfo))
-		Format(sInfo, sizeof(sInfo), "%s\n \nThere seems to be nothing here...", sName);
-	else
-		Format(sInfo, sizeof(sInfo), "%s\n \n%s", sName, sInfo);
-	
-	hMenuBossInfo.SetTitle(sInfo);
-	hMenuBossInfo.AddItem("back", "<- Back");
-	
-	g_mMenuInfo.SetValue(sBossType, hMenuBossInfo);
-}
-
-void MenuBoss_AddInfoModifiers(const char[] sModifiersType)
-{
-	char sName[512], sInfo[512];
-	
-	SaxtonHaleBase boss = SaxtonHaleBase(0);
-	boss.CallFunction("SetModifiersType", sModifiersType);
-	boss.CallFunction("GetModifiersName", sName, sizeof(sName));
-	
-	//Create menu info for modifiers
-	Menu hMenuModifiersInfo = new Menu(MenuBoss_SelectModifiersInfo);
-	
-	//Get Modifiers info to set title
-	boss.CallFunction("GetModifiersInfo", sInfo, sizeof(sInfo));
-	if (StrEmpty(sInfo))
-		Format(sInfo, sizeof(sInfo), "%s\n \nThere seems to be nothing here...", sName);
-	else
-		Format(sInfo, sizeof(sInfo), "%s\n \n%s", sName, sInfo);
-	
-	hMenuModifiersInfo.SetTitle(sInfo);
-	hMenuModifiersInfo.AddItem("back", "<- Back");
-	
-	g_mMenuInfo.SetValue(sModifiersType, hMenuModifiersInfo);
-}
-
-void MenuBoss_RemoveInfo(const char[] sType)
-{
-	Menu hMenuInfo;
-	if (g_mMenuInfo.GetValue(sType, hMenuInfo))
-	{
-		delete hMenuInfo;
-		g_mMenuInfo.Remove(sType);
-	}
-}
-
-/*
  * Display bosses/modifiers info
  */
 
@@ -204,33 +136,41 @@ public void MenuBoss_CallbackInfo(int iClient, const char[] sType)
 	if (StrEqual(sType, "back"))
 		Menu_DisplayMain(iClient);
 	else
-		MenuBoss_DisplayInfo(iClient, sType);
+		MenuBoss_DisplayInfo(iClient, g_nMenuBossClassType[iClient], sType);
 }
 
-void MenuBoss_DisplayInfo(int iClient, const char[] sType, int iTime = MENU_TIME_FOREVER)
+void MenuBoss_DisplayInfo(int iClient, SaxtonHaleClassType nClassType, const char[] sType, int iTime = MENU_TIME_FOREVER)
 {
-	Menu hMenuInfo;
-	if (!g_mMenuInfo.GetValue(sType, hMenuInfo))
-	{
-		Menu_DisplayError(iClient);
-		return;
-	}
+	g_nMenuBossClassType[iClient] = nClassType;
 	
-	hMenuInfo.Display(iClient, iTime);
+	char sName[512], sInfo[512];
+	
+	SaxtonHaleBase boss = SaxtonHaleBase(0);
+	boss.CallFunction(g_menuBossListInfo[nClassType].sSetType, sType);
+	boss.CallFunction(g_menuBossListInfo[nClassType].sGetName, sName, sizeof(sName));
+	
+	//Create menu info for boss
+	Menu hMenuBossInfo = new Menu(MenuBoss_SelectInfo);
+	
+	//Get Boss info to set title
+	boss.CallFunction(g_menuBossListInfo[nClassType].sGetInfo, sInfo, sizeof(sInfo));
+	if (StrEmpty(sInfo))
+		Format(sInfo, sizeof(sInfo), "%s\n \nThere seems to be nothing here...", sName);
+	else
+		Format(sInfo, sizeof(sInfo), "%s\n \n%s", sName, sInfo);
+	
+	hMenuBossInfo.SetTitle(sInfo);
+	hMenuBossInfo.AddItem("back", "<- Back");
+	hMenuBossInfo.Display(iClient, iTime);
 }
 
-public int MenuBoss_SelectBossInfo(Menu hMenu, MenuAction action, int iClient, int iSelect)
+public int MenuBoss_SelectInfo(Menu hMenu, MenuAction action, int iClient, int iSelect)
 {
 	//Only back button in menu
 	if (action == MenuAction_Select)
-		MenuBoss_DisplayBossList(iClient, MenuBoss_CallbackInfo);
-}
-
-public int MenuBoss_SelectModifiersInfo(Menu hMenu, MenuAction action, int iClient, int iSelect)
-{
-	//Only back button in menu
-	if (action == MenuAction_Select)
-		MenuBoss_DisplayModifiersList(iClient, MenuBoss_CallbackInfo);
+		MenuBoss_DisplayList(iClient, g_nMenuBossClassType[iClient], MenuBoss_CallbackInfo);
+	else if (action == MenuAction_End)
+		delete hMenu;
 }
 
 /*
@@ -270,7 +210,8 @@ void MenuBoss_DisplayNextList(int iClient)
 	Format(sBuffer, sizeof(sBuffer), "%s\n---", sBuffer);
 	hAdminBossList.SetTitle(sBuffer);
 	hAdminBossList.AddItem("back", "<- back");
-	hAdminBossList.AddItem("add", "Add New Boss");
+	hAdminBossList.AddItem("boss", "Add New Boss");
+	hAdminBossList.AddItem("bossmulti", "Add New Multi Boss");
 	hAdminBossList.AddItem("clear", "Clear List");
 	hAdminBossList.Display(iClient, MENU_TIME_FOREVER);
 }
@@ -288,9 +229,13 @@ public int MenuBoss_SelectNextList(Menu hMenu, MenuAction action, int iClient, i
 	char sSelect[16];
 	hMenu.GetItem(iSelect, sSelect, sizeof(sSelect));
 	
-	if (StrEqual(sSelect, "add"))
+	if (StrEqual(sSelect, "boss"))
 	{
 		MenuBoss_DisplayNextClient(iClient);
+	}
+	else if (StrEqual(sSelect, "bossmulti"))
+	{
+		MenuBoss_DisplayList(iClient, VSHClassType_BossMulti, MenuBoss_CallbackNextBossMulti, MenuBossFlags_Hidden);
 	}
 	else if (StrEqual(sSelect, "clear"))
 	{
@@ -373,7 +318,7 @@ public int MenuBoss_SelectNextClient(Menu hMenu, MenuAction action, int iClient,
 		else
 			g_menuBossSelect[iClient].iClient = 0;
 		
-		MenuBoss_DisplayBossList(iClient, MenuBoss_CallbackNextBoss, MenuBossFlags_Hidden|MenuBossFlags_Random);
+		MenuBoss_DisplayList(iClient, VSHClassType_Boss, MenuBoss_CallbackNextBoss, MenuBossFlags_Hidden|MenuBossFlags_Random);
 	}
 }
 
@@ -393,14 +338,14 @@ public void MenuBoss_CallbackNextBoss(int iClient, const char[] sType)
 		Format(g_menuBossSelect[iClient].sBossType, sizeof(g_menuBossSelect[].sBossType), sType);
 	}
 	
-	MenuBoss_DisplayModifiersList(iClient, MenuBoss_CallbackNextModifiers, MenuBossFlags_Hidden|MenuBossFlags_Random|MenuBossFlags_None);
+	MenuBoss_DisplayList(iClient, VSHClassType_Modifier, MenuBoss_CallbackNextModifiers, MenuBossFlags_Hidden|MenuBossFlags_Random|MenuBossFlags_None);
 }
 
 public void MenuBoss_CallbackNextModifiers(int iClient, const char[] sType)
 {
 	if (StrEqual(sType, "back"))
 	{
-		MenuBoss_DisplayBossList(iClient, MenuBoss_CallbackNextBoss, MenuBossFlags_Hidden|MenuBossFlags_Random);
+		MenuBoss_DisplayList(iClient, VSHClassType_Boss, MenuBoss_CallbackNextBoss, MenuBossFlags_Hidden|MenuBossFlags_Random);
 		return;
 	}
 	else if (StrEqual(sType, "random"))
@@ -416,21 +361,77 @@ public void MenuBoss_CallbackNextModifiers(int iClient, const char[] sType)
 		Format(g_menuBossSelect[iClient].sModifierType, sizeof(g_menuBossSelect[].sModifierType), sType);
 	}
 	
-	//Add to list
-	SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(g_menuBossSelect[iClient].iClient);
-	nextBoss.SetBoss(g_menuBossSelect[iClient].sBossType);
-	nextBoss.SetModifier(g_menuBossSelect[iClient].sModifierType);
-	nextBoss.bForceNext = true;
-	
-	//Print chat boss been set
-	char sBuffer[256];
-	nextBoss.GetName(sBuffer, sizeof(sBuffer));
-	PrintToChatAll("%s%s %N added next boss %s", TEXT_TAG, TEXT_COLOR, iClient, sBuffer);
+	if (!StrEmpty(g_menuBossSelect[iClient].sBossType))
+	{
+		//Add to list
+		SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss(g_menuBossSelect[iClient].iClient);
+		nextBoss.SetBoss(g_menuBossSelect[iClient].sBossType);
+		nextBoss.SetModifier(g_menuBossSelect[iClient].sModifierType);
+		nextBoss.bForceNext = true;
+		
+		//Print chat boss been set
+		char sBuffer[256];
+		nextBoss.GetName(sBuffer, sizeof(sBuffer));
+		PrintToChatAll("%s%s %N added next boss %s", TEXT_TAG, TEXT_COLOR, iClient, sBuffer);
+	}
+	else if (!StrEmpty(g_menuBossSelect[iClient].sBossMultiType))
+	{
+		//Add all bosses from multi to list
+		SaxtonHaleBase boss = SaxtonHaleBase(0);
+		boss.CallFunction("SetBossMultiType", g_menuBossSelect[iClient].sBossMultiType);
+		boss.CallFunction("SetModifiersType", g_menuBossSelect[iClient].sModifierType);
+		
+		ArrayList aList = new ArrayList(ByteCountToCells(MAX_TYPE_CHAR));
+		boss.CallFunction("GetBossMultiList", aList);
+		
+		int iLength = aList.Length;
+		for (int i = 0; i < iLength; i++)
+		{
+			char sBossType[MAX_TYPE_CHAR];
+			aList.GetString(i, sBossType, sizeof(sBossType));
+			
+			SaxtonHaleNextBoss nextBoss = SaxtonHaleNextBoss();
+			nextBoss.SetBoss(sBossType);
+			nextBoss.SetBossMulti(g_menuBossSelect[iClient].sBossMultiType);
+			nextBoss.SetModifier(g_menuBossSelect[iClient].sModifierType);
+			nextBoss.bForceNext = true;
+		}
+		
+		delete aList;
+		
+		char sModifiersName[256], sBossMultiName[256];
+		boss.CallFunction("GetModifiersName", sModifiersName, sizeof(sModifiersName));
+		boss.CallFunction("GetBossMultiName", sBossMultiName, sizeof(sBossMultiName));
+		
+		if (StrEmpty(sModifiersName))
+			PrintToChatAll("%s%s %N added next multi boss %s", TEXT_TAG, TEXT_COLOR, iClient, sBossMultiName);
+		else
+			PrintToChatAll("%s%s %N added next multi boss %s %s", TEXT_TAG, TEXT_COLOR, iClient, sModifiersName, sBossMultiName);
+	}
+	else
+	{
+		Menu_DisplayError(iClient);
+		return;
+	}
 	
 	//Clear stuffs
-	g_menuBossSelect[iClient].iClient = 0;
-	g_menuBossSelect[iClient].sBossType = NULL_STRING;
-	g_menuBossSelect[iClient].sModifierType = NULL_STRING;
+	MenuBossSelect nothing;
+	g_menuBossSelect[iClient] = nothing;
 	
 	MenuBoss_DisplayNextList(iClient);
+}
+
+public void MenuBoss_CallbackNextBossMulti(int iClient, const char[] sType)
+{
+	if (StrEqual(sType, "back"))
+	{
+		MenuBoss_DisplayNextList(iClient);
+		return;
+	}
+	else
+	{
+		Format(g_menuBossSelect[iClient].sBossMultiType, sizeof(g_menuBossSelect[].sBossMultiType), sType);
+	}
+	
+	MenuBoss_DisplayList(iClient, VSHClassType_Modifier, MenuBoss_CallbackNextModifiers, MenuBossFlags_Hidden|MenuBossFlags_Random|MenuBossFlags_None);
 }

--- a/addons/sourcemod/scripting/vsh/native.sp
+++ b/addons/sourcemod/scripting/vsh/native.sp
@@ -3,6 +3,8 @@ void Native_AskLoad()
 	CreateNative("SaxtonHaleNextBoss.SaxtonHaleNextBoss", Native_NextBoss);
 	CreateNative("SaxtonHaleNextBoss.GetBoss", Native_NextBoss_GetBoss);
 	CreateNative("SaxtonHaleNextBoss.SetBoss", Native_NextBoss_SetBoss);
+	CreateNative("SaxtonHaleNextBoss.GetBossMulti", Native_NextBoss_GetBossMulti);
+	CreateNative("SaxtonHaleNextBoss.SetBossMulti", Native_NextBoss_SetBossMulti);
 	CreateNative("SaxtonHaleNextBoss.GetModifier", Native_NextBoss_GetModifier);
 	CreateNative("SaxtonHaleNextBoss.SetModifier", Native_NextBoss_SetModifier);
 	CreateNative("SaxtonHaleNextBoss.GetName", Native_NextBoss_GetName);
@@ -53,6 +55,27 @@ public any Native_NextBoss_SetBoss(Handle hPlugin, int iNumParams)
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
 	
 	GetNativeString(2, nextBoss.sBossType, sizeof(nextBoss.sBossType));
+	NextBoss_SetStruct(nextBoss);
+}
+
+//void SaxtonHaleNextBoss.GetBossMulti(char[] sMultiType, int iLength);
+public any Native_NextBoss_GetBossMulti(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	SetNativeString(2, nextBoss.sBossMultiType, GetNativeCell(3));
+}
+
+//void SaxtonHaleNextBoss.SetBossMulti(const char[] sMultiType);
+public any Native_NextBoss_SetBossMulti(Handle hPlugin, int iNumParams)
+{
+	NextBoss nextBoss;
+	if (!NextBoss_GetStruct(GetNativeCell(1), nextBoss))
+		ThrowNativeError(SP_ERROR_NATIVE, "Invalid id passed, id may be already used");
+	
+	GetNativeString(2, nextBoss.sBossMultiType, sizeof(nextBoss.sBossMultiType));
 	NextBoss_SetStruct(nextBoss);
 }
 

--- a/addons/sourcemod/scripting/vsh/nextboss.sp
+++ b/addons/sourcemod/scripting/vsh/nextboss.sp
@@ -319,7 +319,7 @@ void NextBoss_SetBoss(SaxtonHaleNextBoss nextBoss, ArrayList aNonBosses)
 	TF2_RespawnPlayer(nextBoss.iClient);
 	
 	//Display to client what boss you are for 10 seconds
-	MenuBoss_DisplayInfo(nextBoss.iClient, sBossType, 10);
+	MenuBoss_DisplayInfo(nextBoss.iClient, VSHClassType_Boss, sBossType, 10);
 	
 	//Enable special round if triggered
 	if (nextBoss.bSpecialClassRound)


### PR DESCRIPTION
Adds new class type `VSHClassType_BossMulti`, similar to how boss, ability and modifier class functions.

This allows to create multi-boss by reusing existing bosses. For example creating new multi boss that contains both painis cupcake and vagineer while both bosses can still appear as normal.

This also allows identical bosses code be put into one code, eg `CBlutarch` and `CRedmond` (`VSHClassType_Boss`) both uses same melee weapon, where it given in one code ``CMannBrothers` (`VSHClassType_BossMulti`).