### PR TITLE
Tomislav: flatten custom stats

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1564,8 +1564,8 @@
 		
 		"424"	//Tomislav
 		{
-			"desp"			"Tomislav: {positive}Additional +25% faster switch speed, additional +20% accuracy, {negative}-60% max overheal"
-			"attrib"		"178 ; 0.5 ; 106 ; 0.6 ; 800 ; 0.4"
+			"desp"			"Tomislav: {positive}+50% more accurate"
+			"attrib"		"106 ; 0.5"
 		}
 		
 		"811"	//Huo-Long Heater


### PR DESCRIPTION
It doesn't make much sense to have custom positives and negatives that don't complement each other. In this case, the negative even makes the weapon pretty unusable.

This PR reduces stat spam and changes them into a neat, single one that enhances what the weapon is supposed to do. I think it'll still not be quite as good as the brass beast, but this at least makes the weapon possible to use.