### PR TITLE
Eviction Notice

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1478,8 +1478,8 @@
 		
 		"426"	//Eviction Notice
 		{
-			"desp"			"Eviction Notice: {neutral}Active movement speed bonus is replaced with 50% greater jump height"
-			"attrib"		"524 ; 1.5 ; 851 ; 1.0"
+			"desp"			"Eviction Notice: {neutral}Movement speed bonus is replaced with 70% greater jump height, {negative}+400% damage from melee sources while active"
+			"attrib"		"524 ; 1.7 ; 851 ; 1.0 ; 206 ; 4.0"
 		}
 		
 		"310"	//Warrior's Spirit


### PR DESCRIPTION
An attempt to return old Eviction Notice
The reason I suggested to nerf jump height to 50% back then was too much survivability it granted, Eviction Notice has always meant to be a tool for heavies to reach a good spot, not a mean to get away, that's GRU's job.
Shouldn't be a problem now, heavy holding it will just get oneshotted