### PR TITLE
Boston Basher changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -163,6 +163,8 @@
 //- sound                   - Optional sound of the explosion, up to 16 sounds can be specified. Set to air strike explosion sounds by default. Does not support custom sounds
 //
 //Tags_DestroyEntity      - Destroy entity target
+// - attrib                 - Check if entity has attribute index
+// - value                  - Value to check from attribute
 //
 //Tags_ForceSuicide       - Forces the target to suicide
 //
@@ -694,8 +696,25 @@
 		
 		"325"	//Boston Basher
 		{
-			"desp"			"Boston Basher: {positive}+75 max health, +60% damage bonus, {negative}only consumable and throwable weapons can be equipped"
-			"attrib"		"79 ; 0.00 ; 77 ; 0.00 ; 26 ; 75 ; 2 ; 1.60"
+			"desp"			"Boston Basher: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
+			"attrib"		"26 ; 75.0 ; 2 ; 1.60"
+			
+			"spawn"
+			{
+				"Tags_DestroyEntity"
+				{
+					"target"	"primary"
+					"attrib"	"2029"	//allowed_in_medieval_mode
+					"value"		"0.0"
+				}
+				
+				"Tags_DestroyEntity"
+				{
+					"target"	"secondary"
+					"attrib"	"2029"	//allowed_in_medieval_mode
+					"value"		"0.0"
+				}
+			}
 		}
 
 		"452"	//Three-Rune Blade

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -333,6 +333,14 @@ stock void TF2_RemoveItemInSlot(int client, int slot)
 	}
 }
 
+stock bool TF2_SwitchToWeapon(int iClient, int iWeapon)
+{
+	char sClassname[256];
+	GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+	FakeClientCommand(iClient, "use %s", sClassname);
+	return GetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon") == iWeapon;
+}
+
 stock void TF2_CheckClientWeapons(int iClient)
 {
 	//Weapons


### PR DESCRIPTION
Gives scout a new playstyle, similar to medieval mode you can no longer use guns but can still equip your throwables / drinks. 

Gives scout some extra bonuses to compensate for not having any guns:
changes Boston Basher and it's reskins to give you extra health and damage in exchange for having no primary or secondary ammo.