### PR TITLE
The Degreaser

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -922,6 +922,23 @@
 			}
 		}
 		
+		"215"	//The Degreaser
+		{
+			"desp"			"The Degreaser: {positive}Requires 300 damage for airblast"
+	
+				"spawn"
+				{
+					"Tags_Airblast"
+					{
+						"override"		"pyro-primary-airblast"
+						"target"		"primary"
+						"start"			"300"
+						"damage"		"300"	
+
+					}
+				}
+		}
+		
 		"1179"	//Thermal Thruster
 		{
 			"desp"			"Thermal Thruster: {positive}Stomping deals 1024 damage"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -926,17 +926,15 @@
 		{
 			"desp"			"The Degreaser: {positive}Requires 300 damage for airblast"
 	
-				"spawn"
+			"spawn"
+			{
+				"Tags_Airblast"
 				{
-					"Tags_Airblast"
-					{
-						"override"		"pyro-primary-airblast"
-						"target"		"primary"
-						"start"			"300"
-						"damage"		"300"	
-
-					}
+					"override"		"pyro-primary-airblast"
+					"start"			"300"
+					"damage"		"300"	
 				}
+			}
 		}
 		
 		"1179"	//Thermal Thruster


### PR DESCRIPTION
The Degreaser is outclasses by 2 other Flamethrowers with airblast, and because main source of damage is afterburn, combos aren't very beneficial.
Damage in exchange of  knockback should fill Degreaser's utility role 