### PR TITLE
Gameplay & QoL changes to HHH Jr.

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_ghost.sp
@@ -250,8 +250,8 @@ public void RageGhost_OnThink(SaxtonHaleBase boss)
 			}
 		}
 		
-		//Random Spook effects, 1.5 sec cooldown
-		if (g_flGhostLastSpookTime[iClient] < GetGameTime() - 1.5)
+		//Random Spook effects, 2.5 sec cooldown
+		if (g_flGhostLastSpookTime[iClient] < GetGameTime() - 2.5)
 		{
 			g_flGhostLastSpookTime[iClient] = GetGameTime();
 			
@@ -281,32 +281,28 @@ public void RageGhost_OnThink(SaxtonHaleBase boss)
 				iLength -= 2;
 			}
 			
-			//Other random effects
+			//Attempt to change to a random weapon slot
 			for (int i = 0; i < iLength; i++)
 			{
-				//Attempt use random slot
-				if (GetRandomInt(0, 1))
+				ArrayList aWeapons = new ArrayList();
+				int iActiveWeapon = GetEntPropEnt(iSpooked[i], Prop_Send, "m_hActiveWeapon");
+				
+				//We don't want to count PDA2 due to invis watch
+				for (int iSlot = 0; iSlot <= WeaponSlot_PDADisguise; iSlot++)
 				{
-					ArrayList aWeapons = new ArrayList();
-					int iActiveWeapon = GetEntPropEnt(iSpooked[i], Prop_Send, "m_hActiveWeapon");
-					
-					//We don't want to count PDA2 due to invis watch
-					for (int iSlot = 0; iSlot <= WeaponSlot_PDADisguise; iSlot++)
-					{
-						int iWeapon = GetPlayerWeaponSlot(iSpooked[i], iSlot);
-						if (IsValidEdict(iWeapon) && iWeapon != iActiveWeapon)
-							aWeapons.Push(iWeapon);
-					}
-					
-					if (aWeapons.Length > 0)
-					{
-						//Get random weapon/slot to change
-						aWeapons.Sort(Sort_Random, Sort_Integer);
-						TF2_SwitchToWeapon(iSpooked[i], aWeapons.Get(0));
-					}
-					
-					delete aWeapons;
+					int iWeapon = GetPlayerWeaponSlot(iSpooked[i], iSlot);
+					if (IsValidEdict(iWeapon) && iWeapon != iActiveWeapon)
+						aWeapons.Push(iWeapon);
 				}
+				
+				if (aWeapons.Length > 0)
+				{
+					//Get random weapon/slot to change
+					aWeapons.Sort(Sort_Random, Sort_Integer);
+					TF2_SwitchToWeapon(iSpooked[i], aWeapons.Get(0));
+				}
+				
+				delete aWeapons;
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_teleport_swap.sp
@@ -49,11 +49,11 @@ public void TeleportSwap_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iL
 	if (g_flTeleportSwapCooldownWait[boss.iClient] != 0.0 && g_flTeleportSwapCooldownWait[boss.iClient] > GetGameTime())
 	{
 		int iSec = RoundToCeil(g_flTeleportSwapCooldownWait[boss.iClient]-GetGameTime());
-		Format(sMessage, iLength, "%s\nTeleport-swap cooldown %i second%s remaining!", sMessage, iSec, (iSec > 1) ? "s" : "");
+		Format(sMessage, iLength, "%s\nTeleport-swap is on cooldown for %d second%s!", sMessage, iSec, (iSec > 1) ? "s" : "");
 	}
 	else if (boss.GetPropInt("TeleportSwap", "Charge") > 0)
 	{
-		Format(sMessage, iLength, "%s\nTeleport-swap: %0.2f%%. Look up and stand up to use teleport-swap.", sMessage, (float(boss.GetPropInt("TeleportSwap", "Charge"))/float(boss.GetPropInt("TeleportSwap", "MaxCharge")))*100.0);
+		Format(sMessage, iLength, "%s\nTeleport-swap: %.0f％. Look up and release right click to teleport.", sMessage, (float(boss.GetPropInt("TeleportSwap", "Charge"))/float(boss.GetPropInt("TeleportSwap", "MaxCharge")))*100.0);
 	}
 	else
 	{
@@ -71,13 +71,22 @@ public void TeleportSwap_OnButtonRelease(SaxtonHaleBase boss, int button)
 {
 	if (button == IN_ATTACK2)
 	{
-		if (TF2_IsPlayerInCondition(boss.iClient, TFCond_Dazed))//Can't teleport-swap if stunned
-			return;
-		
-		if (!(GetEntityFlags(boss.iClient) & FL_ONGROUND))
-			return;
-		
 		g_bTeleportSwapHoldingChargeButton[boss.iClient] = false;
+		
+		// Deny teleporting when stunned
+		if (TF2_IsPlayerInCondition(boss.iClient, TFCond_Dazed))
+		{
+			PrintHintText(boss.iClient, "Can't teleport-swap when stunned.");
+			return;
+		}
+		
+		// Deny teleporting when airborne
+		if (!(GetEntityFlags(boss.iClient) & FL_ONGROUND))
+		{
+			PrintHintText(boss.iClient, "Can't teleport-swap when airborne.");
+			return;
+		}
+		
 		if (g_flTeleportSwapCooldownWait[boss.iClient] > GetGameTime()) return;
 		
 		float vecAng[3];

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -797,6 +797,9 @@ stock void TF2_TeleportSwap(int iClient[2])
 		
 		//Create particle
 		CreateTimer(3.0, Timer_EntityCleanup, TF2_SpawnParticle(PARTICLE_GHOST, vecOrigin[i], vecAngles[i]));
+		
+		//Play a sound
+		EmitGameSoundToAll("Halloween.spell_teleport", iClient[i]);
 	}
 	
 	for (int i = 0; i <= 1; i++)


### PR DESCRIPTION
Gameplay changes:
- HHH Jr.
	- Fixed rage not affecting bosses (including Zombie Scouts), in which cases it'll hurt them, but not regen your own hp
	- Reduced super rage radius from 150% (600 units) to 125% (500 units) of regular rage radius
	- Removed occasional view disorientation from the rage's random effect pool
	
It's all up to discussion!

QoL changes:
- Teleport-Swap ability
	- Added a teleporting sound on both ends of teleport-swap
	- Fixed the charge meter not going down on button release when failing to trigger due to an external source (like while stunned or airborne)
		- Such external sources will now be displayed in a little hint message to the user if the ability is blocked
	- The on-button-hold text has been changed to "Teleport-swap: [round number]％. Look up and release right click to teleport."
		- Note that a full-width percentage sign was used here. It looks a little bit cut off (see image at the bottom), but it's better than having to dance around the hyper scuffedness of text with a bunch of formatting
	- The cooldown text has been changed to "Teleport-swap is on cooldown for x second(s)!"

For the meter/text changes, every similar ability should get the same treatment. I'm just not sure if that should be done in this or another pull request, as this one is entirely related to HHH Jr.

![image](https://user-images.githubusercontent.com/33163183/197176755-6c1a9435-930e-441d-bb8c-0e604f907bcd.png)
