### PR TITLE
vsh_dome_speed_duration, vsh_dome_cp_captime

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2346,13 +2346,13 @@
 		"vsh_dome_cp_radius"        "250"               //If vsh_dome_centre specified, new radius from CP to capture
 		"vsh_dome_cp_unlock"        "30"                //Time in second to unlock CP on round start
 		"vsh_dome_cp_unlockplayer"  "5"                 //Time in second to add on every player to unlock CP on round start
-		"vsh_dome_cp_captime"       "15"                //How long to capture CP
+		"vsh_dome_cp_captime"       "20"                //How long to capture CP
 		"vsh_dome_cp_bossrate"      "2"                 //Capture value for boss
 		"vsh_dome_color_neu"        "192 192 192 255"   //Color of dome in RGBA if nobody owns the capture point
 		"vsh_dome_color_red"        "255 0 0 255"       //Color of dome in RGBA if red owns the capture point
 		"vsh_dome_color_blu"        "0 0 255 255"       //Color of dome in RGBA if red owns the capture point
 		"vsh_dome_radius_start"     "3500"              //Start radius of dome
 		"vsh_dome_radius_end"       "0"                 //End radius of dome
-		"vsh_dome_speed_duration"   "180"               //How long it takes in second for dome to fully shrink, without any slowdown
+		"vsh_dome_speed_duration"   "120"               //How long it takes in second for dome to fully shrink, without any slowdown
 	}
 }


### PR DESCRIPTION
It's became really popular to delay as of late, Hales delay because they know they'll have an advantage when capping at the end of the round, most red players are dead at that point.
This should solve that issue and encourage Hales to engage more instead of hiding to score cheap kills