### PR TITLE
Remove area of range uber effect

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -327,7 +327,7 @@
 			
 			"Secondary"
 			{
-				"desp"		"Secondary: {positive}Patients get minicrits, able to heal buildings and ÜberCharges get an area of range effect"
+				"desp"		"Secondary: {positive}Patients get minicrits, able to heal buildings"
 				
 				"spawn"
 				{
@@ -356,18 +356,6 @@
 					"params"
 					{
 						"healbuilding"	"1"
-					}
-				}
-				
-				"uber"
-				{
-					"Tags_AreaOfEffect"
-					{
-						"name"			"medic-secondary-aoe"	//Name of this function used for weapons to override it
-						
-						"radius"		"250.0"
-						"duration"		"8.0"
-						"cond"			"5"		//Add uber cond
 					}
 				}
 			}
@@ -1736,15 +1724,15 @@
 		
 		"35"	//Kritzkrieg
 		{
-			"desp"			"Kritzkrieg: {positive}ÜberCharge also applies a defense buff to self"
+			"desp"			"Kritzkrieg: {positive}ÜberCharges get an area of range crits effect, applies a defense buff to self"
 			
 			"uber"
 			{
 				"Tags_AreaOfEffect"
 				{
-					"override"		"medic-secondary-aoe"	//Overrides Tags_AreaOfEffect from medic-secondary with new values
-					
-					"cond"			"11"	//Add kritz cond
+					"radius"		"250.0"
+					"duration"		"8.0"
+					"cond"			"11"	//Add Kritz cond
 				}
 				
 				"Tags_AddCond"
@@ -1757,16 +1745,15 @@
 		
 		"411"	//Quick Fix
 		{
-			"desp"			"Quick Fix: {positive}+35% ÜberCharge rate, +20% larger area of range, {neutral}replace megaheal to speed boost for area of range effect"
+			"desp"			"Quick Fix: {positive}+35% ÜberCharge rate, ÜberCharges get an area of range speed boost effect"
 			"attrib"		"10 ; 1.35"
 			
 			"uber"
 			{
 				"Tags_AreaOfEffect"
 				{
-					"override"		"medic-secondary-aoe"	//Overrides Tags_AreaOfEffect from medic-secondary with new values
-					
-					"radius"		"300.0"	//From 250 to 300
+					"radius"		"300.0"
+					"duration"		"8.0"
 					"cond"			"32"	//Speed boost
 				}
 			}


### PR DESCRIPTION
Stock Medigun now no longer gets area of range uber effect, just acts as normal uber. Kritzkrieg and Quick Fix are unchanged and still get area of range effects