### PR TITLE
Machina: remove outline duration penalty

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1901,25 +1901,6 @@
 			}
 		}
 		
-		"526"	//Machina
-		{
-			"desp"			"Machina: {negative}-33% outline duration"
-			
-			"attackdamage"
-			{
-				"Tags_Glow"
-				{
-					"override"		"sniper-primary-glow"	//Override function with new values
-					"duration"		"4.0"
-				}
-			}
-		}
-		
-		"30665"	//Shooting Star
-		{
-			"prefab"		"526"
-		}
-		
 		"58"	//Jarate
 		{
 			"desp"			"Jarate: {neutral}Replaces jarate effect into a rage drain, removing equivalent of 400 damage"


### PR DESCRIPTION
Don't worry, it's nothing big.

The Machina's tracer rounds are a good enough downside, it doesn't deserve this one as well.