### PR TITLE
Config rewording

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -211,7 +211,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}Crit rockets when aiming directly at the boss"
+				"desp"		"Primary: {positive}Crits when aiming directly at the boss"
 				
 				"attack"
 				{
@@ -237,7 +237,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}12 seconds airblast cooldown"
+				"desp"		"Primary: {positive}200% afterburn damage bonus, {negative}12 seconds airblast cooldown"
 				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"
@@ -430,7 +430,7 @@
 			
 			"Melee"
 			{
-				"desp"		"Melee: {neutral}Backstabs deal 1000 damage"
+				"desp"		"Melee: {neutral}Backstab deals 1000 damage"
 				
 				"attackdamage"
 				{
@@ -552,7 +552,7 @@
 		
 		"1103"	//Back Scatter
 		{
-			"desp"			"Back Scatter: {positive}Fires fast rockets instead of bullets, crits when aiming at boss, {negative}deals less damage"
+			"desp"			"Back Scatter: {positive}Crits when aiming directly at the boss, {neutral}fires fast rockets instead of bullets"
 			"attrib"		"280 ; 2.0 ; 2 ; 8.0 ; 103 ; 1.33"
 			"attack"
 			{
@@ -612,7 +612,7 @@
 		
 		"46"	//Bonk! Atomic Punch
 		{
-			"desp"			"Bonk: {neutral}Replaces bonk effect into defense buff"
+			"desp"			"Bonk: {neutral}Replaces bonk effect with a defense buff for 8 seconds"
 			
 			"think"
 			{
@@ -641,7 +641,7 @@
 		
 		"449"	//Winger
 		{
-			"desp"			"Winger: {positive}Stomping deals 300 damage"
+			"desp"			"Winger: {positive}Allows stomping for 300 damage"
 			"attrib" 		"259 ; 1.0"
 			
 			"attackdamage"
@@ -682,7 +682,7 @@
 		
 		"812"	//Flying Guillotine
 		{
-			"desp"			"Flying Guillotine: {positive}Permanent crits"
+			"desp"			"Flying Guillotine: {positive}Always crits"
 			"crit"			"1"
 		}
 		
@@ -700,7 +700,7 @@
 		
 		"317"	//Candy Cane
 		{
-			"desp"			"Candy Cane: {positive}Drops 2 small health pack on hit"
+			"desp"			"Candy Cane: {positive}Drops 2 small health packs on hit"
 			
 			"attackdamage"
 			{
@@ -719,7 +719,7 @@
 		
 		"325"	//Boston Basher
 		{
-			"desp"			"Boston Basher: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
+			"desp"			"Boston Basher: {positive}+75 max health, 60% damage bonus, {negative}only medieval weapons can be equipped"
 			"attrib"		"26 ; 75.0 ; 2 ; 1.60"
 			
 			"spawn"
@@ -747,7 +747,7 @@
 		
 		"355"	//Fan O'War
 		{
-			"desp"			"Fan O'War: {neutral}Replaces mark-for-death into 5 seconds of crit on hit, {negative}no crits"
+			"desp"			"Fan O'War: {neutral}Replaces marked-for-death effect with 5 seconds of crits on hit, {negative}no crits"
 			"attrib"		"218 ; 0.0"
 			"crit"			"0"
 			
@@ -819,7 +819,7 @@
 		
 		"1104"	//Air Strike
 		{
-			"desp"			"Air Strike: {positive}Every 200 damages gains 1 clip size, +20% explosion radius"
+			"desp"			"Air Strike: {positive}Adds 1 clip size per 200 damage done, +20% explosion radius"
 			"tags"			"damage_head_required ; 200"
 			"attrib"		"99 ; 1.33"
 			
@@ -846,7 +846,7 @@
 		
 		"730"	//Beggar's Bazooka
 		{
-			"desp"			"Beggar's Bazooka: {positive}+25% faster reload time"
+			"desp"			"Beggar's Bazooka: {positive}25% faster reload time"
 			"attrib"		"318 ; 0.75"
 		}
 
@@ -908,7 +908,7 @@
 		
 		"226"	//Battalion's Backup
 		{
-			"desp"			"Battalion's Backup: {positive}Spawns up to 3 Zombie Scouts on use"
+			"desp"			"Battalion's Backup: {positive}Spawns 3 Zombie Scouts on use"
 			
 			"banner"	//Called when client use banner
 			{
@@ -921,7 +921,7 @@
 		
 		"354"	//Concheror
 		{
-			"desp"			"Concheror: {positive}+50% speed bonus and ammo regen on use"
+			"desp"			"Concheror: {positive}50% faster move speed and ammo regen on use"
 			
 			"banner"	//Called when client use banner
 			{
@@ -960,8 +960,8 @@
 		
 		"442"	//Righteous Bison
 		{
-			"desp"			"Righteous Bison: {positive}+100% firing speed, no reload necessary"
-			"attrib"		"6 ; 0.5"
+			"desp"			"Righteous Bison: {positive}50% faster firing speed, no reload necessary"
+			"attrib"		"6 ; 0.5 ; 307 ; 1.0"
 			
 			"think"
 			{
@@ -1005,7 +1005,7 @@
 		
 		"416"	//Market Gardener
 		{
-			"desp"			"Market Gardener: {positive}Airborne hits deal 750 damage, {negative}no crits"
+			"desp"			"Market Gardener: {positive}Airborne hit deals 750 damage, {negative}no crits"
 			"minicrit"		"0"
 			"crit"			"0"
 			
@@ -1037,7 +1037,7 @@
 		
 		"128"	//Equalizer
 		{
-			"desp"			"Equalizer: {positive}+50% damage bonus"
+			"desp"			"Equalizer: {positive}50% damage bonus"
 			"attrib"		"2 ; 1.5"
 		}
 		
@@ -1056,7 +1056,7 @@
 		
 		"215"	//Degreaser
 		{
-			"desp"			"Degreaser: {positive}+100% Airblast push force, {negative}+100% airblast cooldown"
+			"desp"			"Degreaser: {positive}+100% airblast push force, {negative}+100% airblast cooldown"
 			"attrib"		"255 ; 2.0"
 			
 			"spawn"
@@ -1119,19 +1119,19 @@
 		
 		"1180"	//Gas Passer
 		{
-			"desp"			"Gas Passer: {positive}Boss explodes when ignited, {negative}100% slower charge rate"
+			"desp"			"Gas Passer: {positive}Deals 350 explosion damage, {negative}100% slower charge rate"
 			"attrib"		"874 ; 2.0 ; 875 ; 1.0"
 		}
 		
 		"39"	//Flare gun
 		{
-			"desp"			"Flare Gun: {positive}+50% damage bonus"
+			"desp"			"Flare Gun: {positive}50% damage bonus"
 			"attrib"		"2 ; 1.5" 
 		}
 		
 		"595"	//The Manmelter
 		{
-			"desp"			"Manmelter: {positive}+10% damage and +10% increased fire rate on hit, {neutral}Damage caps at 3x and fire rate at 8x "
+			"desp"			"Manmelter: {positive}+10% damage and +10% firing speed on hit (capped at +200% damage and +88% firing speed)"
 			"attrib"		"2 ; 1.0 ; 6 ; 1.0"	//This is so the stats can be modified
 			
 			"attackdamage"
@@ -1189,7 +1189,7 @@
 		
 		"348"	//Sharpened Volcano Fragment
 		{
-			"desp"					"Sharpened Volcano Fragment: {positive}+200% afterburn damage bonus, {negative}minicrits instead of crits"
+			"desp"					"Sharpened Volcano Fragment: {positive}200% afterburn damage bonus, {negative}minicrits instead of crits"
 			"attrib"				"71 ; 3.0"
 			"minicrit"				"1"
 			"crit"					"0"
@@ -1242,7 +1242,7 @@
 
 		"308"	//Loch-n-load
 		{
-			"desp"			"Loch-n-load: {positive}+30% damage bonus"
+			"desp"			"Loch-n-load: {positive}30% damage bonus"
 			"attrib"		"2 ; 1.30"
 		}
 		
@@ -1256,7 +1256,7 @@
 		
 		"405"	//Ali Baba's Wee Booties
 		{
-			"desp"			"Ali Baba's Wee Booties: {positive}Allows stomping for 1024 damage, {positive}Always +10% movement speed"
+			"desp"			"Ali Baba's Wee Booties: {positive}Allows stomping for 1024 damage, move speed bonus is unrestricted"
 			"attrib"		"259 ; 1.0 ; 788 ; 1.0 ; 107 ; 1.1"
 			
 			"attackdamage"
@@ -1417,7 +1417,7 @@
 		
 		"132"	//Eyelander
 		{
-			"desp"			"Eyelander: {positive}+25 max health on every hit, {negative}no speed bonus"
+			"desp"			"Eyelander: {positive}+25 max health on every hit, {negative}no move speed bonus"
 			"attrib"		"26 ; 0.0 ; 219 ; 0.0"
 			
 			"attackdamage"
@@ -1485,7 +1485,7 @@
 		
 		"307"	//Ullapool Caber
 		{
-			"desp"			"Ullapool Caber: {neutral}Explosion deals massive damage as a true last resort killing yourself in the process, {negative}marked-for-death while active"
+			"desp"			"Ullapool Caber: {neutral}Explosion deals massive damage while killing yourself in the process, {negative}marked-for-death while active"
 			"attrib"		"414 ; 1.0 ; 207 ; 11.0"
 			
 			"spawn"
@@ -1604,7 +1604,7 @@
 		
 		"159"	//Dalokohs Bar
 		{
-			"desp"			"Dalokohs Bar: {positive}Refills 100 ammo on consume, {negative}30 seconds recharge"
+			"desp"			"Dalokohs Bar: {positive}Refills 100 ammo when eaten, {negative}30 seconds recharge"
 			"attrib"		"801 ; 30.0"
 			
 			"lunchbox"
@@ -1633,7 +1633,7 @@
 		
 		"311"	//Buffalo Steak Sandvich
 		{
-			"desp"			"Buffalo Steak Sandvich: {positive}30% damage resistance"
+			"desp"			"Buffalo Steak Sandvich: {positive}Gives 30% damage resistance"
 			
 			"takedamage"
 			{
@@ -1652,7 +1652,7 @@
 		
 		"42"	//Sandvich
 		{
-			"desp"			"Sandvich: {positive}+200% faster lunchbox consumption time"
+			"desp"			"Sandvich: {positive}200% faster eating speed"
 			"attrib"		"876 ; 4.0 ; 201 ; 3.0"
 		}
 		
@@ -1668,13 +1668,13 @@
 		
 		"1190"	//Second Banana
 		{
-			"desp"			"Second Banana: {positive}+200% faster lunchbox consumption time"
+			"desp"			"Second Banana: {positive}200% faster eating speed"
 			"attrib"		"876 ; 2.678 ; 201 ; 3.0"	//such a precise number needed to heal exactly 200
 		}
 		
 		"43"	//Killing Gloves of Boxing
 		{
-			"desp"			"Killing Gloves of Boxing: {positive}7 seconds of crit on hit"
+			"desp"			"Killing Gloves of Boxing: {positive}7 seconds of crits on hit"
 			
 			"attackdamage"
 			{
@@ -1693,7 +1693,7 @@
 		
 		"239"	//Gloves of Running Urgently
 		{
-			"desp"			"Gloves of Running Urgently: {positive}+50% faster move speed on wearer"
+			"desp"			"Gloves of Running Urgently: {positive}50% faster move speed while active"
 			"attrib"		"851 ; 1.5"
 		}
 		
@@ -1709,13 +1709,13 @@
 		
 		"331"	//Fists of Steel
 		{
-			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}-20% move speed"
+			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}20% slower move speed"
 			"attrib"		"206 ; 0.6 ; 54 ; 0.8"
 		}
 		
 		"426"	//Eviction Notice
 		{
-			"desp"			"Eviction Notice: {neutral}Movement speed bonus is replaced with 70% greater jump height, {negative}+400% damage from melee sources while active"
+			"desp"			"Eviction Notice: {neutral}Move speed bonus is replaced with 70% greater jump height, {negative}+300% damage from melee sources while active"
 			"attrib"		"524 ; 1.7 ; 851 ; 1.0 ; 206 ; 4.0"
 		}
 		
@@ -1772,7 +1772,7 @@
 		
 		"588"	//Pomson 6000
 		{
-			"desp"			"Pomson 6000: {positive}Drains equivalent of 200 damage on hit"
+			"desp"			"Pomson 6000: {positive}Drains 200 damage worth of rage on hit"
 			
 			"attackdamage"
 			{
@@ -1791,7 +1791,7 @@
 		
 		"528"	//Short Circuit
 		{
-			"desp"			"Short Circuit: {positive}Ball explode on impact"
+			"desp"			"Short Circuit: {positive}Energy ball explodes on impact"
 			
 			"projectile"	//Called when projectile touches something
 			{
@@ -1811,7 +1811,7 @@
 		
 		"140"	//Wrangler		
 		{
-			"desp"			"Wrangler: {positive}Always minicrit" 
+			"desp"			"Wrangler: {positive}Always minicrits" 
 			"minicrit"		"1"
 		}
 		
@@ -1820,20 +1820,20 @@
 			"prefab"		"140"
 		}
 		
-		"30668" //Gigar Counter
+		"30668" //Giger Counter
 		{
 			"prefab"		"140"
 		}
 		
 		"589"	//Eureka Effect
 		{
-			"desp"			"Eureka Effect: {positive}+20 metal every 5 seconds"
+			"desp"			"Eureka Effect: {positive}Gain 20 metal every 5 seconds"
 			"attrib"		"113 ; 25.0"
 		}
 		
 		"155"	//Southern Hospitality
 		{
-			"desp"			"Southern Hospitality: {positive}+25% sentry range, +100% dispencer range, {negative}cannot carry buildings"
+			"desp"			"Southern Hospitality: {positive}+25% sentry range, +100% dispenser range, {negative}cannot carry buildings"
 			"attrib"		"353 ; 1.0 ; 344 ; 1.25 ; 345 ; 2.0"
 		}
 		
@@ -1871,7 +1871,7 @@
 		
 		"305"	//Crusader's Crossbow
 		{
-			"desp"			"Crusader's Crossbow: {positive}+60% damage bonus"
+			"desp"			"Crusader's Crossbow: {positive}60% damage bonus"
 			"attrib"		"2 ; 1.6"
 		}
 		
@@ -1887,7 +1887,7 @@
 		
 		"35"	//Kritzkrieg
 		{
-			"desp"			"Kritzkrieg: {positive}ÜberCharges get an area of range crits effect, applies a defense buff to self"
+			"desp"			"Kritzkrieg: {positive}ÜberCharge gives crits to nearby teammates and applies a defense buff to self"
 			
 			"uber"
 			{
@@ -1908,7 +1908,7 @@
 		
 		"411"	//Quick Fix
 		{
-			"desp"			"Quick Fix: {positive}+35% ÜberCharge rate, ÜberCharges get an area of range speed boost effect"
+			"desp"			"Quick Fix: {positive}ÜberCharge gives a speed boost to nearby teammates, +35% ÜberCharge rate"
 			"attrib"		"10 ; 1.35"
 			
 			"uber"
@@ -1924,7 +1924,7 @@
 		
 		"998"	//Vaccinator
 		{
-			"desp"			"Vaccinator: {positive}+20% max overheal, -50% decay rate."
+			"desp"			"Vaccinator: {positive}+20% max overheal, -50% overheal decay rate"
 			"attrib"		"11 ; 1.20 ; 13 ; 1.50"
 		}
 		
@@ -1936,7 +1936,7 @@
 		
 		"413"	//Solemn Vow
 		{
-			"desp"			"Solemn Vow: {positive}Allows you see the boss's current rage"
+			"desp"			"Solemn Vow: {positive}Allows you to see the boss' current rage"
 			
 			"spawn"
 			{
@@ -1978,7 +1978,7 @@
 		
 		"230"	//Sydney Sleeper
 		{
-			"desp"			"Sydney Sleeper: {negative}Removed Jarate effect, no outline"
+			"desp"			"Sydney Sleeper: {negative}Removed jarate effect, no outline"
 			"attrib"		"175 ; 0.0"
 			
 			"attackdamage"
@@ -1989,7 +1989,7 @@
 		
 		"402"	//Bazaar Bargain
 		{
-			"desp"			"Bazaar Bargain: {positive}+1 head on every headshot"
+			"desp"			"Bazaar Bargain: {positive}Adds 1 head per headshot"
 			
 			"attackdamage"
 			{
@@ -2037,7 +2037,7 @@
 		
 		"58"	//Jarate
 		{
-			"desp"			"Jarate: {neutral}Replaces jarate effect into a rage drain, removing equivalent of 400 damage"
+			"desp"			"Jarate: {neutral}Replaces jarate effect with a rage drain, removing 400 damage worth of rage"
 			
 			"jarate"
 			{
@@ -2103,7 +2103,7 @@
 		
 		"231"	//Darwin's Danger Shield
 		{
-			"desp"			"Darwin's Danger Shield: {positive}No fall damage, +40% greater jump height"
+			"desp"			"Darwin's Danger Shield: {positive}No fall damage, 40% greater jump height"
 			"attrib"		"275 ; 1.0 ; 326 ; 1.4"
 		}
 		
@@ -2210,7 +2210,7 @@
 
 		"61"	//Ambassador
 		{
-			"desp"			"Ambassador: {positive}Gain 3 second speed boost on headshot"
+			"desp"			"Ambassador: {positive}Gain a 3 second speed boost on headshot"
 			
 			"attackdamage"
 			{
@@ -2241,7 +2241,7 @@
 		
 		"525"	//Diamondback
 		{
-			"desp"			"Diamondback: {positive}Backstabs gives +2 crits"
+			"desp"			"Diamondback: {positive}Backstab gives +2 crits"
 			
 			"attackdamage"
 			{
@@ -2347,7 +2347,7 @@
 		
 		"356"	//Conniver's Kunai
 		{
-			"desp"			"Conniver's Kunai: {positive}Backstabs give 220 health"
+			"desp"			"Conniver's Kunai: {positive}Backstab gives 220 health"
 			
 			"attackdamage"
 			{
@@ -2367,7 +2367,7 @@
 		
 		"461"	//Big Earner
 		{
-			"desp"			"Big Earner: {positive}Backstabs give 100% cloak and 6 seconds of speed boost"
+			"desp"			"Big Earner: {positive}Backstab gives 100% cloak and 6 seconds of speed boost"
 			
 			"attackdamage"
 			{
@@ -2395,7 +2395,7 @@
 		
 		"649"	//Spy-cicle
 		{
-			"desp"			"Spy-cicle: {positive}Slows your victim for 5 seconds on backstab, {negative}-40% damage"
+			"desp"			"Spy-cicle: {positive}Backstab slows your victim for 5 seconds, {negative}40% damage penalty"
 			
 			"attackdamage"
 			{
@@ -2437,7 +2437,7 @@
 		
 		"60"	//Cloak and Dagger
 		{
-			"desp"			"Cloak and Dagger: {positive}Gives A 40% jump height and speed bonus while cloaked, {negative}Lose health while cloaked"
+			"desp"			"Cloak and Dagger: {positive}Gives a 40% jump height and speed bonus while cloaked, {negative}lose health while cloaked"
 			
 			"think"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2037,7 +2037,7 @@
 		
 		"58"	//Jarate
 		{
-			"desp"			"Jarate: {neutral}Replaces jarate effect with a rage drain, removing 400 damage worth of rage"
+			"desp"			"Jarate: {neutral}Replaces jarate effect with a rage drain, drains 400 damage worth of rage"
 			
 			"jarate"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -552,7 +552,7 @@
 		
 		"1103"	//Back Scatter
 		{
-			"desp"			"Back Scatter: {positive}Crits when aiming directly at the boss, {neutral}fires fast rockets instead of bullets"
+			"desp"			"Back Scatter: {neutral}Fires fast rockets instead of bullets, {positive}crits when aiming directly at the boss"
 			"attrib"		"280 ; 2.0 ; 2 ; 8.0 ; 103 ; 1.33"
 			"attack"
 			{
@@ -1548,7 +1548,7 @@
 		
 		"327"	//Claidheamh Mòr
 		{
-			"desp"			"Claidheamh Mòr: {positive}Refills 25% of your charge meter on hit, {neutral}replaces damage vulnerability with slower attack speed"
+			"desp"			"Claidheamh Mòr: {neutral}Replaces damage vulnerability with 15% slower attack speed, {positive}refills 25% of your charge meter on hit"
 			"attrib"		"5 ; 1.15 ; 412 ; 1.0"	
 
 			"attackdamage"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -908,7 +908,7 @@
 		
 		"226"	//Battalion's Backup
 		{
-			"desp"			"Battalion's Backup: {positive}Spawns 3 Zombie Scouts on use"
+			"desp"			"Battalion's Backup: {positive}Spawns up to 3 Zombie Scouts on use"
 			
 			"banner"	//Called when client use banner
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -237,7 +237,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}200% afterburn damage bonus, {negative}12 seconds airblast cooldown"
+				"desp"		"Primary: {positive}+200% afterburn damage bonus, {negative}12 seconds airblast cooldown"
 				"attrib"	"71 ; 3.0 ; 171 ; 0.0"
 				
 				"spawn"
@@ -282,7 +282,7 @@
 		{
 			"Primary"
 			{
-				"desp"		"Primary: {positive}25% faster weapon switch and 25% faster spin up time"
+				"desp"		"Primary: {positive}+25% faster weapon switch and +25% faster spin up time"
 				"attrib"	"178 ; 0.75 ; 87 ; 0.75"
 				
 				"attackdamage"
@@ -309,7 +309,7 @@
 		{
 			"Secondary"
 			{
-				"desp"		"Secondary (Pistols): {positive}50% more accurate, 70% faster reload time"
+				"desp"		"Secondary (Pistols): {positive}+50% more accurate, +70% faster reload time"
 				"attrib"	"106 ; 0.50 ; 97 ; 0.30"
 			}
 			
@@ -719,7 +719,7 @@
 		
 		"325"	//Boston Basher
 		{
-			"desp"			"Boston Basher: {positive}+75 max health, 60% damage bonus, {negative}only medieval weapons can be equipped"
+			"desp"			"Boston Basher: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
 			"attrib"		"26 ; 75.0 ; 2 ; 1.60"
 			
 			"spawn"
@@ -846,7 +846,7 @@
 		
 		"730"	//Beggar's Bazooka
 		{
-			"desp"			"Beggar's Bazooka: {positive}25% faster reload time"
+			"desp"			"Beggar's Bazooka: {positive}+25% faster reload time"
 			"attrib"		"318 ; 0.75"
 		}
 
@@ -960,7 +960,7 @@
 		
 		"442"	//Righteous Bison
 		{
-			"desp"			"Righteous Bison: {positive}50% faster firing speed, no reload necessary"
+			"desp"			"Righteous Bison: {positive}+50% faster firing speed, no reload necessary"
 			"attrib"		"6 ; 0.5 ; 307 ; 1.0"
 			
 			"think"
@@ -1037,7 +1037,7 @@
 		
 		"128"	//Equalizer
 		{
-			"desp"			"Equalizer: {positive}50% damage bonus"
+			"desp"			"Equalizer: {positive}+50% damage bonus"
 			"attrib"		"2 ; 1.5"
 		}
 		
@@ -1045,7 +1045,7 @@
 
 		"40"	//Backburner
 		{
-			"desp"			"Backburner: {negative}20% damage penalty"
+			"desp"			"Backburner: {negative}-20% damage penalty"
 			"attrib"		"1 ; 0.8"
 		}
 		
@@ -1125,7 +1125,7 @@
 		
 		"39"	//Flare gun
 		{
-			"desp"			"Flare Gun: {positive}50% damage bonus"
+			"desp"			"Flare Gun: {positive}+50% damage bonus"
 			"attrib"		"2 ; 1.5" 
 		}
 		
@@ -1189,7 +1189,7 @@
 		
 		"348"	//Sharpened Volcano Fragment
 		{
-			"desp"					"Sharpened Volcano Fragment: {positive}200% afterburn damage bonus, {negative}minicrits instead of crits"
+			"desp"					"Sharpened Volcano Fragment: {positive}+200% afterburn damage bonus, {negative}minicrits instead of crits"
 			"attrib"				"71 ; 3.0"
 			"minicrit"				"1"
 			"crit"					"0"
@@ -1242,7 +1242,7 @@
 
 		"308"	//Loch-n-load
 		{
-			"desp"			"Loch-n-load: {positive}30% damage bonus"
+			"desp"			"Loch-n-load: {positive}+30% damage bonus"
 			"attrib"		"2 ; 1.30"
 		}
 		
@@ -1587,7 +1587,7 @@
 		
 		"424"	//Tomislav
 		{
-			"desp"			"Tomislav: {positive}Additional +25% faster switch speed, additional 20% accuracy, {negative}-60% max overheal"
+			"desp"			"Tomislav: {positive}Additional +25% faster switch speed, additional +20% accuracy, {negative}-60% max overheal"
 			"attrib"		"178 ; 0.5 ; 106 ; 0.6 ; 800 ; 0.4"
 		}
 		
@@ -1633,7 +1633,7 @@
 		
 		"311"	//Buffalo Steak Sandvich
 		{
-			"desp"			"Buffalo Steak Sandvich: {positive}Gives 30% damage resistance"
+			"desp"			"Buffalo Steak Sandvich: {positive}Gives +30% damage resistance"
 			
 			"takedamage"
 			{
@@ -1652,7 +1652,7 @@
 		
 		"42"	//Sandvich
 		{
-			"desp"			"Sandvich: {positive}200% faster eating speed"
+			"desp"			"Sandvich: {positive}+200% faster eating speed"
 			"attrib"		"876 ; 4.0 ; 201 ; 3.0"
 		}
 		
@@ -1668,7 +1668,7 @@
 		
 		"1190"	//Second Banana
 		{
-			"desp"			"Second Banana: {positive}200% faster eating speed"
+			"desp"			"Second Banana: {positive}+200% faster eating speed"
 			"attrib"		"876 ; 2.678 ; 201 ; 3.0"	//such a precise number needed to heal exactly 200
 		}
 		
@@ -1693,7 +1693,7 @@
 		
 		"239"	//Gloves of Running Urgently
 		{
-			"desp"			"Gloves of Running Urgently: {positive}50% move speed bonus while active"
+			"desp"			"Gloves of Running Urgently: {positive}+50% move speed bonus while active"
 			"attrib"		"851 ; 1.5"
 		}
 		
@@ -1709,13 +1709,13 @@
 		
 		"331"	//Fists of Steel
 		{
-			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}20% move speed penalty"
+			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}-20% move speed penalty"
 			"attrib"		"206 ; 0.6 ; 54 ; 0.8"
 		}
 		
 		"426"	//Eviction Notice
 		{
-			"desp"			"Eviction Notice: {neutral}Move speed bonus is replaced with 70% greater jump height, {negative}+300% damage from melee sources while active"
+			"desp"			"Eviction Notice: {neutral}Move speed bonus is replaced with +70% greater jump height, {negative}+300% damage from melee sources while active"
 			"attrib"		"524 ; 1.7 ; 851 ; 1.0 ; 206 ; 4.0"
 		}
 		
@@ -1747,7 +1747,7 @@
 
 		"141"	//Frontier Justice
 		{
-			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}15% less accurate, 50% slower reload time"
+			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}-15% less accurate, 50% slower reload time"
 			"attrib"		"36 ; 1.15 ; 96 ; 1.50"
 			
 			"think"
@@ -1871,7 +1871,7 @@
 		
 		"305"	//Crusader's Crossbow
 		{
-			"desp"			"Crusader's Crossbow: {positive}60% damage bonus"
+			"desp"			"Crusader's Crossbow: {positive}+60% damage bonus"
 			"attrib"		"2 ; 1.6"
 		}
 		
@@ -2103,7 +2103,7 @@
 		
 		"231"	//Darwin's Danger Shield
 		{
-			"desp"			"Darwin's Danger Shield: {positive}No fall damage, 40% greater jump height"
+			"desp"			"Darwin's Danger Shield: {positive}No fall damage, +40% greater jump height"
 			"attrib"		"275 ; 1.0 ; 326 ; 1.4"
 		}
 		
@@ -2149,7 +2149,7 @@
 		
 		"171"	//Tribalman's Shiv
 		{
-			"desp"			"Tribalman's Shiv: {positive}Able to wall climb twice without touching the ground, 200% increased air control from climbing, {negative}less climb height"
+			"desp"			"Tribalman's Shiv: {positive}Able to wall climb twice without touching the ground, +200% increased air control from climbing, {negative}less climb height"
 			
 			"attack"
 			{
@@ -2174,7 +2174,7 @@
 		
 		"232"	//Bushwacka
 		{
-			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative}167% extra health cost on climb"
+			"desp"			"Bushwacka: {positive}Higher climb height, removed damage vulnerability, {negative+}167% extra health cost on climb"
 			"attrib"		"412 ; 1.0"
 			
 			"attack"
@@ -2395,7 +2395,7 @@
 		
 		"649"	//Spy-cicle
 		{
-			"desp"			"Spy-cicle: {positive}Backstab slows your victim for 5 seconds, {negative}40% damage penalty"
+			"desp"			"Spy-cicle: {positive}Backstab slows your victim for 5 seconds, {negative}-40% damage penalty"
 			
 			"attackdamage"
 			{
@@ -2437,7 +2437,7 @@
 		
 		"60"	//Cloak and Dagger
 		{
-			"desp"			"Cloak and Dagger: {positive}Gives a 40% jump height and speed bonus while cloaked, {negative}lose health while cloaked"
+			"desp"			"Cloak and Dagger: {positive}Gives a +40% jump height and speed bonus while cloaked, {negative}lose health while cloaked"
 			
 			"think"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -921,7 +921,7 @@
 		
 		"354"	//Concheror
 		{
-			"desp"			"Concheror: {positive}50% faster move speed and ammo regen on use"
+			"desp"			"Concheror: {positive}50% move speed bonus and ammo regen on use"
 			
 			"banner"	//Called when client use banner
 			{
@@ -1693,7 +1693,7 @@
 		
 		"239"	//Gloves of Running Urgently
 		{
-			"desp"			"Gloves of Running Urgently: {positive}50% faster move speed while active"
+			"desp"			"Gloves of Running Urgently: {positive}50% move speed bonus while active"
 			"attrib"		"851 ; 1.5"
 		}
 		
@@ -1709,7 +1709,7 @@
 		
 		"331"	//Fists of Steel
 		{
-			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}20% slower move speed"
+			"desp"			"Fists of Steel: {positive}-40% damage from all sources, {negative}20% move speed penalty"
 			"attrib"		"206 ; 0.6 ; 54 ; 0.8"
 		}
 		


### PR DESCRIPTION
Lots of changes by lots of contributors done in a considerable amount of time tend to lead to inconsistency (and in some cases even slightly wrong info 😮 !) so I reworded stuff to be a bit more consistent

Anyone who wants to bother to read this stuff can let me know if I missed something or if you don't like what I typed and want to suggest something else, it's cool, we chillin

Just remember, this has no gameplay changes at all

Changes include:
- some color code rearranging (firing x instead of y should be neutral and not positive)
- changing "movement speed" to "move speed" because that's what valve apparently calls it in all cases, plus it's shorter
- the addition of a single display only "no reload necessary" attribute to the bison
- removing redundant +/- on stats that are already shown as bonuses/penalties/faster/slower/etc
- "boss's" > "boss'" to consistently match with "players'"
- "up to" removed from backup because it has been only spawning 3 zombies with a recent-ish change, but kept in bfb because its charge meter sometimes fills up with 380 damage or some shit like that for a reason i forgot (happens in stock tf2 to a lesser extent too)
- fixing some typos
- some more stuff

As far as things I haven't missed go, I'm just not happy with the jarate description because the words "rage" and "drain" show up twice and I want to keep it consistent with the pomson, if you have any suggestions let me know