### PR TITLE
Turn the Shortstop into a Pocket Rocket

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -530,7 +530,23 @@
 			"attrib"		"3 ; 0.17"
 			"clip"			"1"
 		}
-		
+		"220"	//Shortstop
+		{
+			"desp"			"Shortstop: {positive}Fires fast rockets instead of bullets, crits when aiming at boss, {negative}does less damage & 50% slower firing speed"
+			"attrib"		"280 ; 2 ; 2 ; 4 ; 103 ; 0.33 ; 5 ; 1.5"
+			"attack"
+			{
+				"filter"
+				{
+					"aim"			"1"
+				}
+				
+				"params"
+				{
+					"attackcrit"	"1"
+				}
+			}
+		}
 		"1078"	//Festive Force-A-Nature
 		{
 			"prefab"		"45"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -530,10 +530,16 @@
 			"attrib"		"3 ; 0.17"
 			"clip"			"1"
 		}
-		"220"	//Shortstop
+		
+		"1078"	//Festive Force-A-Nature
 		{
-			"desp"			"Shortstop: {positive}Fires fast rockets instead of bullets, crits when aiming at boss, {negative}does less damage & 50% slower firing speed"
-			"attrib"		"280 ; 2 ; 2 ; 4 ; 103 ; 0.33 ; 5 ; 1.5"
+			"prefab"		"45"
+		}
+		
+		"1103"	//Back Scatter
+		{
+			"desp"			"Back Scatter: {positive}Fires fast rockets instead of bullets, crits when aiming at boss, {negative}deals less damage"
+			"attrib"		"280 ; 2.0 ; 2 ; 6.0 ; 103 ; 1.33"
 			"attack"
 			{
 				"filter"
@@ -546,10 +552,6 @@
 					"attackcrit"	"1"
 				}
 			}
-		}
-		"1078"	//Festive Force-A-Nature
-		{
-			"prefab"		"45"
 		}
 		
 		"772"	//Baby Face Blaster


### PR DESCRIPTION
this PR turns the Shortstop from an ordinary bullet firing gun into a tiny rocket launcher, with the same 'crit on aim' mechanic that all Soldier rocket launchers have, while being notably weaker in damage and slower firing than the Shortstop normally is to balance it out.

the following attributes are used to make this work:

- 280/override projectile type set to 2 - this changes the projectile type from a bullet, into a rocket.

- 2/damage bonus set to 400% - despite the weapon being mentioned as being weaker, i actually had to buff up the damage a bit to make it work. otherwise this thing does only like 15 damage a shot. generally it does around ~50 uncritted, and 144 critted.

- 103/Projectile speed increased set to 33% - makes it similar to the liberty launcher, but a bit more speedy, 25% vs. 33%.

- 5/fire rate penalty set to -50% - lowers the fire rate to make it slightly closer to rocket launcher firing speeds, but slightly above.

i thought it'd be neat to let Scout have a unique weapon with a firing projectile instead of bullets. something that can be alongside a Soldier, but not quite as powerful as one. and no, you can't really rocket jump with this. i tried it a few times and it doesn't really work. so it shouldn't make Scout more annoying to fight, escaping-wise when he has this out. 

i'm willing to change some of these values to lower ones or add additional 'negative' attributes to compensate, as i know something like this hasn't really been implemented in any way in VSH Rewrite before. because of that, please fucking tell me if some of this shit won't work or is broken

[a visual example of how this looks is available here.](https://streamable.com/cckfuo)