### PR TITLE
Bonk! Atomic Punch

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -609,10 +609,10 @@
 					"cond"			"14"	//Bonk
 				}
 				
-				"Tags_AddCond"	//Add defense buff for 8 seconds
+				"Tags_AddCond"	//Add defense buff for 12 seconds
 				{
 					"cond"			"26"
-					"duration"		"8.0"
+					"duration"		"12.0"
 				}
 				
 				"Tags_RemoveCond"	//Remove bonk


### PR DESCRIPTION
Taunt eats 1 second from already short duration, 12 should be plenty, with 18 seconds window to recharge after effect.
On the other hand, I'm not sure anyone wants to see tankier scouts, might be good to tweak it to 10 seconds