### PR TITLE
Update demo shields a bit

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -253,24 +253,8 @@
 		{
 			"Secondary"
 			{
-				"desp"		"Secondary (Shields): {positive}Primary weapon receives minicrits, {negative}charge meter is reset when hit"
+				"desp"		"Secondary (Shields): {positive}Primary weapon receives minicrits"
 				
-				"takedamage" //When taking damage...
-				{
-					"filter"
-					{
-						"attackweapon"	"melee"	//...from a melee weapon...
-					}
-					
-					"Tags_SetEntProp" //...reset charge meter.
-					{
-						"target"		"client"
-						"type"			"float"
-						"prop"			"m_flChargeMeter"
-						"value"			"0.0" 
-					}
-				}
-			
 				"attackdamage"
 				{
 					"params"
@@ -1203,15 +1187,10 @@
 		
 		"131"	//Chargin' Targe
 		{
-			"desp"			"Chargin' Targe: {positive}On bash: gain a defense buff for 6 seconds"
+			"desp"			"Chargin' Targe: {positive}Gain a defense buff for 6 seconds on charge hit"
 			
 			"attackdamage" //When dealing damage with this weapon...
-			{
-				"filter"
-				{
-					"cond"			"35"	//...while at least 25% into your charge...
-				}
-				
+			{				
 				"Tags_AddCond"
 				{
 					"cond"			"26"	//...give a defense buff (with crit resistance) to the attacker...
@@ -1238,8 +1217,8 @@
 		
 		"406"	//Splendid Screen
 		{
-			"desp"			"Splendid Screen: {positive}On bash: increased damage and knockback"
-			"attrib"		"791 ; 1.5 ; 248 ; 3.0"
+			"desp"			"Splendid Screen: {positive}Significantly increased knockback on charge hit"
+			"attrib"		"791 ; 1.5"
 			
 			"attackdamage"	//When dealing damage with this weapon...
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1187,14 +1187,14 @@
 		
 		"131"	//Chargin' Targe
 		{
-			"desp"			"Chargin' Targe: {positive}Gain a defense buff for 6 seconds on charge hit"
+			"desp"			"Chargin' Targe: {positive}Gain a defense buff for 4 seconds on charge hit"
 			
 			"attackdamage" //When dealing damage with this weapon...
 			{				
 				"Tags_AddCond"
 				{
 					"cond"			"26"	//...give a defense buff (with crit resistance) to the attacker...
-					"duration"		"6.0"	//...for 6 seconds.
+					"duration"		"4.0"	//...for 4 seconds.
 				}
 			}
 			


### PR DESCRIPTION
This PR focuses on removal of bloat/restrictions for demoknight shields, changes are:

- General
  - Removed the charge drain from boss melee hits, as demoknights aren't as much of a "nuisance" they used to be as the Eyelander speed boost was removed
  - Updated descriptions for individual shields so it's consistent with the rest

- Chargin' Targe
  - Removed the 25% charge requirement for the buff to trigger. This alongside the lack of charge drain should create, let's say, interesting combos (like really, people have been sleeping on this weapon!)
  - Reduced the buff time from 6 to 4 seconds to compensate

- Splendid Screen
  - Removed the increased damage bonus, as the knockback (which should remain the same) and halved charge time are probably enough to keep it as a viable option