### PR TITLE
Flamethrower: Only increase airblast meter if from primary

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1405,6 +1405,8 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 		if (action > finalAction)
 			finalAction = action;
 		
+		Tags_OnTakeDamage(victim, attacker, damage, weapon);
+		
 		char sWeaponClass[64];
 		if (weapon > MaxClients)
 			GetEdictClassname(weapon, sWeaponClass, sizeof(sWeaponClass));

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -811,7 +811,6 @@ public Action Event_PlayerHurt(Event event, const char[] sName, bool bDontBroadc
 	{
 		int iAttacker = GetClientOfUserId(event.GetInt("attacker"));
 		int iDamageAmount = event.GetInt("damageamount");
-		Tags_PlayerHurt(iClient, iAttacker, iDamageAmount);
 		
 		if (0 < iAttacker <= MaxClients && IsClientInGame(iAttacker) && iClient != iAttacker)
 		{

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -197,14 +197,18 @@ void Tags_OnThink(int iClient)
 	}
 }
 
-void Tags_PlayerHurt(int iVictim, int iAttacker, int iDamage)
+void Tags_OnTakeDamage(int iVictim, int iAttacker, float flDamage, int iWeapon)
 {
-	if (SaxtonHale_IsValidBoss(iVictim) && SaxtonHale_IsValidAttack(iAttacker))
+	if (SaxtonHale_IsValidBoss(iVictim) && SaxtonHale_IsValidAttack(iAttacker) && !TF2_IsUbercharged(iVictim))
 	{
-		if (g_iTagsAirblastRequirement[iAttacker] > 0)
+		int iPrimary = TF2_GetItemInSlot(iAttacker, WeaponSlot_Primary);
+		if (iPrimary == INVALID_ENT_REFERENCE)
+			return;
+		
+		if (g_iTagsAirblastRequirement[iAttacker] > 0 && iPrimary == iWeapon)
 		{
 			bool bFull = (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker]);
-			g_iTagsAirblastDamage[iAttacker] += iDamage;
+			g_iTagsAirblastDamage[iAttacker] += RoundToNearest(flDamage);
 			
 			if (g_iTagsAirblastDamage[iAttacker] >= g_iTagsAirblastRequirement[iAttacker])
 			{
@@ -213,10 +217,7 @@ void Tags_PlayerHurt(int iVictim, int iAttacker, int iDamage)
 				if (!bFull)
 				{
 					EmitSoundToClient(iAttacker, SOUND_METERFULL);	//Alert player meter is fully
-					
-					int iPrimary = TF2_GetItemInSlot(iAttacker, WeaponSlot_Primary);
-					if (iPrimary > MaxClients)
-						SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 0.0);	//Allow airblast to be used
+					SetEntPropFloat(iPrimary, Prop_Send, "m_flNextSecondaryAttack", 0.0);	//Allow airblast to be used
 				}
 			}
 		}


### PR DESCRIPTION
Before it increases meter from any damage sources, now it only increases if it from flamethrower. Afterburn counts if it originate from flamethrower. Gas Passer damage does not count.