### PR TITLE
Gentle spy health

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -68,8 +68,8 @@ methodmap CGentleSpy < SaxtonHaleBase
 {
 	public CGentleSpy(CGentleSpy boss)
 	{
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iBaseHealth = 600;
+		boss.iHealthPerPlayer = 600;
 		boss.nClass = TFClass_Spy;
 		boss.iMaxRageDamage = 2000;
 		


### PR DESCRIPTION
Gentle spy has pretty good rage he can use more often than most other Hales, this nerf should make him rely more on his one-shot pistol and invisibility, spy's kit is just too good to have regular health