### PR TITLE
Engineer balance changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1688,7 +1688,7 @@
 
 		"141"	//Frontier Justice
 		{
-			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative} Increased spread, slower reload speed"
+			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}15% less accurate, 50% slower reload time"
 			"attrib"                "36 ; 1.15 ; 96 ; 1.50"
 			"think"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -302,23 +302,11 @@
 		}
 		
 		"Engineer"
-		{
-			
-			"Secondary"
-			{
-				"desp"		"Secondary (Pistols): {positive} Increased accuracy and reload speed"
-				"attrib"	"106 ; 0.50 ; 97 ; 0.30"
-			}
-			
+		{	
 			"Melee"
 			{
 				"crit"		"1"
 			}
-			
-			"pda1"
-			{
-				"desp"		"Sentries: {negative} -10% damage"
-				"attrib"	"287 ; 0.90"
 		}
 		
 		"Medic"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -302,7 +302,7 @@
 		}
 		
 		"Engineer"
-		{	
+		{
 			"Melee"
 			{
 				"crit"		"1"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1701,7 +1701,7 @@
 		"141"	//Frontier Justice
 		{
 			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative} Increased spread, slower reload speed"
-			"attrib"                "36 ; 0.15 ; 96 ; 0.50"
+			"attrib"                "36 ; 1.15 ; 96 ; 1.50"
 			"think"
 			{
 				"filter"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -303,10 +303,22 @@
 		
 		"Engineer"
 		{
+			
+			"Secondary"
+			{
+				"desp"		"Secondary (Pistols): {positive} Increased accuracy and reload speed"
+				"attrib"	"106 ; 0.50 ; 97 ; 0.30"
+			}
+			
 			"Melee"
 			{
 				"crit"		"1"
 			}
+			
+			"pda1"
+			{
+				"desp"		"Sentries: {negative} -10% damage"
+				"attrib"	"287 ; 0.90"
 		}
 		
 		"Medic"
@@ -1688,8 +1700,8 @@
 
 		"141"	//Frontier Justice
 		{
-			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss"
-			
+			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative} Increased spread, slower reload speed"
+			"attrib"                "36 ; 0.15 ; 96 ; 0.50"
 			"think"
 			{
 				"filter"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1689,7 +1689,8 @@
 		"141"	//Frontier Justice
 		{
 			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}15% less accurate, 50% slower reload time"
-			"attrib"                "36 ; 1.15 ; 96 ; 1.50"
+			"attrib"		"36 ; 1.15 ; 96 ; 1.50"
+			
 			"think"
 			{
 				"filter"


### PR DESCRIPTION
Frontier justice and engineer's sentries have received nerfs to compensate for their insane damage output. The engineer's pistol has been greatly underused, so it's accuracy and reload speed have been improved.