### PR TITLE
Notify boss when milked

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -50,6 +50,7 @@
 #define SOUND_METERFULL		"player/recharged.wav"
 #define SOUND_BACKSTAB		"player/spy_shield_break.wav"
 #define SOUND_DOUBLEDONK	"player/doubledonk.wav"
+#define SOUND_JAR_EXPLODE	"weapons/jar_explode.wav"
 #define SOUND_NULL			"vo/null.mp3"
 
 #define PARTICLE_GHOST 		"ghost_appearation"


### PR DESCRIPTION
In regular TF2, classes speak a voice line when they are milked. As the boss, most voice lines are suppressed so it is hard to tell whether you have been milked or not. Your only indicator is a small HUD icon that's fairly easy to miss in a chaotic firefight. This can easily lead to situations where the boss is not aware that the enemy heals on every hit, leading to a quick victory for RED.

I propose adding an indicator similar to getting backstabbed. This is not needed for other debuffs such as Jarate since they use an overlay.