### PR TITLE
Fix restricted weapons being enforced when VSH is disabled

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1583,6 +1583,8 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] classname, int itemDef
 
 Action GiveNamedItem(int iClient, const char[] sClassname, int iIndex)
 {
+	if (!g_bEnabled) return Plugin_Continue;
+	
 	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 	if (boss.bValid)
 		return boss.CallFunction("OnGiveNamedItem", sClassname, iIndex);


### PR DESCRIPTION
Running the plugin on my own server, I noticed that after VSH was played, weapons that are marked as restricted in VSH such as the Sticky Jumper were being disabled.

This PR fixes that issue by having the GiveNamedItem function check if the mode is enabled and returning Plugin_Continue if not.