### PR TITLE
Add music volume compatibility to boss themes

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -837,6 +837,31 @@ stock void SaxtonHale_PrepareSound(const char[] sSound)
 }
 
 /**
+ * Precaches a sound and adds music volume compatibility
+ *
+ * @param sSound			Sound to precache
+ * @param bCustom			Should the sound be added to the downloads table?
+ */
+stock void SaxtonHale_PrepareMusic(const char[] sSound, bool bCustom = true)
+{
+	// Prefix the filepath with #, so it's considered as music by the engine, allowing people to adjust its volume through the music volume slider
+	char sBuffer[PLATFORM_MAX_PATH];
+	FormatEx(sBuffer, sizeof(sBuffer), "#%s", sSound);
+	PrecacheSound(sBuffer, true);
+	
+	if (!bCustom)
+		return;
+	
+	if (ReplaceString(sBuffer, sizeof(sBuffer), "#", "sound/") != 1)
+	{
+		LogError("PrepareMusic could not prepare %s: filepath must not have any '#' characters.", sSound);
+		return;
+	}
+	
+	AddFileToDownloadsTable(sBuffer);
+}
+
+/**
  * Deprecated functions, do not use
  */
 

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1164,10 +1164,10 @@ public Action Timer_Music(Handle hTimer, SaxtonHaleBase boss)
 		if (IsClientInGame(iClient))
 		{
 			//Stop current music before playing another one
-			StopSound(iClient, SNDCHAN_AUTO, g_sBossMusic);
+			StopSound(iClient, SNDCHAN_STATIC, g_sBossMusic);
 			
 			if (Preferences_Get(iClient, VSHPreferences_Music))
-				EmitSoundToClient(iClient, g_sBossMusic);
+				EmitSoundToClient(iClient, g_sBossMusic, _, SNDCHAN_STATIC, SNDLEVEL_NONE);
 		}
 	}
 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -1,5 +1,5 @@
 #define ANNOUNCER_MODEL "models/player/kirillian/boss/sedisocks_administrator.mdl"
