### PR TITLE
Fan O'War

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -655,7 +655,7 @@
 		
 		"355"	//Fan O'War
 		{
-			"desp"			"Fan O'War: {neutral}Replaces mark-for-death into a rage drain, {negative}100% slower firing speed"
+			"desp"			"Fan O'War: {negative}Mark for death only lasts 8 seconds, {negative}100% slower firing speed"
 			"attrib"		"5 ; 2.0 ; 218 ; 0.0"
 			
 			"attackdamage"
@@ -665,14 +665,15 @@
 					"victimuber"	"0"
 				}
 				
-				"Tags_RemoveRage"
+				"Tags_AddCond"
 				{
+					"cond" 			"30"
 					"target"		"victim"	//victim boss whos taken damage
-					"amount"		"100"
+					"duration"		"8.0"
 				}
 			}
 		}
-		
+				
 		"648"	//Wrap Assassin
 		{
 			"desp"			"Wrap Assassin: {positive}Can hold up to 2 balls at once"


### PR DESCRIPTION
I feel like rage drain is just not a good concept for scout, if he has to go into melee range, effect has to be worth it, right now it's basically a weaker bat with delayed damage in a form of rage, and very crippling fire rate. Rage drain itself isn't even that good! You'll make hale use 1 less rage in ideal conditions, how many hits do you need to make it 2? Ten? Twenty? How about 35+?

Mark for death is a strong effect, I'm not sure making it last half as long (8, previously 15) would still be enough, decided to keep slow fire rate.

Open to discussions