### PR TITLE
The Spy-cicle

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2120,6 +2120,32 @@
 			}
 		}
 		
+		"649"	//The Spy-cicle
+		{
+			"desp"			"The Spy-cicle: {positive}Slows your victim for 5 seconds on backstab, {negative}-40% damage"
+			
+			"attackdamage"
+			{
+				"filter"
+				{
+					"victimuber"		"0"
+					"damagecustom"		"backstab"
+				}
+			
+				"params"
+				{
+					"set"			"600.0"	
+				}
+
+				"Tags_Stun"	//Used for slowdown effect
+				{
+					"target"		"victim"
+					"duration"		"5.0"	//Slowdown duration
+					"slowdown"		"0.4"	//Slowdown strength, here it's 40%
+				}
+			}
+		}
+		
 		"59"	//Dead Ringer
 		{
 			"takedamage"


### PR DESCRIPTION
Gives Spy-cicle slowdown effect on successful backstab, slowing bosses down to slightly-slower-than-heavy speed.
Similar to Sandman's stun, they can't super jump during slowdown