### PR TITLE
Pyrocar: fix custom damage amount from the Backburner to buildings never being applied

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -344,7 +344,10 @@ public Action PyroCar_OnAttackBuilding(SaxtonHaleBase boss, int victim, int &inf
 {
 	//Buildings take constant damage
 	if (weapon == TF2_GetItemInSlot(boss.iClient, WeaponSlot_Primary))
+	{
 		damage = 20.0;
+		return Plugin_Changed;
+	}
 	
 	return Plugin_Continue;
 }


### PR DESCRIPTION
The damage value was being altered, but `Plugin_Continue` was being returned instead of `Plugin_Changed`, making the value change never go through.