### PR TITLE
Start superjump cooldown on round start

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -118,6 +118,9 @@ methodmap CBraveJump < SaxtonHaleBase
 	{
 		if (GameRules_GetRoundState() == RoundState_Preround) return;
 		
+		if (g_flJumpCooldownWait[this.iClient] == 0.0)	//Round started, start cooldown
+			g_flJumpCooldownWait[this.iClient] = GetGameTime()+this.flCooldown;
+		
 		char sMessage[255];
 		if (this.iJumpCharge > 0)
 			Format(sMessage, sizeof(sMessage), "Jump charge: %0.2f%%. Look up and stand up to use super-jump.", (float(this.iJumpCharge)/float(this.iMaxJumpCharge))*100.0);
@@ -134,8 +137,6 @@ methodmap CBraveJump < SaxtonHaleBase
 		}
 		
 		Hud_AddText(this.iClient, sMessage);
-		
-		g_flJumpCooldownWait[this.iClient] = 0.0;
 		
 		if (g_bBraveJumpHoldingChargeButton[this.iClient])
 			this.iJumpCharge += this.iJumpChargeBuild;


### PR DESCRIPTION
For #274. Uses same cooldown property `flCooldown` to set duration. Could've made new property for start cooldown, but not needed for now.