### PR TITLE
Replace airblast dmg requirement to cooldown

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -154,7 +154,7 @@
 //Tags_AddHealersUber     - Add uber to every healers healing target
 //- amount                  - Max uber to evenly split give every healers
 //
-//Tags_Airblast           - Set weapon to require damage or cooldown inorder to able to airblast
+//Tags_Airblast           - Set weapon cooldown inorder to able to airblast
 //- cooldown                - Cooldown in seconds to be able to use airblast
 //
 //Tags_Explode            - Creates explosion at target

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -235,7 +235,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}12 seconds airblast cooldown"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}12 seconds airblast cooldown"
 				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -154,9 +154,8 @@
 //Tags_AddHealersUber     - Add uber to every healers healing target
 //- amount                  - Max uber to evenly split give every healers
 //
-//Tags_Airblast           - Set weapon to require damage inorder to able to airblast
-//- start                   - Damage meter to start
-//- damage                  - Damage requirement to able to use airblast
+//Tags_Airblast           - Set weapon to require damage or cooldown inorder to able to airblast
+//- cooldown                - Cooldown in seconds to be able to use airblast
 //
 //Tags_Explode            - Creates explosion at target
 //- damage                  - Explosion damage
@@ -236,7 +235,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}replace airblast ammo cost to 400 damage requirement"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {neutral}12 seconds airblast cooldown"
 				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"
@@ -245,9 +244,7 @@
 					{
 						"name"			"pyro-primary-airblast"
 						
-						"target"		"primary"
-						"start"			"400"	//Start with 100% meter
-						"damage"		"400"	//400 dmg required
+						"cooldown"		"12"	//12 Seconds
 					}
 				}
 			}
@@ -1055,6 +1052,21 @@
 			"prefab"		"40"
 		}
 		
+		"215"	//Degreaser
+		{
+			"desp"			"Degreaser: {positive}+200% Airblast push force, {negative}+100% airblast cooldown"
+			"attrib"		"255 ; 3.0"
+			
+			"spawn"
+			{
+				"Tags_Airblast"
+				{
+					"override"		"pyro-primary-airblast"
+					"cooldown"		"24"
+				}
+			}
+		}
+		
 		"594"	//Phlogistinator
 		{
 			"desp"			"Phlogistinator: {negative}No afterburn damage bonus"
@@ -1066,17 +1078,16 @@
 			}
 		}
 		
-		"215"	//Degreaser
+		"1178"	//Dragon's Fury
 		{
-			"desp"			"Degreaser: {positive}Requires 300 damage for airblast"
-	
+			"desp"			"Dragon's Fury: {negative}+50% airblast cooldown"
+			
 			"spawn"
 			{
 				"Tags_Airblast"
 				{
 					"override"		"pyro-primary-airblast"
-					"start"			"300"
-					"damage"		"300"	
+					"cooldown"		"18"
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1396,8 +1396,6 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 		if (action > finalAction)
 			finalAction = action;
 		
-		Tags_OnTakeDamage(victim, attacker, damage, weapon);
-		
 		char sWeaponClass[64];
 		if (weapon > MaxClients)
 			GetEdictClassname(weapon, sWeaponClass, sizeof(sWeaponClass));

--- a/addons/sourcemod/scripting/vsh/hud.sp
+++ b/addons/sourcemod/scripting/vsh/hud.sp
@@ -40,9 +40,9 @@ void Hud_Think(int iClient)
 			Format(sMessage, sizeof(sMessage), "%s\nDamage: %i Assist: %i", sMessage, g_iPlayerDamage[iClient], g_iPlayerAssistDamage[iClient]);
 		
 		//Display airblast percentage
-		float flPercentage = Tags_GetAirblastPercentage(iClient);
-		if (flPercentage >= 0.0)
-			Format(sMessage, sizeof(sMessage), "%s\nAirblast: %i%%", sMessage, RoundToFloor(flPercentage * 100.0));
+		float flCooldown = Tags_GetAirblastCooldown(iClient);
+		if (flCooldown > 0.0)
+			Format(sMessage, sizeof(sMessage), "%s\nAirblast Cooldown: %d sec", sMessage, RoundToCeil(flCooldown));
 	}
 	else if (!IsPlayerAlive(iClient))
 	{


### PR DESCRIPTION
- Flamethrower and Backburner: Replace 400 dmg requirement to 12 seconds cooldown
- Degreaser: Replace 300 dmg requirement to +200% airblast force and +100% airblast cooldown (24 seconds)
- Dragon's Fury: +50% airblast cooldown (18 seconds)