### PR TITLE
Ambassador

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1951,8 +1951,22 @@
 
 		"61"	//Ambassador
 		{
-			"desp"			"Ambassador: {positive}Critical damage is no longer affected by range"
-			"attrib"		"868 ; 0"
+			"desp"			"Ambassador: {positive}Gain 3 second speed boost on headshot"
+			
+			"attackdamage"
+			{
+				"filter"
+				{
+					"victimuber"	"0"
+					"damagecustom"	"headshot"
+				}
+				
+				"Tags_AddCond"
+				{
+					"cond"			"32"
+					"duration"		"3.0"
+				}
+			}
 		}
 		
 		"1006"	//Festive Ambassador


### PR DESCRIPTION
Ambassador wasn't good at dealing damage before, and removed falloff didn't really help.
This change gives it utility role, rewarding precise gunfire with the speed boost