### PR TITLE
Jump cooldown time

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -175,7 +175,7 @@ methodmap CBraveJump < SaxtonHaleBase
 				TeleportEntity(this.iClient, NULL_VECTOR, NULL_VECTOR, vecVel);
 				
 				float flCooldownTime = (this.flCooldown*(float(this.iJumpCharge)/float(this.iMaxJumpCharge)));
-				if (flCooldownTime < 2.5) flCooldownTime = 2.5;
+				if (flCooldownTime < 7.0) flCooldownTime = 7.0;
 				g_flJumpCooldownWait[this.iClient] = GetGameTime()+flCooldownTime;
 				
 				this.iJumpCharge = 0;


### PR DESCRIPTION
This is something I wanted to discuss for a long time.
In Rewrite, Super Jump cooldown linked to the time spent charging it, with maximum cooldown being 7 seconds, and minimum 2.5. Simply put, stronger jump — longer cooldown. If I had to guess, this was done in assumption the smaller jump is = the lower value it has. On practice, this isn't the case, small jumps are just as valuable as fully changed ones, they even give same velocity.
It's easier to hit someone in the air with weak jump, they're more precise, give same speed and have lower cooldown, and when someone is really far away, you just hold button longer.

Since there's practically no difference (with weak jump being stronger), I suggest to equate all cooldowns to 7 seconds