### PR TITLE
Shortstop

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -590,6 +590,12 @@
 			}
 		}
 		
+		"220"	//Shortstop
+		{
+			"desp"			"Shortstop: {positive}+35% faster reload time"
+			"attrib"		"97 ; 1.35"
+		}
+		
 		"46"	//Bonk! Atomic Punch
 		{
 			"desp"			"Bonk: {neutral}Replaces bonk effect into defense buff"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -593,7 +593,7 @@
 		"220"	//Shortstop
 		{
 			"desp"			"Shortstop: {positive}+35% faster reload time"
-			"attrib"		"97 ; 1.35"
+			"attrib"		"97 ; 0.65"
 		}
 		
 		"46"	//Bonk! Atomic Punch


### PR DESCRIPTION
Reload speed buff for spam weapon Shortstop meant to be, low damage with constant rate of fire and high accuracy

35% brings reload time to 0.98 seconds compared to 1.52 old 