### PR TITLE
Back Scatter

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -593,6 +593,7 @@
 		"1103"	//Back Scatter
 		{
 			"desp"			"Back Scatter: {positive}Crits whenever it would normally mini-crit"
+			"minicrit"		"0"
 			"attrib"		"179 ; 1.0"
 		}
 		

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -590,6 +590,12 @@
 			}
 		}
 		
+		"1103"	//Back Scatter
+		{
+			"desp"			"Back Scatter: {positive}Crits whenever it would normally mini-crit"
+			"attrib"		"179 ; 1.0"
+		}
+		
 		"46"	//Bonk! Atomic Punch
 		{
 			"desp"			"Bonk: {neutral}Replaces bonk effect into defense buff"


### PR DESCRIPTION
Crits whenever it would normally mini-crit, no minicrits from usual sources (Crit-a-cola, medic beam, last survivors);
given weapon downsides and hard condition to get additional damage, this change should make Back Scatter useful