### PR TITLE
Hot Hand

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1025,7 +1025,13 @@
 				}
 			}
 		}
-
+		
+		"1181"	//Hot Hand
+		{
+			"desp"			"Hot Hand: {positive}Hitting teammates boosts both players' speed"
+			"attrib"		"264 ; 1.7 ; 251 ; 1.0" //attrib 264 is whip's range
+		}
+		
 		// DEMOMAN
 
 		"308"	//Loch-n-load


### PR DESCRIPTION
Turns Hot Hand into whip, much more useful on the pyro, who's always on the ground, rather than soldier, constantly trying to fill banners or market garden.
I thought non-existent damage is enough to balance out attack speed, but it might need tweaks, pyro is much faster after all 