### PR TITLE
vaccinator rework

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1834,8 +1834,8 @@
 		
 		"998"	//Vaccinator
 		{
-			"desp"			"Vaccinator: {positive}+20% max overheal, -50% decay rate, Reduced overheal and ubercharge build rate by 30%"
-			"attrib"		"11 ; 1.20 ; 13 ; 0.50 ; 9 ; 0.70 ; 479 ; 0.70"
+			"desp"			"Vaccinator: {positive}+20% max overheal, -50% decay rate."
+			"attrib"		"11 ; 1.20 ; 13 ; 0.50"
 		}
 		
 		"173"	//Vita-Saw


### PR DESCRIPTION
reworking the vaccinator so it can be unrestricted in VSH again.

New changes are an increased overheal rate (1.7 times instead of normal 1.5) and reduces the overheal decay rate to half of it's normal value.

However the ubercharge and overheal build slower than normal so you can't buff your teams health too fast.