### PR TITLE
Add Tags_IgnitePlayer + some new filters for minimum/maximum damage

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -37,8 +37,8 @@
 //- attackweapon          - Is attacked weapon in slot X, only works on 'attackdamage' and 'takedamage'
 //- aim                   - Is client aiming at boss
 //- sentrytarget          - Is client's sentry targeting at boss
-//- damagemax		  - Did client deal less than X amount of damage
-//- damagemin		  - Did client deal more than X amount of damage
+//- damagemax             - Did client deal less than X amount of damage
+//- damagemin             - Did client deal more than X amount of damage
 //- damagetype            - Does damagetype have X, only works on 'attackdamage' and 'takedamage'
 //- damagecustom          - Is damagecustom X, only works on 'attackdamage' and 'takedamage'
 //- backstabcount         - X consecutive backstabs required
@@ -178,8 +178,8 @@
 //Tags_MakeBleed          - Adds bleed to target
 //- duration                - Bleed duration
 //
-//Tags_IgnitePlayer		  - Sets target on fire
-//- duration				- Afterburn duration
+//Tags_IgnitePlayer       - Sets target on fire
+//- duration                - Afterburn duration
 
 "Config"
 {

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -41,6 +41,8 @@
 //- damagecustom          - Is damagecustom X, only works on 'attackdamage' and 'takedamage'
 //- backstabcount         - X consecutive backstabs required
 //- feigndeath            - Does client have feign death ready
+//- minimumdamage		  - Did client deal more than X amount of damage
+//- maximumdamage		  - Did client deal less than X amount of damage
 //- victimuber            - Is victim ubered or not, only works on 'attackdamage' and 'takedamage'
 //
 //List of possible targets for each functions, where client is the calling function
@@ -175,6 +177,8 @@
 //
 //Tags_MakeBleed          - Adds bleed to target
 //- duration                - Bleed duration
+//Tags_IgnitePlayer		  - Sets target on fire
+//- duration				- Afterburn duration
 
 "Config"
 {

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -37,12 +37,12 @@
 //- attackweapon          - Is attacked weapon in slot X, only works on 'attackdamage' and 'takedamage'
 //- aim                   - Is client aiming at boss
 //- sentrytarget          - Is client's sentry targeting at boss
+//- damagemax		  - Did client deal less than X amount of damage
+//- damagemin		  - Did client deal more than X amount of damage
 //- damagetype            - Does damagetype have X, only works on 'attackdamage' and 'takedamage'
 //- damagecustom          - Is damagecustom X, only works on 'attackdamage' and 'takedamage'
 //- backstabcount         - X consecutive backstabs required
 //- feigndeath            - Does client have feign death ready
-//- minimumdamage		  - Did client deal more than X amount of damage
-//- maximumdamage		  - Did client deal less than X amount of damage
 //- victimuber            - Is victim ubered or not, only works on 'attackdamage' and 'takedamage'
 //
 //List of possible targets for each functions, where client is the calling function
@@ -177,6 +177,7 @@
 //
 //Tags_MakeBleed          - Adds bleed to target
 //- duration                - Bleed duration
+//
 //Tags_IgnitePlayer		  - Sets target on fire
 //- duration				- Afterburn duration
 

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -919,6 +919,14 @@ public void Tags_MakeBleed(int iClient, int iTarget, TagsParams tParams)
 	TF2_MakeBleed(iTarget, iClient, tParams.GetFloat("duration"));
 }
 
+public void Tags_IgnitePlayer(int iClient, int iTarget, TagsParams tParams)
+{
+	if (iTarget <= 0 || iTarget > MaxClients || !IsClientInGame(iTarget) || !IsPlayerAlive(iTarget))
+		return;
+	
+	TF2_IgnitePlayer(iTarget, iClient, tParams.GetFloat("duration"));
+}
+
 //---------------------------
 
 public void Frame_AreaOfRange(DataPack data)

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -134,19 +134,19 @@ enum struct TagsFilterStruct
 			}
 			case TagsFilterType_DamageMaximum:
 			{
-               			int iDamage;
-         			if (!tParams.GetIntEx("damage", iDamage))
-                    			return false;
-                
-                		return iDamage <= this.nValue;
+				int iDamage;
+				if (!tParams.GetIntEx("damage", iDamage))
+					return false;
+				
+				return iDamage <= this.nValue;
 			}
 			case TagsFilterType_DamageMinimum:
 			{
-              			int iDamage;
-                		if (!tParams.GetIntEx("damage", iDamage))
-                   			return false;
-                
-                		return iDamage >= this.nValue;
+				int iDamage;
+				if (!tParams.GetIntEx("damage", iDamage))
+					return false;
+				
+				return iDamage >= this.nValue;
 			}
 		}
 		

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -6,12 +6,12 @@ enum TagsFilterType			//List of possible filters
 	TagsFilterType_AttackWeapon,
 	TagsFilterType_Aim,
 	TagsFilterType_SentryTarget,
+	TagsFilterType_DamageMaximum,
+	TagsFilterType_DamageMinimum,
 	TagsFilterType_DamageType,
 	TagsFilterType_DamageCustom,
 	TagsFilterType_BackstabCount,
 	TagsFilterType_FeignDeath,
-	TagsFilterType_MaximumDamage,
-	TagsFilterType_MinimumDamage,
 	TagsFilterType_VictimUber,
 }
 
