### PR TITLE
Scout pistols

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -179,7 +179,7 @@
 			{
 				"desp"		"Scout: {positive}+66% max ammo capacity on all pistols"
 				"minicrit"	"1"
-				"attrib"	"78 ; 1.66"
+				"attrib"	"78 ; 1.67"
 			}
 			
 			"Melee"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -177,7 +177,7 @@
 			
 			"Secondary"
 			{
-				"desp"		"Scout: {positive}+66% max ammo capacity on all pistols"
+				"desp"		"Scout: {positive}+67% max ammo capacity on all pistols"
 				"minicrit"	"1"
 				"attrib"	"78 ; 1.67"
 			}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -177,7 +177,9 @@
 			
 			"Secondary"
 			{
+				"desp"		"Scout: {positive}+66% max ammo capacity on all pistols"
 				"minicrit"	"1"
+				"attrib"	"78 ; 1.66"
 			}
 			
 			"Melee"


### PR DESCRIPTION
Pistols, aside from Winger, are rarely useful and overshadowed by other secondaries, mainly because you run out of ammo too quickly.

+67% results in 2 additional clips, that makes scout carry 60 ammo, 1 small ammopack restores full clip.