### PR TITLE
Add boss health exponential

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -303,6 +303,13 @@ methodmap SaxtonHaleBase
 		public native set(float val);
 	}
 	
+	// Retrieve/Set health exponential to calculate
+	property float flHealthExponential
+	{
+		public native get();
+		public native set(float val);
+	}
+	
 	// Retrieve/Set health multiplier to calculate 
 	property float flHealthMultiplier
 	{
@@ -881,6 +888,8 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHaleBase.flRageLastTime.set");
 	MarkNativeAsOptional("SaxtonHaleBase.flMaxRagePercentage.get");
 	MarkNativeAsOptional("SaxtonHaleBase.flMaxRagePercentage.set");
+	MarkNativeAsOptional("SaxtonHaleBase.flHealthExponential.get");
+	MarkNativeAsOptional("SaxtonHaleBase.flHealthExponential.set");
 	MarkNativeAsOptional("SaxtonHaleBase.flHealthMultiplier.get");
 	MarkNativeAsOptional("SaxtonHaleBase.flHealthMultiplier.set");
 	MarkNativeAsOptional("SaxtonHaleBase.iMaxHealth.get");

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -20,19 +20,21 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 		this.iBaseHealth = 0;
 		this.iHealthPerPlayer = 0;
 		this.iMaxHealth = 0;
+		this.flHealthExponential = 1.0;
+		this.flHealthMultiplier = 1.0;
+		this.bHealthPerPlayerAlive = false;
 		
 		this.flSpeed = 370.0;
 		this.flSpeedMult = 0.07;
-		this.flHealthMultiplier = 1.0;
 		this.flMaxRagePercentage = 2.0;
 		this.iRageDamage = 0;
 		this.flEnvDamageCap = 400.0;
 		this.flWeighDownTimer = 2.8;
 		this.flWeighDownForce = 3000.0;
 		this.flGlowTime = 0.0;
+		
 		this.bMinion = false;
 		this.bModel = true;
-		this.bHealthPerPlayerAlive = false;
 		this.nClass = TFClass_Unknown;
 
 		strcopy(g_sClientBossType[this.iClient], sizeof(g_sClientBossType[]), type);
@@ -86,13 +88,15 @@ methodmap SaxtonHaleBoss < SaxtonHaleBase
 
 	public int CalculateMaxHealth()
 	{
-		int iHealth;
+		float flHealth;
 		if (this.bHealthPerPlayerAlive)
-			iHealth = RoundToNearest((this.iBaseHealth + this.iHealthPerPlayer * SaxtonHale_GetAliveAttackPlayers()) * this.flHealthMultiplier);
+			flHealth = float(this.iHealthPerPlayer * SaxtonHale_GetAliveAttackPlayers());
 		else
-			iHealth = RoundToNearest((this.iBaseHealth + this.iHealthPerPlayer * g_iTotalAttackCount) * this.flHealthMultiplier);
+			flHealth = float(this.iHealthPerPlayer * g_iTotalAttackCount);
 		
-		return iHealth;
+		flHealth += float(this.iBaseHealth);
+		flHealth = Pow(flHealth, this.flHealthExponential);
+		return RoundToNearest(flHealth * this.flHealthMultiplier);
 	}
 	
 	public void GetBossName(char[] sName, int length)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -65,8 +65,8 @@ methodmap CAnnouncer < SaxtonHaleBase
 {
 	public CAnnouncer(CAnnouncer boss)
 	{
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Spy;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_blutarch.sp
@@ -46,8 +46,8 @@ methodmap CBlutarch < SaxtonHaleBase
 		weaponSpells.flRageRequirement = 0.0;
 		weaponSpells.flCooldown = 15.0;
 		
-		boss.iBaseHealth = 500;
-		boss.iHealthPerPlayer = 700;
+		boss.iHealthPerPlayer = 550;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Spy;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -71,8 +71,8 @@ methodmap CBonkBoy < SaxtonHaleBase
 		rageCond.AddCond(TFCond_SpeedBuffAlly);			//Speed boost effect
 		
 		boss.flSpeed = 400.0;
-		boss.iBaseHealth = 700;
-		boss.iHealthPerPlayer = 650;
+		boss.iHealthPerPlayer = 500;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Scout;
 		boss.iMaxRageDamage = 1500;
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -81,8 +81,8 @@ methodmap CBrutalSniper < SaxtonHaleBase
 		CScareRage scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
 		scareAbility.flRadius = 200.0;
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Sniper;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demopan.sp
@@ -70,8 +70,8 @@ methodmap CDemoPan < SaxtonHaleBase
 		//CDropModel dropmodel = boss.CallFunction("CreateAbility", "CDropModel");
 		//dropmodel.SetModel(DEMOPAN_DROP_MODEL);
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_DemoMan;
 		boss.iMaxRageDamage = 3000;
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -84,8 +84,8 @@ methodmap CDemoRobot < SaxtonHaleBase
 	{
 		boss.CallFunction("CreateAbility", "CBraveJump");
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_DemoMan;
 		boss.iMaxRageDamage = 2500;
 		g_flGrenadeLauncherRemoveTime[boss.iClient] = 0.0;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -68,8 +68,8 @@ methodmap CGentleSpy < SaxtonHaleBase
 {
 	public CGentleSpy(CGentleSpy boss)
 	{
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Spy;
 		boss.iMaxRageDamage = 2000;
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
@@ -105,8 +105,8 @@ methodmap CSaxtonHale < SaxtonHaleBase
 		CScareRage scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
 		scareAbility.flRadius = 800.0;
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Soldier;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -81,8 +81,8 @@ methodmap CHorsemann < SaxtonHaleBase
 		modelOverride.flScale = 0.5;
 		*/
 		
-		boss.iBaseHealth = 700;
-		boss.iHealthPerPlayer = 650;
+		boss.iHealthPerPlayer = 500;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_DemoMan;
 		boss.iMaxRageDamage = 3000;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
@@ -103,8 +103,8 @@ methodmap CMerasmus < SaxtonHaleBase
 		rageCond.AddCond(TFCond_UberchargedCanteen);	//Ubered while raged
 		rageCond.AddCond(TFCond_CritCanteen);	// Crits while raged
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Sniper;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_painiscupcakes.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_painiscupcakes.sp
@@ -94,8 +94,8 @@ methodmap CPainisCupcake < SaxtonHaleBase
 		rageCond.AddCond(TFCond_UberchargedCanteen);
 		rageCond.AddCond(TFCond_SpeedBuffAlly);
 		
-		boss.iBaseHealth = 700;
-		boss.iHealthPerPlayer = 650;
+		boss.iHealthPerPlayer = 500;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Soldier;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -84,8 +84,8 @@ methodmap CPyroCar < SaxtonHaleBase
 		//boss.CallFunction("CreateAbility", "CFloatJump");
 		boss.CallFunction("CreateAbility", "CRageGas");
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 800;
+		boss.iHealthPerPlayer = 600;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Pyro;
 		boss.iMaxRageDamage = 2500;
 		boss.flSpeed = 350.0;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -46,8 +46,8 @@ methodmap CRedmond < SaxtonHaleBase
 		weaponSpells.flRageRequirement = 0.0;
 		weaponSpells.flCooldown = 5.0;
 		
-		boss.iBaseHealth = 500;
-		boss.iHealthPerPlayer = 700;
+		boss.iHealthPerPlayer = 550;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Spy;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -8,8 +8,8 @@ methodmap CSeeldier < SaxtonHaleBase
 		boss.CallFunction("CreateAbility", "CWeaponFists");
 		boss.CallFunction("CreateAbility", "CBraveJump");
 		
-		boss.iBaseHealth = 500;
-		boss.iHealthPerPlayer = 700;
+		boss.iHealthPerPlayer = 550;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Soldier;
 		boss.iMaxRageDamage = 2000;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
@@ -16,8 +16,8 @@ methodmap CSeeMan < SaxtonHaleBase
 		bomb.flBombDamage = 75.0;
 		bomb.flNukeRadius = 650.0;
 		
-		boss.iBaseHealth = 500;
-		boss.iHealthPerPlayer = 700;
+		boss.iHealthPerPlayer = 550;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_DemoMan;
 		boss.iMaxRageDamage = 2000;
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -60,8 +60,8 @@ methodmap CUberRanger < SaxtonHaleBase
 		rageCond.flRageCondSuperRageMultiplier = 1.6;	//8 seconds
 		rageCond.AddCond(TFCond_UberchargedCanteen);
 		
-		boss.iBaseHealth = 700;
-		boss.iHealthPerPlayer = 650;
+		boss.iHealthPerPlayer = 500;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Medic;
 		boss.iMaxRageDamage = 2500;
 		

--- a/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_vagineer.sp
@@ -56,8 +56,8 @@ methodmap CVagineer < SaxtonHaleBase
 		CScareRage scareAbility = boss.CallFunction("CreateAbility", "CScareRage");
 		scareAbility.flRadius = 200.0;
 		
-		boss.iBaseHealth = 750;
-		boss.iHealthPerPlayer = 700;
+		boss.iHealthPerPlayer = 550;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Engineer;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -56,8 +56,8 @@ methodmap CYeti < SaxtonHaleBase
 		rageCond.flRageCondDuration = rageFreeze.flSlowDuration + rageFreeze.flFreezeDuration;
 		rageCond.flRageCondSuperRageMultiplier = rageFreeze.flRageFreezeSuperRageMultiplier;
 		
-		boss.iBaseHealth = 800;
-		boss.iHealthPerPlayer = 850;
+		boss.iHealthPerPlayer = 650;
+		boss.flHealthExponential = 1.05;
 		boss.nClass = TFClass_Heavy;
 		boss.iMaxRageDamage = 2500;
 	}

--- a/addons/sourcemod/scripting/vsh/property.sp
+++ b/addons/sourcemod/scripting/vsh/property.sp
@@ -12,6 +12,7 @@ static float g_flWeighDownForce[TF_MAXPLAYERS];
 static float g_flGlowTime[TF_MAXPLAYERS];
 static float g_flRageLastTime[TF_MAXPLAYERS];
 static float g_flMaxRagePercentage[TF_MAXPLAYERS];
+static float g_flHealthExponential[TF_MAXPLAYERS];
 static float g_flHealthMultiplier[TF_MAXPLAYERS];
 static int g_iMaxHealth[TF_MAXPLAYERS];
 static int g_iBaseHealth[TF_MAXPLAYERS];
@@ -50,6 +51,8 @@ void Property_AskLoad()
 	CreateNative("SaxtonHaleBase.flRageLastTime.get", Property_GetRageLastTime);
 	CreateNative("SaxtonHaleBase.flMaxRagePercentage.set", Property_SetMaxRagePercentage);
 	CreateNative("SaxtonHaleBase.flMaxRagePercentage.get", Property_GetMaxRagePercentage);
+	CreateNative("SaxtonHaleBase.flHealthExponential.set", Property_SetHealthExponential);
+	CreateNative("SaxtonHaleBase.flHealthExponential.get", Property_GetHealthExponential);
 	CreateNative("SaxtonHaleBase.flHealthMultiplier.set", Property_SetHealthMultiplier);
 	CreateNative("SaxtonHaleBase.flHealthMultiplier.get", Property_GetHealthMultiplier);
 	CreateNative("SaxtonHaleBase.iMaxHealth.set", Property_SetMaxHealth);
@@ -204,6 +207,16 @@ public any Property_SetMaxRagePercentage(Handle hPlugin, int iNumParams)
 public any Property_GetMaxRagePercentage(Handle hPlugin, int iNumParams)
 {
 	return g_flMaxRagePercentage[GetNativeCell(1)];
+}
+
+public any Property_SetHealthExponential(Handle hPlugin, int iNumParams)
+{
+	g_flHealthExponential[GetNativeCell(1)] = GetNativeCell(2);
+}
+
+public any Property_GetHealthExponential(Handle hPlugin, int iNumParams)
+{
+	return g_flHealthExponential[GetNativeCell(1)];
 }
 
 public any Property_SetHealthMultiplier(Handle hPlugin, int iNumParams)


### PR DESCRIPTION
This basically makes it that the more players there is, the more health boss gets per player.

It calculates by using `iBaseHealth` and `iHealthPerPlayer` together as normal first, then whole is exponentially by `flHealthExponential`, then whole is multiplied by `flHealthMultiplier`, aka ranks.

All main bosses now have `iBaseHealth` as 0 and `flHealthExponential` as 1.05, only `iHealthPerPlayer` has a different number between the bosses.

Using Saxton Hale as a example, previously it had 800 base health and 800 health per player:
- 800 + 800 * 1 = 1600
- 800 + 800 * 10 = 8800
- 800 + 800 * 20 = 16800
- 800 + 800 * 30 = 24800

Now Saxton Hale has 800 health per player with 1.05 exponential:
- (600 * 1) ^ 1.05 = 826
- (600 * 10) ^ 1.05 = 9270
- (600 * 20) ^ 1.05 = 19193
- (600 * 30) ^ 1.05 = 29379

8 players is where Saxton Hale gets more health than previously.