### PR TITLE
The B.A.S.E. Jumper

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -866,6 +866,12 @@
 			}
 		}
 		
+		"1101"	//The B.A.S.E. Jumper
+		{
+			"desp"			"The B.A.S.E. Jumper: {positive}+50% health from packs"
+			"attrib"		"108 ; 1.5"
+		}
+		
 		"416"	//Market Gardener
 		{
 			"desp"			"Market Gardener: {positive}Airborne hits deal 1000 damage, {negative}no crits"


### PR DESCRIPTION
Explosions take a fair chunk of health, this should make B.A.S.E. Jumper less irrelevant than it currently is, there's no reason to pick it over Gunboats or Mantreads at the moment 