### PR TITLE
Revert crit-a-cola

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -639,21 +639,6 @@
 			"prefab"		"46"
 		}
 		
-		"163"	//Crit-a-Cola
-		{
-			"desp"			"Crit-a-Cola: {positive}Gives 15 seconds of minicrits, {negative}30 second recharge time"
-			"attrib" 		"801 ; 30.0"
-			
-			"lunchbox"	//Called when client consumes lunchbox
-			{
-				"Tags_AddCond"	//Add minicrits for 15 seconds
-				{
-					"cond"			"16"
-					"duration"		"15"
-				}
-			}
-		}
-		
 		"449"	//Winger
 		{
 			"desp"			"Winger: {positive}Stomping deals 300 damage"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -641,30 +641,15 @@
 		
 		"163"	//Crit-a-Cola
 		{
-			"desp"			"Crit-a-Cola: {positive}Grants 8 temporary clip size with 10x fire rate, {negative}30 second recharge time"
-			"attrib" 		"801 ; 30.0"
+			"desp"			"Crit-a-Cola: {positive}Gives 7.5 seconds of crits instead of minicrits, {negative}25 second recharge time"
+			"attrib" 		"801 ; 25.0"
 			
 			"lunchbox"	//Called when client consumes lunchbox
 			{
-				"Tags_AddAttrib"
+				"Tags_AddCond"	//Add crit for 7.5 seconds
 				{
-					"target"		"primary"	//Primary weapon
-					"index"			"6"		//Faster firing rate
-					"value"			"0.1"		//10x faster firing speed
-					"duration"		"4.0"		//After 4 sec, remove attrib
-				}
-				
-				"Tags_AddAttrib"
-				{
-					"target"		"primary"	//Primary weapon
-					"duration"		"4.0"		//After 4 sec, remove attrib
-				}
-				
-				"Tags_AddClip"
-				{
-					"target"		"primary"	//Primary weapon
-					"amount"		"8"		//Adds 8 clip
-					"duration"		"4.0"		//After 4 sec, remove any extra clips
+					"cond"			"56"
+					"duration"		"7.5
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -641,15 +641,15 @@
 		
 		"163"	//Crit-a-Cola
 		{
-			"desp"			"Crit-a-Cola: {positive}Gives 10 seconds of minicrits, {negative}25 second recharge time"
-			"attrib" 		"801 ; 25.0"
+			"desp"			"Crit-a-Cola: {positive}Gives 15 seconds of minicrits, {negative}30 second recharge time"
+			"attrib" 		"801 ; 30.0"
 			
 			"lunchbox"	//Called when client consumes lunchbox
 			{
-				"Tags_AddCond"	//Add minicrits for 10 seconds
+				"Tags_AddCond"	//Add minicrits for 15 seconds
 				{
 					"cond"			"16"
-					"duration"		"10"
+					"duration"		"15"
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -641,15 +641,15 @@
 		
 		"163"	//Crit-a-Cola
 		{
-			"desp"			"Crit-a-Cola: {positive}Gives 7.5 seconds of crits instead of minicrits, {negative}25 second recharge time"
+			"desp"			"Crit-a-Cola: {positive}Gives 10 seconds of minicrits, {negative}25 second recharge time"
 			"attrib" 		"801 ; 25.0"
 			
 			"lunchbox"	//Called when client consumes lunchbox
 			{
-				"Tags_AddCond"	//Add crit for 7.5 seconds
+				"Tags_AddCond"	//Add minicrits for 10 seconds
 				{
-					"cond"			"56"
-					"duration"		"7.5
+					"cond"			"16"
+					"duration"		"10"
 				}
 			}
 		}


### PR DESCRIPTION
The previous crit-a-cola change turned out to be extremely situational and dumb. So instead these changes make crit-a-cola give 7.5 seconds of crits.