### PR TITLE
Degreaser: undo current attributes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1033,17 +1033,8 @@
 		
 		"215"	//Degreaser
 		{
-			"desp"			"Degreaser: {positive}+100% airblast push force, {negative}+100% airblast cooldown"
-			"attrib"		"255 ; 2.0"
-			
-			"spawn"
-			{
-				"Tags_Airblast"
-				{
-					"override"		"pyro-primary-airblast"
-					"cooldown"		"24"
-				}
-			}
+			"desp"			"Degreaser: {positive}Passive +65% faster weapon switch speed"
+			"attrib"		"178 ; 0.35 ; 199 ; 1.0 ; 547 ; 1.0"
 		}
 		
 		"594"	//Phlogistinator


### PR DESCRIPTION
This is a major change.

being completely honest with you, I don't think the Degreaser we have right now is healthy for the gamemode. being sent across a room (or half the map if the pyro is standing on a high edge), per pyro, is not a fun thing for bosses to deal with.

that said, the Degreaser with no changes is pretty shit in this gamemode so this is some sort of discussion point: how to make it better?

if anyone has a suggestion, let us know somewhere, but this PR has a suggestion of my own: give it the passive weapon switch speed that it had until Tough Break. it's pretty tame and doesn't sound like much, but people could hopefully have an easier time comboing it with something, as it's the point of the Degreaser.