### PR TITLE
Scattergun: +50% bullets per shot

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -177,7 +177,8 @@
 		{
 			"Primary"
 			{
-				"desp"		"Scout: {negative}Always scared from nearby rages"
+				"desp"		"Primary: {positive}+50% bullets per shot"
+				"attrib"	"45 ; 1.5"
 			}
 			
 			"Secondary"
@@ -576,12 +577,6 @@
 					"duration"		"0.0"	//No duration, really just to recalculate speed
 				}
 			}
-		}
-		
-		"220"	//Shortstop
-		{
-			"desp"			"Shortstop: {positive}+35% faster reload time"
-			"attrib"		"97 ; 0.65"
 		}
 		
 		"46"	//Bonk! Atomic Punch


### PR DESCRIPTION
All scout primaries get extra bullets.
Also removed Shortstop extra reload time.