### PR TITLE
Air strike

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -820,7 +820,6 @@
 		"1104"	//Air Strike
 		{
 			"desp"			"Air Strike: {positive}Adds 1 clip size per 200 damage done"
-			"tags"			"damage_head_required ; 200"
 			
 			"attackdamage"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -819,9 +819,8 @@
 		
 		"1104"	//Air Strike
 		{
-			"desp"			"Air Strike: {positive}Adds 1 clip size per 200 damage done, +20% explosion radius"
+			"desp"			"Air Strike: {positive}Adds 1 clip size per 200 damage done"
 			"tags"			"damage_head_required ; 200"
-			"attrib"		"99 ; 1.33"
 			
 			"attackdamage"
 			{


### PR DESCRIPTION
Time has proven Air Strike doesn't need increased explosion radius to be effective, it's gimmick is good enough