### PR TITLE
Fixed VSH Event_PointCaptured firing even when VSH is disabled

### DIFF
--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -480,6 +480,8 @@ public Action Event_RoundEnd(Event event, const char[] sName, bool bDontBroadcas
 
 public void Event_PointCaptured(Event event, const char[] sName, bool bDontBroadcast)
 {
+	if (!g_bEnabled) return;
+	
 	TFTeam nTeam = view_as<TFTeam>(event.GetInt("team"));
 	Dome_SetTeam(nTeam);
 }


### PR DESCRIPTION
Fixes #261 

Event_PointCaptured wasn't checking if VSH was enabled or not, causing various issues in other modes that use control points.