-#define ANNOUNCER_THEME "#vsh_rewrite/administrator/admin_music.mp3"
+#define ANNOUNCER_THEME "vsh_rewrite/administrator/admin_music.mp3"
 
 static char g_strAnnouncerRoundStart[][] = {
 	"vo/announcer_dec_missionbegins60s01.mp3",

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -1,5 +1,5 @@
 #define ANNOUNCER_MODEL "models/player/kirillian/boss/sedisocks_administrator.mdl"
-#define ANNOUNCER_THEME "vsh_rewrite/administrator/admin_music.mp3"
+#define ANNOUNCER_THEME "#vsh_rewrite/administrator/admin_music.mp3"
 
 static char g_strAnnouncerRoundStart[][] = {
 	"vo/announcer_dec_missionbegins60s01.mp3",
@@ -242,7 +242,7 @@ public void Announcer_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(ANNOUNCER_MODEL);
 	
-	PrepareSound(ANNOUNCER_THEME);
+	PrepareMusic(ANNOUNCER_THEME);
 	
 	for (int i = 0; i < sizeof(g_strAnnouncerRoundStart); i++) PrecacheSound(g_strAnnouncerRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strAnnouncerWin); i++) PrecacheSound(g_strAnnouncerWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -1,5 +1,5 @@
 #define BRUTALSNIPER_MODEL "models/player/saxton_hale/cbs_v4.mdl"
-#define BRUTALSNIPER_THEME "vsh_rewrite/brutalsniper/brutalsniper_music.mp3"
+#define BRUTALSNIPER_THEME "#vsh_rewrite/brutalsniper/brutalsniper_music.mp3"
 #define BRUTALSNIPER_MAXWEAPONS 4
 
 #define ITEM_KUKRI			3
@@ -343,7 +343,7 @@ public void BrutalSniper_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(BRUTALSNIPER_MODEL);
 	
-	PrepareSound(BRUTALSNIPER_THEME);
+	PrepareMusic(BRUTALSNIPER_THEME);
 	
 	for (int i = 0; i < sizeof(g_strBrutalSniperRoundStart); i++) PrecacheSound(g_strBrutalSniperRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strBrutalSniperWin); i++) PrecacheSound(g_strBrutalSniperWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -1,5 +1,5 @@
 #define BRUTALSNIPER_MODEL "models/player/saxton_hale/cbs_v4.mdl"
-#define BRUTALSNIPER_THEME "#vsh_rewrite/brutalsniper/brutalsniper_music.mp3"
+#define BRUTALSNIPER_THEME "vsh_rewrite/brutalsniper/brutalsniper_music.mp3"
 #define BRUTALSNIPER_MAXWEAPONS 4
 
 #define ITEM_KUKRI			3

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -1,6 +1,6 @@
 #define DEMO_ROBOT_GIANT_SCALE					1.75
 #define DEMO_ROBOT_TURN_INTO_GIANT  			"mvm/giant_heavy/giant_heavy_entrance.wav"
-#define DEMO_ROBOT_THEME						"vsh_rewrite/demorobot/demorobot_music.mp3"
+#define DEMO_ROBOT_THEME						"#vsh_rewrite/demorobot/demorobot_music.mp3"
 #define DEMO_ROBOT_DEATH						"mvm/sentrybuster/mvm_sentrybuster_explode.wav"
 #define DEMO_ROBOT_MODEL						"models/bots/demo/bot_demo.mdl"
 #define DEMO_ROBOT_GRENADE_LAUNCHER_SHOOT		"mvm/giant_demoman/giant_demoman_grenade_shoot.wav"
@@ -264,7 +264,7 @@ public void DemoRobot_Precache(SaxtonHaleBase boss)
 	PrecacheSound(DEMO_ROBOT_TURN_INTO_GIANT);
 	PrecacheSound(DEMO_ROBOT_DEATH);
 	PrecacheSound(DEMO_ROBOT_GRENADE_LAUNCHER_SHOOT);
-	PrepareSound(DEMO_ROBOT_THEME);
+	PrepareMusic(DEMO_ROBOT_THEME);
 	
 	PrecacheModel(DEMO_ROBOT_MODEL);
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_demorobot.sp
@@ -1,6 +1,6 @@
 #define DEMO_ROBOT_GIANT_SCALE					1.75
 #define DEMO_ROBOT_TURN_INTO_GIANT  			"mvm/giant_heavy/giant_heavy_entrance.wav"
-#define DEMO_ROBOT_THEME						"#vsh_rewrite/demorobot/demorobot_music.mp3"
+#define DEMO_ROBOT_THEME						"vsh_rewrite/demorobot/demorobot_music.mp3"
 #define DEMO_ROBOT_DEATH						"mvm/sentrybuster/mvm_sentrybuster_explode.wav"
 #define DEMO_ROBOT_MODEL						"models/bots/demo/bot_demo.mdl"
 #define DEMO_ROBOT_GRENADE_LAUNCHER_SHOOT		"mvm/giant_demoman/giant_demoman_grenade_shoot.wav"

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -1,5 +1,5 @@
 #define GENTLE_SPY_MODEL "models/freak_fortress_2/gentlespy/the_gentlespy_v1.mdl"
-#define GENTLE_SPY_THEME "#vsh_rewrite/gentlespy/gentle_music.mp3"
+#define GENTLE_SPY_THEME "vsh_rewrite/gentlespy/gentle_music.mp3"
 
 static bool g_bFirstCloak[TF_MAXPLAYERS];
 static bool g_bIsCloaked[TF_MAXPLAYERS];

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -1,5 +1,5 @@
 #define GENTLE_SPY_MODEL "models/freak_fortress_2/gentlespy/the_gentlespy_v1.mdl"
-#define GENTLE_SPY_THEME "vsh_rewrite/gentlespy/gentle_music.mp3"
+#define GENTLE_SPY_THEME "#vsh_rewrite/gentlespy/gentle_music.mp3"
 
 static bool g_bFirstCloak[TF_MAXPLAYERS];
 static bool g_bIsCloaked[TF_MAXPLAYERS];
@@ -324,7 +324,7 @@ public void GentleSpy_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(GENTLE_SPY_MODEL);
 	
-	PrepareSound(GENTLE_SPY_THEME);
+	PrepareMusic(GENTLE_SPY_THEME);
 	
 	for (int i = 0; i < sizeof(g_strGentleSpyRoundStart); i++) PrecacheSound(g_strGentleSpyRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strGentleSpyWin); i++) PrecacheSound(g_strGentleSpyWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -1,5 +1,5 @@
 #define HORSEMANN_MODEL "models/player/saxton_hale/hhh_jr_mk3.mdl"
-#define HORSEMANN_THEME "ui/holiday/gamestartup_halloween.mp3"
+#define HORSEMANN_THEME "#ui/holiday/gamestartup_halloween.mp3"
 
 static char g_strHorsemannRoundStart[][] = {
 	"ui/halloween_boss_summoned_fx.wav",

--- a/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_horsemann.sp
@@ -1,5 +1,5 @@
 #define HORSEMANN_MODEL "models/player/saxton_hale/hhh_jr_mk3.mdl"
-#define HORSEMANN_THEME "#ui/holiday/gamestartup_halloween.mp3"
+#define HORSEMANN_THEME "ui/holiday/gamestartup_halloween.mp3"
 
 static char g_strHorsemannRoundStart[][] = {
 	"ui/halloween_boss_summoned_fx.wav",
@@ -183,7 +183,7 @@ public void Horsemann_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(HORSEMANN_MODEL);
 	
-	PrecacheSound(HORSEMANN_THEME);
+	PrepareMusic(HORSEMANN_THEME, false);
 	
 	for (int i = 0; i < sizeof(g_strHorsemannRoundStart); i++) PrecacheSound(g_strHorsemannRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strHorsemannWin); i++) PrecacheSound(g_strHorsemannWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
@@ -2,7 +2,7 @@
 #define MERASMUS_MODEL "models/player/vsh_rewrite/merasmus/merasmus_v2.mdl"
 #define MERASMUS_MODEL_WAND "models/player/vsh_rewrite/merasmus/c_merasmus_staff.mdl"
 #define MERASMUS_MODEL_ARMS "models/player/vsh_rewrite/merasmus/c_merasmus_arms.mdl"
-#define MERASMUS_THEME "ui/holiday/gamestartup_halloween1.mp3"
+#define MERASMUS_THEME "#ui/holiday/gamestartup_halloween1.mp3"
 
 static char g_strMerasmusRoundStart[][] = {
 	"vo/halloween_merasmus/sf12_appears02.mp3",

--- a/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_merasmus.sp
@@ -2,7 +2,7 @@
 #define MERASMUS_MODEL "models/player/vsh_rewrite/merasmus/merasmus_v2.mdl"
 #define MERASMUS_MODEL_WAND "models/player/vsh_rewrite/merasmus/c_merasmus_staff.mdl"
 #define MERASMUS_MODEL_ARMS "models/player/vsh_rewrite/merasmus/c_merasmus_arms.mdl"
-#define MERASMUS_THEME "#ui/holiday/gamestartup_halloween1.mp3"
+#define MERASMUS_THEME "ui/holiday/gamestartup_halloween1.mp3"
 
 static char g_strMerasmusRoundStart[][] = {
 	"vo/halloween_merasmus/sf12_appears02.mp3",
@@ -245,7 +245,7 @@ public void Merasmus_Precache(SaxtonHaleBase boss)
 	g_iMerasmusModelWand = PrecacheModel(MERASMUS_MODEL_WAND);
 	g_iMerasmusModelArms = PrecacheModel(MERASMUS_MODEL_ARMS);
 	
-	PrecacheSound(MERASMUS_THEME);
+	PrepareMusic(MERASMUS_THEME, false);
 	
 	for (int i = 0; i < sizeof(g_strMerasmusRoundStart); i++) PrecacheSound(g_strMerasmusRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strMerasmusWin); i++) PrecacheSound(g_strMerasmusWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -1,5 +1,5 @@
 #define RANGER_MODEL 		"models/player/vsh_rewrite/uber_ranger/uber_ranger_v2.mdl"
-#define RANGER_THEME 		"#vsh_rewrite/uber_ranger/uberrangers_music.mp3"
+#define RANGER_THEME 		"vsh_rewrite/uber_ranger/uberrangers_music.mp3"
 #define RANGER_RAGESOUND 	"mvm/mvm_tele_deliver.wav"
 
 static int g_iUberRangerMinionAFKTimeLeft[TF_MAXPLAYERS];

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -1,5 +1,5 @@
 #define RANGER_MODEL 		"models/player/vsh_rewrite/uber_ranger/uber_ranger_v2.mdl"
-#define RANGER_THEME 		"vsh_rewrite/uber_ranger/uberrangers_music.mp3"
+#define RANGER_THEME 		"#vsh_rewrite/uber_ranger/uberrangers_music.mp3"
 #define RANGER_RAGESOUND 	"mvm/mvm_tele_deliver.wav"
 
 static int g_iUberRangerMinionAFKTimeLeft[TF_MAXPLAYERS];
@@ -196,7 +196,7 @@ public void UberRanger_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLen
 public void UberRanger_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(RANGER_MODEL);
-	PrepareSound(RANGER_THEME);
+	PrepareMusic(RANGER_THEME);
 	PrecacheSound(RANGER_RAGESOUND);
 	
 	for (int i = 0; i < sizeof(g_strUberRangerRoundStart); i++) PrecacheSound(g_strUberRangerRoundStart[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -173,7 +173,7 @@ public void Yeti_Precache(SaxtonHaleBase boss)
 {
 	PrecacheModel(YETI_MODEL);
 	
-	PrecacheSound(YETI_THEME);
+	PrepareMusic(YETI_THEME, false);
 	
 	for (int i = 0; i < sizeof(g_strYetiRoundStart); i++)PrecacheSound(g_strYetiRoundStart[i]);
 	for (int i = 0; i < sizeof(g_strYetiWin); i++)PrecacheSound(g_strYetiWin[i]);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -1,5 +1,5 @@
 #define YETI_MODEL "models/player/kirillian/boss/yeti_modded.mdl"
-#define YETI_THEME "ui/gamestartup29.mp3"
+#define YETI_THEME "#ui/gamestartup29.mp3"
 
 static char g_strYetiRoundStart[][] =  {
 	"ambient_mp3/lair/animal_call_yeti1.mp3", 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -1,5 +1,5 @@
 #define YETI_MODEL "models/player/kirillian/boss/yeti_modded.mdl"
-#define YETI_THEME "#ui/gamestartup29.mp3"
+#define YETI_THEME "ui/gamestartup29.mp3"
 
 static char g_strYetiRoundStart[][] =  {
 	"ambient_mp3/lair/animal_call_yeti1.mp3", 

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -189,6 +189,10 @@ public void Event_RoundArenaStart(Event event, const char[] sName, bool bDontBro
 				boss.CallFunction("GetMusicInfo", g_sBossMusic, sizeof(g_sBossMusic), flMusicTime);
 				if (!StrEmpty(g_sBossMusic))
 				{
+					// Prefix the filepath with #, so it's considered as music by the engine, allowing people to adjust its volume through the music volume slider
+					if (g_sBossMusic[0] != '#')
+						Format(g_sBossMusic, sizeof(g_sBossMusic), "#%s", g_sBossMusic);
+					
 					for (int i = 1; i <= MaxClients; i++)
 						if (IsClientInGame(i) && Preferences_Get(i, VSHPreferences_Music))
 							EmitSoundToClient(i, g_sBossMusic, _, SNDCHAN_STATIC, SNDLEVEL_NONE);

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -191,7 +191,7 @@ public void Event_RoundArenaStart(Event event, const char[] sName, bool bDontBro
 				{
 					for (int i = 1; i <= MaxClients; i++)
 						if (IsClientInGame(i) && Preferences_Get(i, VSHPreferences_Music))
-							EmitSoundToClient(i, g_sBossMusic);
+							EmitSoundToClient(i, g_sBossMusic, _, SNDCHAN_STATIC, SNDLEVEL_NONE);
 					
 					if (flMusicTime > 0.0)
 						g_hTimerBossMusic = CreateTimer(flMusicTime, Timer_Music, boss, TIMER_REPEAT);
@@ -337,7 +337,7 @@ public void Event_RoundEnd(Event event, const char[] sName, bool bDontBroadcast)
 		{
 			//End music
 			if (!StrEmpty(g_sBossMusic))
-				StopSound(iClient, SNDCHAN_AUTO, g_sBossMusic);
+				StopSound(iClient, SNDCHAN_STATIC, g_sBossMusic);
 			
 			if (GetClientTeam(iClient) > 1 && (!SaxtonHale_IsValidBoss(iClient, false)))
 			{				

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -968,6 +968,7 @@ stock void PrepareSound(const char[] sSoundPath)
 
 stock void PrepareMusic(const char[] sSoundPath)
 {
+	// Ensure the filepath has a # prefix, so it's considered as music by the engine (so people can adjust its volume through the music volume slider)
 	if (sSoundPath[0] != '#')
 	{
 		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must have the '#' prefix.", sSoundPath);

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -966,6 +966,27 @@ stock void PrepareSound(const char[] sSoundPath)
 	AddFileToDownloadsTable(s);
 }
 
+stock void PrepareMusic(const char[] sSoundPath)
+{
+	if (sSoundPath[0] != '#')
+	{
+		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must have the '#' prefix.", sSoundPath);
+		return;
+	}
+	
+	char s[PLATFORM_MAX_PATH];
+	strcopy(s, sizeof(s), sSoundPath);
+	
+	if (ReplaceString(s, sizeof(s), "#", "sound/") != 1)
+	{
+		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must only have one '#' character.", sSoundPath);
+		return;
+	}
+	
+	PrecacheSound(sSoundPath, true);
+	AddFileToDownloadsTable(s);
+}
+
 stock int PrecacheParticleSystem(const char[] particleSystem)
 {
 	static int particleEffectNames = INVALID_STRING_TABLE;

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -966,25 +966,22 @@ stock void PrepareSound(const char[] sSoundPath)
 	AddFileToDownloadsTable(s);
 }
 
-stock void PrepareMusic(const char[] sSoundPath)
+stock void PrepareMusic(const char[] sSoundPath, bool bCustom = true)
 {
-	// Ensure the filepath has a # prefix, so it's considered as music by the engine (so people can adjust its volume through the music volume slider)
-	if (sSoundPath[0] != '#')
-	{
-		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must have the '#' prefix.", sSoundPath);
-		return;
-	}
-	
+	// Prefix the filepath with #, so it's considered as music by the engine, allowing people to adjust its volume through the music volume slider
 	char s[PLATFORM_MAX_PATH];
-	strcopy(s, sizeof(s), sSoundPath);
+	FormatEx(s, sizeof(s), "#%s", sSoundPath);
+	PrecacheSound(s, true);
+	
+	if (!bCustom)
+		return;
 	
 	if (ReplaceString(s, sizeof(s), "#", "sound/") != 1)
 	{
-		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must only have one '#' character.", sSoundPath);
+		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must not have any '#' characters.", sSoundPath);
 		return;
 	}
 	
-	PrecacheSound(sSoundPath, true);
 	AddFileToDownloadsTable(s);
 }
 

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -978,7 +978,7 @@ stock void PrepareMusic(const char[] sSoundPath, bool bCustom = true)
 	
 	if (ReplaceString(s, sizeof(s), "#", "sound/") != 1)
 	{
-		PrintToServer("[VSH REWRITE] PrepareMusic could not prepare %s: filepath must not have any '#' characters.", sSoundPath);
+		LogError("PrepareMusic could not prepare %s: filepath must not have any '#' characters.", sSoundPath);
 		return;
 	}
 	


### PR DESCRIPTION
This PR allows players to adjust boss theme volume with TF2's music volume slider. Only applies to boss themes, so rage music and some song-voicelines like Demopan's win theme are unaffected.

Custom and future bosses will need to manually make use of the # prefix character and `PrepareMusic` when precaching sounds to be affected by this change.