### PR TITLE
Concheror: Remove speed boost on stun

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -97,6 +97,9 @@
 //- value                   - Value to apply index
 //- duration                - Duration before removing attribute
 //
+//Tags_RemoveAttrib       - Remove an attribute to an entity
+//- index                   - Attribute index
+//
 //Tags_AreaOfEffect       - Add an area of effect condition with target as centre of effect
 //- radius                  - Radius of effect
 //- cond                    - Condition to apply as an effect
@@ -854,6 +857,20 @@
 					"rate"			"1.0"		//1 sec delay between each functions
 					
 					"amount"		"1"			//1 ammo on every call
+				}
+			}
+			
+			"think"
+			{
+				"filter"
+				{
+					"cond"			"15"	//Dazed
+				}
+				
+				"Tags_RemoveAttrib"
+				{
+					"target"		"secondary"	//Secondary weapon
+					"index"			"107"		//Faster movement speed
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -442,6 +442,29 @@ public void Tags_AddAttrib(int iClient, int iTarget, TagsParams tParams)
 	data.WriteCell(iIndex);
 }
 
+public void Tags_RemoveAttrib(int iClient, int iTarget, TagsParams tParams)
+{
+	if (iTarget <= 0 || !IsValidEdict(iTarget))
+		return;
+	
+	int iRef = EntIndexToEntRef(iTarget);
+	int iIndex = tParams.GetInt("index");
+	
+	TF2Attrib_RemoveByDefIndex(iTarget, iIndex);
+	TF2Attrib_ClearCache(iTarget);
+	
+	//Find in array thats using added attrib and remove it
+	int iLength = g_aAttrib.Length;
+	for (int iPos = 0; iPos < iLength; iPos++)
+	{
+		if (g_aAttrib.Get(iPos, TagsAttrib_Ref) == iRef && g_aAttrib.Get(iPos, TagsAttrib_Index) == iIndex)
+		{
+			g_aAttrib.Erase(iPos);
+			return;
+		}
+	}
+}
+
 public void Tags_AreaOfEffect(int iClient, int iTarget, TagsParams tParams)
 {
 	if (iTarget <= 0 || iTarget > MaxClients || !IsClientInGame(iTarget) || !IsPlayerAlive(iTarget))


### PR DESCRIPTION
Quite similar to Baby Face Blaster, any kind of stun will remove 1.5x speed boost. Speed does not get re-added if stun is over and still in conch effect. Ammo regen is unaffected.

New tag `Tags_RemoveAttrib` is made so it can properly remove attribute along with `Tags_AddAttrib`.