### PR TITLE
Minor general fixes

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -378,6 +378,17 @@ public void RageGhost_OnPlayerKilled(SaxtonHaleBase boss, Event event)
 	}
 }
 
+public void RageGhost_OnDestroyObject(SaxtonHaleBase boss, Event event)
+{
+	// "attacker" does not give the value we're looking for, so check for "weaponid" instead
+	int iWeaponId = event.GetInt("weaponid");
+
+	if (g_bGhostEnable[boss.iClient] && iWeaponId == TF_WEAPON_SWORD)
+	{
+		event.SetString("weapon", "purgatory"); 
+	}
+}
+
 public void RageGhost_Destroy(SaxtonHaleBase boss)
 {
 	SetEntProp(boss.iClient, Prop_Data, "m_takedamage", DAMAGE_YES);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -98,7 +98,7 @@ public void BrutalSniper_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int leng
 	StrCat(sInfo, length, "\n- Brave Jump");
 	StrCat(sInfo, length, "\n- Changes your melee to a random knife on melee kill");
 	StrCat(sInfo, length, "\n  - Kukri: Default");
-	StrCat(sInfo, length, "\n  - Tribalman Shiv: 10 seconds bleed, 15%% dmg penalty");
+	StrCat(sInfo, length, "\n  - Tribalman's Shiv: 10 seconds bleed, 15%% dmg penalty");
 	StrCat(sInfo, length, "\n  - Bushwacka: Always crits, +20%% dmg vulnerability");
 	StrCat(sInfo, length, "\n  - Shahanshah: +15%% dmg when at <50%% health, -15%% dmg when at >50%% health");
 	StrCat(sInfo, length, "\n ");

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -99,8 +99,8 @@ public void BrutalSniper_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int leng
 	StrCat(sInfo, length, "\n- Changes your melee to a random knife on melee kill");
 	StrCat(sInfo, length, "\n  - Kukri: Default");
 	StrCat(sInfo, length, "\n  - Tribalman Shiv: 10 seconds bleed, 15%% dmg penalty");
-	StrCat(sInfo, length, "\n  - Bushwacka: Always crit, 20%% dmg vulnerability");
-	StrCat(sInfo, length, "\n  - Shahanshah: +15%% dmg when <50%% health, -15%% dmg when >50%% health");
+	StrCat(sInfo, length, "\n  - Bushwacka: Always crits, +20%% dmg vulnerability");
+	StrCat(sInfo, length, "\n  - Shahanshah: +15%% dmg when at <50%% health, -15%% dmg when at >50%% health");
 	StrCat(sInfo, length, "\n ");
 	StrCat(sInfo, length, "\nRage");
 	StrCat(sInfo, length, "\n- Damage requirement: 2500");
@@ -259,17 +259,17 @@ public void BrutalSniper_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iL
 		}
 		case ITEM_TRIBALMAN_SHIV:
 		{
-			StrCat(sMessage, iLength, "\nTribalman Shiv: 10 seconds bleed, 15%% dmg penalty");
+			StrCat(sMessage, iLength, "\nTribalman's Shiv: 10 seconds bleed, 15%%%% dmg penalty");
 			iColor = {192, 32, 0, 255};
 		}
 		case ITEM_BUSHWACKA:
 		{
-			StrCat(sMessage, iLength, "\nBushwacka: Always crit, 20%% dmg vulnerability");
+			StrCat(sMessage, iLength, "\nBushwacka: Always crits, +20%%%% dmg vulnerability");
 			iColor = {224, 160, 0, 255};
 		}
 		case ITEM_SHAHANSHAH:
 		{
-			StrCat(sMessage, iLength, "\nShahanshah: +15%% dmg when <50%% health, -15%% dmg when >50%% health");
+			StrCat(sMessage, iLength, "\nShahanshah: +15%%%% dmg when at <50%%%% health, -15%%%% dmg when at >50%%%% health");
 			iColor = {144, 92, 0, 255};
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -203,7 +203,9 @@ public void DemoRobot_OnRage(SaxtonHaleBase boss)
 	int iWeapon = boss.CallFunction("CreateWeapon", 206, "tf_weapon_grenadelauncher", 100, TFQual_Unusual, attribs);
 	if (iWeapon > MaxClients)
 	{
-		SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
+		char sClassname[32];
+		GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+		FakeClientCommand(iClient, "use %s", sClassname);
 		SetEntProp(iWeapon, Prop_Send, "m_iClip1", 1000);
 	}
 	/*
@@ -246,7 +248,9 @@ public void DemoRobot_OnThink(SaxtonHaleBase boss)
 			flVal /= DEMO_ROBOT_GIANT_SCALE;
 			TF2Attrib_SetByDefIndex(iMeleeWep, ATTRIB_MELEE_RANGE_MULTIPLIER, flVal);
 			
-			SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iMeleeWep);
+			char sClassname[32];
+			GetEntityClassname(iMeleeWep, sClassname, sizeof(sClassname));
+			FakeClientCommand(iClient, "use %s", sClassname);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -203,9 +203,7 @@ public void DemoRobot_OnRage(SaxtonHaleBase boss)
 	int iWeapon = boss.CallFunction("CreateWeapon", 206, "tf_weapon_grenadelauncher", 100, TFQual_Unusual, attribs);
 	if (iWeapon > MaxClients)
 	{
-		char sClassname[32];
-		GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
-		FakeClientCommand(iClient, "use %s", sClassname);
+		TF2_SwitchToWeapon(boss.iClient, iWeapon);
 		SetEntProp(iWeapon, Prop_Send, "m_iClip1", 1000);
 	}
 	/*
@@ -248,9 +246,7 @@ public void DemoRobot_OnThink(SaxtonHaleBase boss)
 			flVal /= DEMO_ROBOT_GIANT_SCALE;
 			TF2Attrib_SetByDefIndex(iMeleeWep, ATTRIB_MELEE_RANGE_MULTIPLIER, flVal);
 			
-			char sClassname[32];
-			GetEntityClassname(iMeleeWep, sClassname, sizeof(sClassname));
-			FakeClientCommand(iClient, "use %s", sClassname);
+			TF2_SwitchToWeapon(boss.iClient, iMeleeWep);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
@@ -123,7 +123,7 @@ public void Merasmus_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int length)
 	StrCat(sInfo, length, "\nRage");
 	StrCat(sInfo, length, "\n- Damage requirement: 2500");
 	StrCat(sInfo, length, "\n- Bomb projectiles at random directions from boss");
-	StrCat(sInfo, length, "\n- Self-Über and Crits for 8 seconds");
+	StrCat(sInfo, length, "\n- Übercharge for 8 seconds");
 	StrCat(sInfo, length, "\n- 200%% Rage: Doubled bomb projectile spawn rate");
 }
 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -181,11 +181,7 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 				//Check if his active weapon got removed, if so set as that weapon
 				int iActiveWep = GetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon");
 				if (!(IsValidEntity(iActiveWep)))
-				{
-					char sClassname[32];
-					GetEntityClassname(g_iPyrocarMelee[boss.iClient], sClassname, sizeof(sClassname));
-					FakeClientCommand(boss.iClient, "use %s", sClassname);
-				}
+					TF2_SwitchToWeapon(boss.iClient, g_iPyrocarMelee[boss.iClient]);
 			}
 		}
 	}
@@ -202,11 +198,7 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 				//Check if his active weapon got removed, if so set as that weapon
 				int iActiveWep = GetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon");
 				if (!(IsValidEntity(iActiveWep)))
-				{
-					char sClassname[32];
-					GetEntityClassname(g_iPyrocarPrimary[boss.iClient], sClassname, sizeof(sClassname));
-					FakeClientCommand(boss.iClient, "use %s", sClassname);
-				}
+					TF2_SwitchToWeapon(boss.iClient, g_iPyrocarPrimary[boss.iClient]);
 			}
 		}
 	}
@@ -228,14 +220,10 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 			event.Cancel();
 
 			//Change active weapon
-			char sClassname[32];
-			
 			if (IsValidEntity(GetPlayerWeaponSlot(boss.iClient, WeaponSlot_Primary)))
-				GetEntityClassname(g_iPyrocarPrimary[boss.iClient], sClassname, sizeof(sClassname));
+				TF2_SwitchToWeapon(boss.iClient, g_iPyrocarPrimary[boss.iClient]);
 			else
-				GetEntityClassname(g_iPyrocarMelee[boss.iClient], sClassname, sizeof(sClassname));
-				
-			FakeClientCommand(boss.iClient, "use %s", sClassname);
+				TF2_SwitchToWeapon(boss.iClient, g_iPyrocarMelee[boss.iClient]);
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -181,7 +181,11 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 				//Check if his active weapon got removed, if so set as that weapon
 				int iActiveWep = GetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon");
 				if (!(IsValidEntity(iActiveWep)))
-					SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", g_iPyrocarMelee[boss.iClient]);
+				{
+					char sClassname[32];
+					GetEntityClassname(g_iPyrocarMelee[boss.iClient], sClassname, sizeof(sClassname));
+					FakeClientCommand(boss.iClient, "use %s", sClassname);
+				}
 			}
 		}
 	}
@@ -198,7 +202,11 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 				//Check if his active weapon got removed, if so set as that weapon
 				int iActiveWep = GetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon");
 				if (!(IsValidEntity(iActiveWep)))
-					SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", g_iPyrocarPrimary[boss.iClient]);
+				{
+					char sClassname[32];
+					GetEntityClassname(g_iPyrocarPrimary[boss.iClient], sClassname, sizeof(sClassname));
+					FakeClientCommand(boss.iClient, "use %s", sClassname);
+				}
 			}
 		}
 	}
@@ -220,10 +228,14 @@ public void PyroCar_OnThink(SaxtonHaleBase boss)
 			event.Cancel();
 
 			//Change active weapon
+			char sClassname[32];
+			
 			if (IsValidEntity(GetPlayerWeaponSlot(boss.iClient, WeaponSlot_Primary)))
-				SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", g_iPyrocarPrimary[boss.iClient]);
+				GetEntityClassname(g_iPyrocarPrimary[boss.iClient], sClassname, sizeof(sClassname));
 			else
-				SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", g_iPyrocarMelee[boss.iClient]);
+				GetEntityClassname(g_iPyrocarMelee[boss.iClient], sClassname, sizeof(sClassname));
+				
+			FakeClientCommand(boss.iClient, "use %s", sClassname);
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -46,7 +46,7 @@ static char g_strUberRangerLastMan[][] = {
 static char g_strUberRangerBackStabbed[][] = {
 	"vo/medic_autodejectedtie01.mp3",
 	"vo/medic_sf12_badmagic10.mp3", 
-	"vo/medic_taunts11.mp3"
+	"vo/taunts/medic_taunts11.mp3"
 };
 
 public void UberRanger_Create(SaxtonHaleBase boss)
@@ -106,7 +106,7 @@ public void UberRanger_OnSpawn(SaxtonHaleBase boss)
 	int iWeapon = boss.CallFunction("CreateWeapon", 37, "tf_weapon_bonesaw", 100, TFQual_Collectors, sAttribs);
 	if (iWeapon > MaxClients)
 		SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
-		
+	
 	/*
 	Ubersaw attributes:
 	
@@ -117,10 +117,13 @@ public void UberRanger_OnSpawn(SaxtonHaleBase boss)
 	259: Deals 3x falling damage to the player you land on
 	*/
 	
-	//For reference: 230 230 230 is the color code for TF2's white paint
-	int iColor[4] = { 230, 230, 230, 255 };
+	//We have to check if the color of the boss hasn't already been altered (usually by a modifier) before applying his default color
+	int iColor[4] = {255, 255, 255, 255};
+	boss.CallFunction("GetRenderColor", iColor);
 	
-	SetEntityRenderColor(boss.iClient, iColor[0], iColor[1], iColor[2], iColor[3]);
+	//If all values are 255 (and therefore default), change the boss' color here
+	if (iColor[0] == 255 && iColor[1] == 255 && iColor[2] == 255 && iColor[3] == 255)
+		SetEntityRenderColor(boss.iClient, 230, 230, 230, _);
 }
 
 public void UberRanger_GetModel(SaxtonHaleBase boss, char[] sModel, int length)
