### PR TITLE
Eureka Effect changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1767,8 +1767,8 @@
 		
 		"589"	//The Eureka Effect
 		{
-			"desp"			"The Eureka Effect: {positive}+20 metal every 5 seconds, reduced construction speed on hit penalty"
-			"attrib"		"113 ; 20.0 ; 93 ; 0.65"
+			"desp"			"The Eureka Effect: {positive}+20 metal every 5 seconds"
+			"attrib"		"113 ; 20.0"
 		}
 		
 		"155"	//Southern Hospitality

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1765,9 +1765,9 @@
 			"prefab"		"140"
 		}
 		
-		"589"	//The Eureka Effect
+		"589"	//Eureka Effect
 		{
-			"desp"			"The Eureka Effect: {positive}+20 metal every 5 seconds"
+			"desp"			"Eureka Effect: {positive}+20 metal every 5 seconds"
 			"attrib"		"113 ; 20.0"
 		}
 		

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1765,6 +1765,12 @@
 			"prefab"		"140"
 		}
 		
+		"589"	//The Eureka Effect
+		{
+			"desp"			"The Eureka Effect: {positive}+20 metal every 5 seconds, reduced construction speed on hit penalty"
+			"attrib"		"113 ; 20.0 ; 93 ; 0.65"
+		}
+		
 		"155"	//Southern Hospitality
 		{
 			"desp"			"Southern Hospitality: {positive}+25% sentry range, +100% dispencer range, {negative}cannot carry buildings"


### PR DESCRIPTION
The Eureka Effect has been outclassed by other engineer wrenches for a while. Hopefully 20 metal every 5 seconds and slightly reduced construction speed penalty is enough to make it a viable option in vsh. In order to not make it too strong, the metal penalty from dispensers/pickups will stay.