### PR TITLE
The Manmelter

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -962,6 +962,12 @@
 			"prefab"		"39"
 		}
 		
+		"595"	//The Manmelter
+		{
+			"desp"			"The Manmelter: {positive}+15 max health"
+			"attrib"		"26 ; 15.0" 
+		}
+		
 		"593"	//Third Degree
 		{
 			"desp"			"Third Degree: {positive}+20% Über to your healer on hit, {negative}20% slower firing speed"


### PR DESCRIPTION
This change doesn't make much sense, but I decided to go with it anyway, I feel like purely defensive role is the only one pyro's secondaries do not fulfill at the moment.
Although surviving a hit on your own might prove to be too good, it's better than let Manmelter rot forever 