### PR TITLE
Force-A-Nature: 1 clip size

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -535,6 +535,12 @@
 		}
 
 		// SCOUT
+		
+		"45"	//Force-A-Nature
+		{
+			"desp"			"Force-A-Nature: {negative}-50% clip size"
+			"attrib"		"3 ; 0.17"
+		}
 
 		"772"	//Baby Face Blaster
 		{


### PR DESCRIPTION
`-50% clip size` because 50% of 2 is 1
`3 ; 0.17` because Force-A-Nature uses same attribute to set 2 clip size, 1/6 = ~0.17