### PR TITLE
Rework Cloak and dagger

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -170,7 +170,9 @@
 //- duration                - Stun duration
 //- slowdown                - Slowdown strength, from 0.0 to 1.0
 //- type                    - Stun type, default is 1, which is simple slowdown
-
+//
+//Tags_MakeBleed          - Adds bleed to target
+//- duration                - Bleed duration
 
 "Config"
 {
@@ -2341,7 +2343,52 @@
 		"60"	//Cloak and Dagger
 		{
 			"desp"			"Cloak and Dagger: {positive}Gives A 40% jump height and speed bonus while cloaked, {negative}Lose health while cloaked"
-			"attrib"		"524 ; 1.4 ; 851 ; 1.4 ; 191 ; 2"
+			
+			"think"
+			{
+				"Tags_SetAttrib"	//Reset jump height attribute
+				{
+					"name"		"60-jump"
+					"target"	"pda2"
+					"index"		"326"	//jump height
+					"value"		"1.0"
+				}
+			}
+			
+			"think"
+			{
+				"filter"
+				{
+					"cond"		"4"		//Cloaked
+				}
+				
+				"Tags_SetAttrib"	//Override jump height value above
+				{
+					"override"	"60-jump"
+					"value"		"1.4"
+				}
+				
+				"Tags_AddCond"
+				{
+					"cond"			"32"	//Speed boost
+				}
+				
+				"Tags_MakeBleed"	//Give bleed while cloaked
+				{
+					"name"		"60-makebleed"
+					"duration"	"0.5"
+				}
+			}
+			
+			"think"
+			{
+				"filter"
+				{
+					"cond"		"25"	//Bleeding
+				}
+				
+				"block"			"60-makebleed"	//Block bleed function, client is already bleeding
+			}
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -882,6 +882,14 @@ public void Tags_Stun(int iClient, int iTarget, TagsParams tParams)
 
 	TF2_StunPlayer(iTarget, flDuration, flSlowdown, iStunflags);
 }
+ 
+public void Tags_MakeBleed(int iClient, int iTarget, TagsParams tParams)
+{
+	if (iTarget <= 0 || iTarget > MaxClients || !IsClientInGame(iTarget) || !IsPlayerAlive(iTarget))
+		return;
+	
+	TF2_MakeBleed(iTarget, iClient, tParams.GetFloat("duration"));
+}
 
 //---------------------------
 


### PR DESCRIPTION
Rework item so it can function in rewrite. Now the weapon gives mobility bonuses while active but also has a health drain to avoid it's old problem of stalling out games. (If I understand it right the damage will make a spy using it flash instead of staying cloaked.)