### PR TITLE
Magnet: don't change the boss' velocity if nobody is in range

### DIFF
--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_magnet.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_magnet.sp
@@ -36,6 +36,7 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 	GetClientAbsOrigin(boss.iClient, vecOrigin);
 	TFTeam nTeam = TF2_GetClientTeam(boss.iClient);
 	int iCount;
+	bool bLinked = false;
 	
 	//Player interaction
 	for (int iVictim = 1; iVictim <= MaxClients; iVictim++)
@@ -46,6 +47,9 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 			GetClientAbsOrigin(iVictim, vecTargetOrigin);
 			if (GetVectorDistance(vecOrigin, vecTargetOrigin) <= MAGNET_RANGE)
 			{
+				//If we're connected to at least one player, we'll remember it
+				bLinked = true;
+				
 				float vecTargetPullVelocity[3];
 				MakeVectorFromPoints(vecOrigin, vecTargetOrigin, vecTargetPullVelocity);
 				
@@ -70,6 +74,10 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 			}
 		}
 	}
+	
+	//Don't do anything to the boss if nobody is in range
+	if (!bLinked)
+		return;
 	
 	ScaleVector(vecPullVelocity, 1.0 / float(iCount));	//So vel won't go crazy with huge amount of players
 	ScaleVector(vecPullVelocity, MAGNET_STRENGTH);

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_magnet.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_magnet.sp
@@ -35,8 +35,7 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 	float vecOrigin[3], vecPullVelocity[3];
 	GetClientAbsOrigin(boss.iClient, vecOrigin);
 	TFTeam nTeam = TF2_GetClientTeam(boss.iClient);
-	int iCount;
-	bool bLinked = false;
+	int iCount = 0;
 	
 	//Player interaction
 	for (int iVictim = 1; iVictim <= MaxClients; iVictim++)
@@ -47,9 +46,6 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 			GetClientAbsOrigin(iVictim, vecTargetOrigin);
 			if (GetVectorDistance(vecOrigin, vecTargetOrigin) <= MAGNET_RANGE)
 			{
-				//If we're connected to at least one player, we'll remember it
-				bLinked = true;
-				
 				float vecTargetPullVelocity[3];
 				MakeVectorFromPoints(vecOrigin, vecTargetOrigin, vecTargetPullVelocity);
 				
@@ -76,7 +72,7 @@ public void ModifiersMagnet_OnThink(SaxtonHaleBase boss)
 	}
 	
 	//Don't do anything to the boss if nobody is in range
-	if (!bLinked)
+	if (iCount <= 0)
 		return;
 	
 	ScaleVector(vecPullVelocity, 1.0 / float(iCount));	//So vel won't go crazy with huge amount of players


### PR DESCRIPTION
This PR fixes bosses with the Magnet modifier unable to interact with jump pads in some maps (as long as nobody is in range).