### PR TITLE
Add glow outline to alive MVP player

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1701,7 +1701,7 @@ public Action Transmit_PlayerGlow(int iEntity, int iTarget)
 		return Plugin_Stop;
 	}
 	
-	if (!SaxtonHale_IsValidBoss(iTarget))
+	if (!SaxtonHale_IsValidBoss(iTarget) || TF2_GetClientTeam(iClient) != TF2_GetClientTeam(iTarget))
 		return Plugin_Stop;
 	
 	int iScore = SaxtonHale_GetScore(iClient);

--- a/addons/sourcemod/scripting/vsh/abilities/ability_body_eat.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_body_eat.sp
@@ -133,7 +133,7 @@ methodmap CBodyEat < SaxtonHaleBase
 		SetEntProp(iRagdoll, Prop_Data, "m_iHealth", (bFake) ? 0 : iHeal);
 		
 		//Set model to body
-		char sModel[255];
+		char sModel[PLATFORM_MAX_PATH];
 		GetEntPropString(iVictim, Prop_Data, "m_ModelName", sModel, sizeof(sModel));
 		DispatchKeyValue(iRagdoll, "model", sModel);
 		

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -518,6 +518,8 @@ public Action Event_PlayerSpawn(Event event, const char[] sName, bool bDontBroad
 	// Player spawned, if they are a boss, call their spawn function
 	if (boss.bValid)
 		boss.CallFunction("OnSpawn");
+	
+	UpdateClientGlowEnt(iClient);
 }
 
 public Action Event_BuiltObject(Event event, const char[] sName, bool bDontBroadcast)

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -190,6 +190,30 @@ stock int TF2_CreateGlow(int iEnt, int iColor[4])
 	return ent;
 }
 
+stock int TF2_CreateTransmitGlow(int iClient, const char[] sModel, SDKHookCB callback)
+{
+	int iGlow = CreateEntityByName("tf_taunt_prop");
+	
+	int iTeam = GetClientTeam(iClient);
+	SetEntProp(iGlow, Prop_Data, "m_iInitialTeamNum", iTeam);
+	SetEntProp(iGlow, Prop_Send, "m_iTeamNum", iTeam);
+	
+	DispatchSpawn(iGlow);
+	
+	SetEntityModel(iGlow, sModel);
+	SetEntPropEnt(iGlow, Prop_Data, "m_hEffectEntity", iClient);
+	SetEntProp(iGlow, Prop_Send, "m_bGlowEnabled", true);
+	SetEntProp(iGlow, Prop_Send, "m_fEffects", GetEntProp(iGlow, Prop_Send, "m_fEffects")|EF_BONEMERGE|EF_NOSHADOW|EF_NOINTERP);
+	
+	SetVariantString("!activator");
+	AcceptEntityInput(iGlow, "SetParent", iClient);
+	
+	SetEntityRenderMode(iGlow, RENDER_TRANSCOLOR);
+	SetEntityRenderColor(iGlow, 255, 255, 255, 255);
+	SDKHook(iGlow, SDKHook_SetTransmit, callback);
+	return EntIndexToEntRef(iGlow);
+}
+
 stock bool TF2_FindAttribute(int iEntity, int iAttrib, float &flVal)
 {
 	Address addAttrib = TF2Attrib_GetByDefIndex(iEntity, iAttrib);


### PR DESCRIPTION
#346

Only boss can see glow, does not show glow outline if dealt 0 damage unless if last man, because otherwise everyone would have glow on round start.
Spy's disguising makes this more complicated, not sure if there any better solution for it.