@@ -26,7 +26,7 @@ enum struct TagsFilterStruct
 		
 		switch (this.nType)
 		{
-			case TagsFilterType_Cond, TagsFilterType_BackstabCount, TagsFilterType_MaximumDamage, TagsFilterType_MinimumDamage:
+			case TagsFilterType_Cond, TagsFilterType_BackstabCount, TagsFilterType_DamageMaximum, TagsFilterType_DamageMinimum:
 			{
 				//Get number from string
 				return !!StringToIntEx(sValue, this.nValue);
@@ -132,21 +132,21 @@ enum struct TagsFilterStruct
 				bool bUbered = TF2_IsUbercharged(iVictim);
 				return (this.nValue ? bUbered : !bUbered);
 			}
-			case TagsFilterType_MaximumDamage:
+			case TagsFilterType_DamageMaximum:
 			{
-                int iDamage;
-                if (!tParams.GetIntEx("damage", iDamage))
-                    return false;
+               			int iDamage;
+         			if (!tParams.GetIntEx("damage", iDamage))
+                    			return false;
                 
-                return iDamage <= this.nValue;
+                		return iDamage <= this.nValue;
 			}
-			case TagsFilterType_MinimumDamage:
+			case TagsFilterType_DamageMinimum:
 			{
-                int iDamage;
-                if (!tParams.GetIntEx("damage", iDamage))
-                    return false;
+              			int iDamage;
+                		if (!tParams.GetIntEx("damage", iDamage))
+                   			return false;
                 
-                return iDamage >= this.nValue;
+                		return iDamage >= this.nValue;
 			}
 		}
 		
@@ -220,14 +220,14 @@ TagsFilterType TagsFilter_GetType(const char[] sTarget)
 		mFilterType.SetValue("cond", TagsFilterType_Cond);
 		mFilterType.SetValue("activeweapon", TagsFilterType_ActiveWeapon);
 		mFilterType.SetValue("attackweapon", TagsFilterType_AttackWeapon);
+		mFilterType.SetValue("damagemax", TagsFilterType_DamageMaximum);
+		mFilterType.SetValue("damagemin", TagsFilterType_DamageMinimum);
 		mFilterType.SetValue("aim", TagsFilterType_Aim);
 		mFilterType.SetValue("sentrytarget", TagsFilterType_SentryTarget);
 		mFilterType.SetValue("damagetype", TagsFilterType_DamageType);
 		mFilterType.SetValue("damagecustom", TagsFilterType_DamageCustom);
 		mFilterType.SetValue("backstabcount", TagsFilterType_BackstabCount);
 		mFilterType.SetValue("feigndeath", TagsFilterType_FeignDeath);
-		mFilterType.SetValue("maximumdamage", TagsFilterType_MaximumDamage);
-		mFilterType.SetValue("minimumdamage", TagsFilterType_MinimumDamage);
 		mFilterType.SetValue("victimuber", TagsFilterType_VictimUber);
 	}
 	

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -10,6 +10,8 @@ enum TagsFilterType			//List of possible filters
 	TagsFilterType_DamageCustom,
 	TagsFilterType_BackstabCount,
 	TagsFilterType_FeignDeath,
+	TagsFilterType_MaximumDamage,
+	TagsFilterType_MinimumDamage,
 	TagsFilterType_VictimUber,
 }
 
@@ -24,7 +26,7 @@ enum struct TagsFilterStruct
 		
 		switch (this.nType)
 		{
-			case TagsFilterType_Cond, TagsFilterType_BackstabCount:
+			case TagsFilterType_Cond, TagsFilterType_BackstabCount, TagsFilterType_MaximumDamage, TagsFilterType_MinimumDamage:
 			{
 				//Get number from string
 				return !!StringToIntEx(sValue, this.nValue);
@@ -130,6 +132,22 @@ enum struct TagsFilterStruct
 				bool bUbered = TF2_IsUbercharged(iVictim);
 				return (this.nValue ? bUbered : !bUbered);
 			}
+			case TagsFilterType_MaximumDamage:
+			{
+                int iDamage;
+                if (!tParams.GetIntEx("damage", iDamage))
+                    return false;
+                
+                return iDamage <= this.nValue;
+			}
+			case TagsFilterType_MinimumDamage:
+			{
+                int iDamage;
+                if (!tParams.GetIntEx("damage", iDamage))
+                    return false;
+                
+                return iDamage >= this.nValue;
+			}
 		}
 		
 		return false;
@@ -208,6 +226,8 @@ TagsFilterType TagsFilter_GetType(const char[] sTarget)
 		mFilterType.SetValue("damagecustom", TagsFilterType_DamageCustom);
 		mFilterType.SetValue("backstabcount", TagsFilterType_BackstabCount);
 		mFilterType.SetValue("feigndeath", TagsFilterType_FeignDeath);
+		mFilterType.SetValue("maximumdamage", TagsFilterType_MaximumDamage);
+		mFilterType.SetValue("minimumdamage", TagsFilterType_MinimumDamage);
 		mFilterType.SetValue("victimuber", TagsFilterType_VictimUber);
 	}
 	


### PR DESCRIPTION
originally these additions were intended as an assistance to a change to pyro's shotgun, however after realizing the trouble with reskins & similarly-classes shotguns, i gave up. however, the changes added nonetheless might prove useful in other weapon changes.

`minimumdamage` filter checks to see if attacker dealt above a certain amount of damage

`maximumdamage` filter checks to see if attacker dealt below a certain amount of damage

`Tags_IgnitePlayer` is essentially just a proxy to `TF2_IgnitePlayer`. it sets people on fire.

if there are any tab spacing issues blame notepad++ :v