### PR TITLE
Remove support for SM 1.10

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -8,7 +8,7 @@ jobs:
     
     strategy:
       matrix:
-        version: ["1.10", "1.11"]
+        version: ["1.11"]
     
     steps:
       - name: Checkout

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
       
       - name: Environments
         run: |
-          echo "SM_VERSION=1.10" >> $GITHUB_ENV
+          echo "SM_VERSION=1.11" >> $GITHUB_ENV
           echo "PLUGIN_VERSION_REVISION<<EOF" >> $GITHUB_ENV
           git rev-list --count HEAD >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To download latest build version, select latest package then "Artifacts" button 
 - SourceMod 1.11
 - [tf2attributes](https://forums.alliedmods.net/showthread.php?t=210221)
 - [tf_econ_data](https://forums.alliedmods.net/showthread.php?t=315011)
-- [dhooks with detour support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)
 
 ## Special Thanks
 - [Red Sun Over Paradise](https://redsun.tf/) - Support and playtesting private version with many balance suggestions for nearly 2 years.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ All builds can be found [here](https://github.com/redsunservers/VSH-Rewrite/acti
 To download latest build version, select latest package then "Artifacts" button at top right.
 
 ## Requirements
-- SourceMod 1.10
+- SourceMod 1.11
 - [tf2attributes](https://forums.alliedmods.net/showthread.php?t=210221)
 - [tf_econ_data](https://forums.alliedmods.net/showthread.php?t=315011)
 - [dhooks with detour support](https://forums.alliedmods.net/showpost.php?p=2588686&postcount=589)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,4 +13,3 @@ cd addons/sourcemod/scripting
 # Install Dependencies
 wget "https://raw.githubusercontent.com/FlaminSarge/tf2attributes/master/scripting/include/tf2attributes.inc" -O include/tf2attributes.inc
 wget "https://raw.githubusercontent.com/nosoop/SM-TFEconData/master/scripting/include/tf_econ_data.inc" -O include/tf_econ_data.inc
-wget "https://raw.githubusercontent.com/peace-maker/DHooks2/dynhooks/sourcemod_files/scripting/include/dhooks.inc" -O include/dhooks.inc


### PR DESCRIPTION
SM 1.11 has been stable for a few months now. While this PR doesn't really do anything else, it'd be nice to make use of (at least one! of) its features in the near future.