### PR TITLE
Crusader's Crossbow

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1608,8 +1608,8 @@
 		
 		"305"	//Crusader's Crossbow
 		{
-			"desp"			"Crusader's Crossbow: {positive}+10% ÜberCharge on hit"
-			"attrib"		"17 ; 0.10"
+			"desp"			"Crusader's Crossbow: {positive}+10% ÜberCharge on hit, +45% damage bonus"
+			"attrib"		"17 ; 0.10 ; 2 ; 1.45"
 		}
 		
 		"1079"	//Festive Crusader's Crossbow

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1608,8 +1608,8 @@
 		
 		"305"	//Crusader's Crossbow
 		{
-			"desp"			"Crusader's Crossbow: {positive}+10% ÜberCharge on hit, +45% damage bonus"
-			"attrib"		"17 ; 0.10 ; 2 ; 1.45"
+			"desp"			"Crusader's Crossbow: {positive}+60% damage bonus"
+			"attrib"		"2 ; 1.6"
 		}
 		
 		"1079"	//Festive Crusader's Crossbow


### PR DESCRIPTION
Legacy's Crusader's Crossbow.
If Syringe guns are used for gaining uber, this shall be medic's go-to damage weapon.
Crossbow is fairly hard to hit in the crowd, and it doesn't knockback as much as legacy one did, should work fine