### PR TITLE
Fix Crusader's Crossbow accidentally having +3% über on hit

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -323,7 +323,6 @@
 		{
 			"Primary"
 			{
-				"attrib"	"17 ; 0.03"
 				"crit"		"1"
 			}
 			
@@ -1830,7 +1829,7 @@
 		"36"	//Blutsauger
 		{
 			"desp"			"Blutsauger: {positive}+3% ÜberCharge on hit, +5 health on hit"
-			"attrib"		"16 ; 0.0"
+			"attrib"		"16 ; 0.0 ; 17 ; 0.03"
 			
 			"attackdamage"
 			{
@@ -1860,6 +1859,7 @@
 		"412"	//Overdose
 		{
 			"desp"			"Overdose: {positive}+3% ÜberCharge on hit"
+			"attrib"		"17 ; 0.03"
 		}
 		
 		"35"	//Kritzkrieg


### PR DESCRIPTION
Just a simple bugfix, having a default value for this attribute is no longer necessary as one of the primaries is no longer supposed to have it. They've been moved to the weapons that use it instead.