### PR TITLE
Quick Fix: decrease über rate and AoE radius

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1885,14 +1885,13 @@
 		
 		"411"	//Quick Fix
 		{
-			"desp"			"Quick Fix: {positive}ÜberCharge gives a speed boost to nearby teammates, +35% ÜberCharge rate"
-			"attrib"		"10 ; 1.35"
+			"desp"			"Quick Fix: {positive}ÜberCharge gives a speed boost to nearby teammates"
 			
 			"uber"
 			{
 				"Tags_AreaOfEffect"
 				{
-					"radius"		"300.0"
+					"radius"		"250.0"
 					"duration"		"8.0"
 					"cond"			"32"	//Speed boost
 				}


### PR DESCRIPTION
breaking the month-long no change streak!

the Quick-Fix has been getting a lot of use compared to the other mediguns, so to give them a better chance, I'm suggesting to remove the extra über rate bonus and lower the radius of the AoE buff to match the Kritzkrieg's. (the Kritzkrieg is in a pretty fine spot, imo.)