### PR TITLE
Add Overload Modifier

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -407,6 +407,7 @@ ConVar tf_arena_preround_time;
 #include "vsh/modifiers/modifiers_hot.sp"
 #include "vsh/modifiers/modifiers_ice.sp"
 #include "vsh/modifiers/modifiers_jump.sp"
+#include "vsh/modifiers/modifiers_overload.sp"
 #include "vsh/modifiers/modifiers_speed.sp"
 #include "vsh/modifiers/modifiers_vampire.sp"
 
@@ -730,6 +731,7 @@ public void OnPluginStart()
 	SaxtonHale_RegisterClass("CModifiersHot", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersIce", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersJump", VSHClassType_Modifier);
+	SaxtonHale_RegisterClass("CModifiersOverload", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersSpeed", VSHClassType_Modifier);
 	SaxtonHale_RegisterClass("CModifiersVampire", VSHClassType_Modifier);
 	

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -137,9 +137,9 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 			flHUD[1] = 0.83;
 			
 			int iColor[4];
-			if (flRage >= 200.0)
+			if (flRage >= 200.0 || flRage >= this.flMaxRagePercentage * 100.0)
 			{
-				//200% rage, bright yellow
+				//200% rage or max, bright yellow
 				iColor[0] = 255;
 				iColor[1] = 255;
 				iColor[2] = 0;
@@ -248,11 +248,26 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 	public void OnRage()
 	{
 		this.flRageLastTime = GetGameTime();
-
-		int iNumRageRemove = RoundToFloor(float(this.iRageDamage)/float(this.iMaxRageDamage));
-		this.iRageDamage -= this.iMaxRageDamage * iNumRageRemove;
-		this.bSuperRage = (iNumRageRemove == 2);
-
+		this.bSuperRage = false;
+		
+		if (this.iRageDamage >= this.iMaxRageDamage * 2)
+		{
+			//Super rage by 200% or higher
+			this.bSuperRage = true;
+			this.iRageDamage -= this.iMaxRageDamage * 2;
+		}
+		else if (this.iRageDamage >= this.iMaxRageDamage * this.flMaxRagePercentage)
+		{
+			//Super rage by max rage percentage, but less than 200%
+			this.bSuperRage = true;
+			this.iRageDamage = 0;
+		}
+		else
+		{
+			//Normal rage
+			this.iRageDamage -= this.iMaxRageDamage;
+		}
+		
 		if (TF2_IsPlayerInCondition(this.iClient, TFCond_Dazed))
 			TF2_RemoveCondition(this.iClient, TFCond_Dazed); //Allow hale to escape permastun situations when using rage
 

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_angry.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_angry.sp
@@ -24,9 +24,9 @@ methodmap CModifiersAngry < SaxtonHaleBase
 	
 	public int GetRenderColor(int iColor[4])
 	{
-		iColor[0] = 192;
-		iColor[1] = 128;
-		iColor[2] = 56;
+		iColor[0] = 144;
+		iColor[1] = 96;
+		iColor[2] = 48;
 		iColor[3] = 255;
 	}
 	

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
@@ -24,7 +24,7 @@ methodmap CModifiersElectric < SaxtonHaleBase
 	public int GetRenderColor(int iColor[4])
 	{
 		iColor[0] = 255;
-		iColor[1] = 192;
+		iColor[1] = 255;
 		iColor[2] = 0;
 		iColor[3] = 255;
 	}

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_overload.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_overload.sp
@@ -1,0 +1,36 @@
+methodmap CModifiersOverload < SaxtonHaleBase
+{
+	public CModifiersOverload(CModifiersOverload boss)
+	{
+		//Basically 175% required for super rage
+		boss.iMaxRageDamage = RoundToNearest(float(boss.iMaxRageDamage) * 1.75);
+		boss.flMaxRagePercentage = 1.0;	//Hard set 100% cap
+	}
+	
+	public bool IsModifiersHidden()
+	{
+		return true;
+	}
+	
+	public void GetModifiersName(char[] sName, int length)
+	{
+		strcopy(sName, length, "Overload");
+	}
+	
+	public void GetModifiersInfo(char[] sInfo, int length)
+	{
+		StrCat(sInfo, length, "\nColor: Orange");
+		StrCat(sInfo, length, "\n ");
+		StrCat(sInfo, length, "\n- Normal Rage becomes Super Rage");
+		StrCat(sInfo, length, "\n- 75%% less rage gain");
+		StrCat(sInfo, length, "\n- Rage percentage can't go above 100%%");
+	}
+	
+	public int GetRenderColor(int iColor[4])
+	{
+		iColor[0] = 255;
+		iColor[1] = 144;
+		iColor[2] = 0;
+		iColor[3] = 255;
+	}
+};


### PR DESCRIPTION
Orange modifier

- Normal Rage becomes Super Rage
- 75% less rage gain
- Rage percentage can't go above 100%

Also updated Electric and Angry modifier color to not make it identical to Overload color