@@ -254,7 +257,6 @@ public bool MinionRanger_IsBossHidden(SaxtonHaleBase boss)
 
 public void MinionRanger_OnSpawn(SaxtonHaleBase boss)
 {
-	
 	char sAttribs[64];
 	strcopy(sAttribs, sizeof(sAttribs), "9 ; 0.4");
 	boss.CallFunction("CreateWeapon", 211, "tf_weapon_medigun", 100, TFQual_Collectors, sAttribs);
@@ -280,18 +282,25 @@ public void MinionRanger_OnSpawn(SaxtonHaleBase boss)
 	259: Deals 3x falling damage to the player you land on
 	*/
 	
-	//We're selecting their color from a preset list, so check if it is there at all or has been emptied
-	if (g_aUberRangerColorList == null || g_aUberRangerColorList.Length <= 0)
-		UberRanger_ResetColorList();
-		
-	//Assign color
-	int iColor[4];
-	g_aUberRangerColorList.GetArray(0, iColor);
-	g_aUberRangerColorList.Erase(0);
-	iColor[3] = 255;
-	SetEntityRenderColor(boss.iClient, iColor[0], iColor[1], iColor[2], iColor[3]);
+	//We have to check if the color of the boss hasn't already been altered (usually by a modifier) before applying his default color
+	int iColor[4] = {255, 255, 255, 255};
+	boss.CallFunction("GetRenderColor", iColor);
 	
-	//Add glow for him to be easily recognizable as not the boss during spawn uber
+	//If all values are 255 (and therefore default), change the boss' color here
+	if (iColor[0] == 255 && iColor[1] == 255 && iColor[2] == 255 && iColor[3] == 255)
+	{
+		//We're selecting their color from a preset list, so check if it is there at all or has been emptied
+		if (g_aUberRangerColorList == null || g_aUberRangerColorList.Length <= 0)
+			UberRanger_ResetColorList();
+			
+		//Assign color
+		g_aUberRangerColorList.GetArray(0, iColor);
+		g_aUberRangerColorList.Erase(0);
+		
+		SetEntityRenderColor(boss.iClient, iColor[0], iColor[1], iColor[2], _);
+	}
+	
+	//Add a colored outline so he's more easily recognizable as not the boss during spawn uber
 	//Round started check is there so it doesn't show up when spawning on the next round as well
 	if (GameRules_GetRoundState() != RoundState_Preround)
 		CreateTimer(3.0, Timer_EntityCleanup, TF2_CreateGlow(boss.iClient, iColor));

--- a/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
@@ -9,7 +9,6 @@ public void Zombie_Create(SaxtonHaleBase boss)
 	boss.bMinion = true;
 	boss.bModel = false;
 	
-	SetEntityRenderColor(boss.iClient, 206, 100, 100, _);
 	EmitSoundToClient(boss.iClient, SOUND_ALERT);	//Alert player as he spawned
 }
 
@@ -28,6 +27,8 @@ public void Zombie_OnSpawn(SaxtonHaleBase boss)
 	
 	SetVariantString("TLK_RESURRECTED");
 	AcceptEntityInput(boss.iClient, "SpeakResponseConcept");
+	
+	SetEntityRenderColor(boss.iClient, 206, 100, 100, _);
 }
 
 public void Zombie_OnThink(SaxtonHaleBase boss)


### PR DESCRIPTION
Nothing of this affects gameplay.

Changes:

- Christian Brutal Sniper:
    - Updated weapon info text, mainly to include percentage signs (more on this may be requested in a future PR)

- Glitched Robot:
    - Fixed its sword being invisible after raging once

- Horseless Headless Horsemann Jr.:
    - Fixed building destructions showing the wrong kill icon while raging

- Merasmus:
    - Updated boss description to exclude crits on rage

- Pyrocar
    - Fixed weapons being invisible after throwing gas

- Über Ranger (and his companions)
    - Fixed modifier colors being overridden by preset colors since SM 1.11 support
    - Fixed an incorrect sound filepath

- Zombie Scout
    - Fixed his color not being applied since SM 1.11 support