### PR TITLE
Fix Eureka Effect metal regen

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1781,7 +1781,7 @@
 		"589"	//Eureka Effect
 		{
 			"desp"			"Eureka Effect: {positive}+20 metal every 5 seconds"
-			"attrib"		"113 ; 20.0"
+			"attrib"		"113 ; 25.0"
 		}
 		
 		"155"	//Southern Hospitality


### PR DESCRIPTION
Make Eureka Effect give the correct amount of metal. (Metal regen is affected by -%metal from dispensers and pickups)