### PR TITLE
Add Ground pound

### DIFF
--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -332,20 +332,6 @@ methodmap SaxtonHaleBase
 		public native set(float val);
 	}
 	
-	// Retrieve/Set timer while in air to allow weighdown, -1.0 to disable weighdown
-	property float flWeighDownTimer
-	{
-		public native get();
-		public native set(float val);
-	}
-	
-	// Retrieve/Set weighdown force
-	property float flWeighDownForce
-	{
-		public native get();
-		public native set(float val);
-	}
-	
 	// Retrieve/Set time remaining for glow to end in seconds, 0.0 for no glow, -1.0 for permanent 
 	property float flGlowTime
 	{
@@ -918,10 +904,6 @@ public __pl_saxtonhale_SetNTVOptional()
 	MarkNativeAsOptional("SaxtonHaleBase.flSpeedMult.set");
 	MarkNativeAsOptional("SaxtonHaleBase.flEnvDamageCap.get");
 	MarkNativeAsOptional("SaxtonHaleBase.flEnvDamageCap.set");
-	MarkNativeAsOptional("SaxtonHaleBase.flWeighDownTimer.get");
-	MarkNativeAsOptional("SaxtonHaleBase.flWeighDownTimer.set");
-	MarkNativeAsOptional("SaxtonHaleBase.flWeighDownForce.get");
-	MarkNativeAsOptional("SaxtonHaleBase.flWeighDownForce.set");
 	MarkNativeAsOptional("SaxtonHaleBase.flGlowTime.get");
 	MarkNativeAsOptional("SaxtonHaleBase.flGlowTime.set");
 	MarkNativeAsOptional("SaxtonHaleBase.flRageLastTime.get");

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -17,7 +17,7 @@
 
 #include "include/saxtonhale.inc"
 
-#define PLUGIN_VERSION 					"2.0.0"
+#define PLUGIN_VERSION 					"2.1.0"
 #define PLUGIN_VERSION_REVISION 		"manual"
 
 #if !defined SP_MAX_EXEC_PARAMS

--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -93,9 +93,11 @@ public void BraveJump_OnButtonRelease(SaxtonHaleBase boss, int button)
 			vecVel[2] = boss.GetPropFloat("BraveJump", "MaxHeight")*((float(boss.GetPropInt("BraveJump", "JumpCharge"))/float(boss.GetPropInt("BraveJump", "MaxJumpCharge"))));
 			vecVel[0] *= (1.0+Sine((float(boss.GetPropInt("BraveJump", "JumpCharge"))/float(boss.GetPropInt("BraveJump", "MaxJumpCharge"))) * FLOAT_PI * boss.GetPropFloat("BraveJump", "MaxDistance")));
 			vecVel[1] *= (1.0+Sine((float(boss.GetPropInt("BraveJump", "JumpCharge"))/float(boss.GetPropInt("BraveJump", "MaxJumpCharge"))) * FLOAT_PI * boss.GetPropFloat("BraveJump", "MaxDistance")));
-			SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
 			
 			TeleportEntity(boss.iClient, NULL_VECTOR, NULL_VECTOR, vecVel);
+			
+			SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
+			SetEntityFlags(boss.iClient, GetEntityFlags(boss.iClient) & ~FL_ONGROUND);
 			
 			float flCooldownTime = (boss.GetPropFloat("BraveJump", "Cooldown")*(float(boss.GetPropInt("BraveJump", "JumpCharge"))/float(boss.GetPropInt("BraveJump", "MaxJumpCharge"))));
 			if (flCooldownTime < boss.GetPropFloat("BraveJump", "MinCooldown"))

--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -1,10 +1,7 @@
-static float g_flJumpCooldownWait[TF_MAXPLAYERS];
 static bool g_bBraveJumpHoldingChargeButton[TF_MAXPLAYERS];
 
 public void BraveJump_Create(SaxtonHaleBase boss)
 {
-	g_flJumpCooldownWait[boss.iClient] = 0.0;
-	
 	//Default values, these can be changed if needed
 	boss.SetPropInt("BraveJump", "JumpCharge", 0);
 	boss.SetPropInt("BraveJump", "MaxJumpCharge", 200);
@@ -13,6 +10,7 @@ public void BraveJump_Create(SaxtonHaleBase boss)
 	boss.SetPropFloat("BraveJump", "MaxDistance", 0.45);
 	boss.SetPropFloat("BraveJump", "Cooldown", 7.0);
 	boss.SetPropFloat("BraveJump", "MinCooldown", 5.5);
+	boss.SetPropFloat("BraveJump", "CooldownWait", 0.0);
 	boss.SetPropFloat("BraveJump", "EyeAngleRequirement", -25.0);	//How far up should the boss look for the ability to trigger? Minimum value is -89.0 (all the way up)
 }
 
@@ -21,9 +19,12 @@ public void BraveJump_OnThink(SaxtonHaleBase boss)
 	if (GameRules_GetRoundState() == RoundState_Preround)
 		return;
 	
-	if (g_flJumpCooldownWait[boss.iClient] == 0.0)	//Round started, start cooldown
+	float flCooldownWait = boss.GetPropFloat("BraveJump", "CooldownWait");
+	if (flCooldownWait == 0.0)	//Round started, start cooldown
 	{
-		g_flJumpCooldownWait[boss.iClient] = GetGameTime()+boss.GetPropFloat("BraveJump", "Cooldown");
+		flCooldownWait = GetGameTime()+boss.GetPropFloat("BraveJump", "Cooldown");
+		boss.SetPropFloat("BraveJump", "CooldownWait", flCooldownWait);
+		
 		boss.CallFunction("UpdateHudInfo", 1.0, boss.GetPropFloat("BraveJump", "Cooldown"));	//Update every second for cooldown duration
 	}
 	
@@ -32,7 +33,7 @@ public void BraveJump_OnThink(SaxtonHaleBase boss)
 	int iMaxJumpCharge = boss.GetPropInt("BraveJump", "MaxJumpCharge");
 	int iNewJumpCharge;
 	
-	if (g_flJumpCooldownWait[boss.iClient] <= GetGameTime() && g_bBraveJumpHoldingChargeButton[boss.iClient])
+	if (flCooldownWait <= GetGameTime() && g_bBraveJumpHoldingChargeButton[boss.iClient])
 		iNewJumpCharge = iJumpCharge + iJumpChargeBuild;
 	else
 		iNewJumpCharge = iJumpCharge - iJumpChargeBuild * 2;
@@ -51,9 +52,10 @@ public void BraveJump_OnThink(SaxtonHaleBase boss)
 
 public void BraveJump_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLength, int iColor[4])
 {
-	if (g_flJumpCooldownWait[boss.iClient] != 0.0 && g_flJumpCooldownWait[boss.iClient] > GetGameTime())
+	float flCooldownWait = boss.GetPropFloat("BraveJump", "CooldownWait");
+	if (flCooldownWait != 0.0 && flCooldownWait > GetGameTime())
 	{
-		int iSec = RoundToCeil(g_flJumpCooldownWait[boss.iClient]-GetGameTime());
+		int iSec = RoundToCeil(flCooldownWait-GetGameTime());
 		Format(sMessage, iLength, "%s\nSuper-jump cooldown %i second%s remaining!", sMessage, iSec, (iSec > 1) ? "s" : "");
 	}
 	else if (boss.GetPropInt("BraveJump", "JumpCharge") > 0)
@@ -80,7 +82,8 @@ public void BraveJump_OnButtonRelease(SaxtonHaleBase boss, int button)
 			return;
 		
 		g_bBraveJumpHoldingChargeButton[boss.iClient] = false;
-		if (g_flJumpCooldownWait[boss.iClient] != 0.0 && g_flJumpCooldownWait[boss.iClient] > GetGameTime()) return;
+		float flCooldownWait = boss.GetPropFloat("BraveJump", "CooldownWait");
+		if (flCooldownWait != 0.0 && flCooldownWait > GetGameTime()) return;
 		
 		float vecAng[3];
 		GetClientEyeAngles(boss.iClient, vecAng);
@@ -103,7 +106,7 @@ public void BraveJump_OnButtonRelease(SaxtonHaleBase boss, int button)
 			if (flCooldownTime < boss.GetPropFloat("BraveJump", "MinCooldown"))
 				flCooldownTime = boss.GetPropFloat("BraveJump", "MinCooldown");
 			
-			g_flJumpCooldownWait[boss.iClient] = GetGameTime()+flCooldownTime;
+			boss.SetPropFloat("BraveJump", "CooldownWait", GetGameTime()+flCooldownTime);
 			boss.CallFunction("UpdateHudInfo", 1.0, boss.GetPropFloat("BraveJump", "Cooldown"));	//Update every second for cooldown duration
 			
 			boss.SetPropInt("BraveJump", "JumpCharge", 0);

--- a/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
@@ -100,6 +100,17 @@ public void GroundPound_OnButton(SaxtonHaleBase boss, int &buttons)
 			g_flClientBossWeighDownTimer[boss.iClient] = 0.0;
 			SetEntityGravity(boss.iClient, GetEntityGravity(boss.iClient) * boss.GetPropFloat("GroundPound", "GravityMultiplier"));
 			TF2_AddCondition(boss.iClient, TFCond_SpeedBuffAlly, TFCondDuration_Infinite);
+			
+			// Add brave jump cooldown to it
+			if (boss.HasClass("BraveJump"))
+			{
+				float flCooldownWait = boss.GetPropFloat("BraveJump", "CooldownWait");
+				if (flCooldownWait)
+				{
+					boss.SetPropFloat("BraveJump", "CooldownWait", flCooldownWait + 5.0);
+					boss.CallFunction("UpdateHudInfo", 1.0, flCooldownWait + 5.0);	//Update every second for cooldown duration
+				}
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
@@ -8,6 +8,7 @@ static float g_flClientBossWeighDownTimer[TF_MAXPLAYERS];
 public void GroundPound_Create(SaxtonHaleBase boss)
 {
 	g_bClientBossWeighDownForce[boss.iClient] = false;
+	g_flClientBossWeighDownTimer[boss.iClient] = 0.0;
 	
 	boss.SetPropFloat("GroundPound", "StartTimer", 2.8);
 	boss.SetPropFloat("GroundPound", "GravityMultiplier", 8.0);
@@ -108,6 +109,15 @@ public void GroundPound_GetSoundAbility(SaxtonHaleBase boss, char[] sSound, int 
 	// Allow ground pound immediately on brave jump
 	if (StrEqual(sAbility, "BraveJump"))
 		g_flClientBossWeighDownTimer[boss.iClient] = 1.0;
+}
+
+public void GroundPound_Destroy(SaxtonHaleBase boss)
+{
+	if (g_bClientBossWeighDownForce[boss.iClient])
+	{
+		SetEntityGravity(boss.iClient, GetEntityGravity(boss.iClient) / boss.GetPropFloat("GroundPound", "GravityMultiplier"));
+		TF2_RemoveCondition(boss.iClient, TFCond_SpeedBuffAlly);
+	}
 }
 
 public void GroundPound_Precache(SaxtonHaleBase boss)

--- a/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
@@ -42,7 +42,7 @@ public void GroundPound_OnThink(SaxtonHaleBase boss)
 
 public Action GroundPound_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
-	if (!(damagetype & DMG_FALL))
+	if (!(damagetype & DMG_FALL) || !g_bClientBossWeighDownForce[boss.iClient])
 		return Plugin_Continue;
 	
 	float vecVel[3];

--- a/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_groundpound.sp
@@ -1,16 +1,53 @@
 #define IMPACT_SOUND "player/taunt_yeti_land.wav"
 #define IMPACT_PARTICLE "hammer_impact_button"
 
+static bool g_bClientBossWeighDownForce[TF_MAXPLAYERS];
+
+static float g_flClientBossWeighDownTimer[TF_MAXPLAYERS];
+
 public void GroundPound_Create(SaxtonHaleBase boss)
 {
-	boss.SetPropFloat("GroundPound", "ImpactRadius", 500.0);
-	boss.SetPropFloat("GroundPound", "ImpactDamage", 50.0);
-	boss.SetPropFloat("GroundPound", "ImpactLaunchVelocity", 650.0);
+	g_bClientBossWeighDownForce[boss.iClient] = false;
+	
+	boss.SetPropFloat("GroundPound", "StartTimer", 2.8);
+	boss.SetPropFloat("GroundPound", "GravityMultiplier", 8.0);
+	
+	boss.SetPropFloat("GroundPound", "ImpactPush", 500.0);
+	boss.SetPropFloat("GroundPound", "ImpactVelocity", 750.0);
+	boss.SetPropFloat("GroundPound", "ImpactRadius", 400.0);
+	boss.SetPropFloat("GroundPound", "ImpactDamage", 25.0);
+	boss.SetPropFloat("GroundPound", "ImpactLaunchVelocity", 400.0);
+}
+
+public void GroundPound_OnThink(SaxtonHaleBase boss)
+{
+	if (GetEntityFlags(boss.iClient) & FL_ONGROUND)
+	{
+		if (g_bClientBossWeighDownForce[boss.iClient])
+		{
+			SetEntityGravity(boss.iClient, GetEntityGravity(boss.iClient) / boss.GetPropFloat("GroundPound", "GravityMultiplier"));
+			TF2_RemoveCondition(boss.iClient, TFCond_SpeedBuffAlly);
+		}
+		
+		//Reset weighdown timer
+		g_bClientBossWeighDownForce[boss.iClient] = false;
+		g_flClientBossWeighDownTimer[boss.iClient] = 0.0;
+	}
+	else if (g_flClientBossWeighDownTimer[boss.iClient] == 0.0 && !g_bClientBossWeighDownForce[boss.iClient])
+	{
+		//Start weighdown timer
+		g_flClientBossWeighDownTimer[boss.iClient] = GetGameTime();
+	}
 }
 
 public Action GroundPound_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	if (!(damagetype & DMG_FALL))
+		return Plugin_Continue;
+	
+	float vecVel[3];
+	GetEntPropVector(boss.iClient, Prop_Data, "m_vecVelocity", vecVel);
+	if (vecVel[2] > -boss.GetPropFloat("GroundPound", "ImpactVelocity"))
 		return Plugin_Continue;
 	
 	float vecBossOrigin[3];
@@ -24,16 +61,53 @@ public Action GroundPound_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &
 	{
 		if (IsClientInGame(iClient) && GetClientTeam(iClient) != GetClientTeam(boss.iClient) && IsClientInRange(iClient, vecBossOrigin, boss.GetPropFloat("GroundPound", "ImpactRadius")) && GetEntityFlags(iClient) & FL_ONGROUND)
 		{
-			float vecClientVelocity[3];
+			float vecClientOrigin[3], vecClientVelocity[3];
+			GetClientAbsOrigin(iClient, vecClientOrigin);
 			GetEntPropVector(iClient, Prop_Data, "m_vecVelocity", vecClientVelocity);
 			vecClientVelocity[2] += boss.GetPropFloat("GroundPound", "ImpactLaunchVelocity");
 			
-			TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, vecClientVelocity);
+			float vecVelocity[3];
+			SubtractVectors(vecClientOrigin, vecBossOrigin, vecVelocity);
+			vecVelocity[2] = 0.0;
+			NormalizeVector(vecVelocity, vecVelocity);
+			ScaleVector(vecVelocity, boss.GetPropFloat("GroundPound", "ImpactPush"));
+			AddVectors(vecClientVelocity, vecVelocity, vecClientVelocity);
+			
 			SDKHooks_TakeDamage(iClient, boss.iClient, boss.iClient, boss.GetPropFloat("GroundPound", "ImpactDamage"));
+			TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, vecClientVelocity);
 		}
 	}
 	
 	return Plugin_Continue;
+}
+
+public void GroundPound_OnButton(SaxtonHaleBase boss, int &buttons)
+{
+	//Is boss crouching, allowed to use weighdown if passed timer
+	if (buttons & IN_DUCK
+		&& !g_bClientBossWeighDownForce[boss.iClient]
+		&& g_flClientBossWeighDownTimer[boss.iClient] != 0.0
+		&& g_flClientBossWeighDownTimer[boss.iClient] < GetGameTime() - boss.GetPropFloat("GroundPound", "StartTimer"))
+	{
+		//Check if boss is looking down
+		float vecAngles[3];
+		GetClientEyeAngles(boss.iClient, vecAngles);
+		if (vecAngles[0] > 60.0)
+		{
+			//Enable weighdown
+			g_bClientBossWeighDownForce[boss.iClient] = true;
+			g_flClientBossWeighDownTimer[boss.iClient] = 0.0;
+			SetEntityGravity(boss.iClient, GetEntityGravity(boss.iClient) * boss.GetPropFloat("GroundPound", "GravityMultiplier"));
+			TF2_AddCondition(boss.iClient, TFCond_SpeedBuffAlly, TFCondDuration_Infinite);
+		}
+	}
+}
+
+public void GroundPound_GetSoundAbility(SaxtonHaleBase boss, char[] sSound, int iLength, const char[] sAbility)
+{
+	// Allow ground pound immediately on brave jump
+	if (StrEqual(sAbility, "BraveJump"))
+		g_flClientBossWeighDownTimer[boss.iClient] = 1.0;
 }
 
 public void GroundPound_Precache(SaxtonHaleBase boss)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -283,7 +283,6 @@ public void AnnouncerMinion_Create(SaxtonHaleBase boss)
 {
 	boss.flSpeed = -1.0;
 	boss.iMaxRageDamage = -1;
-	boss.flWeighDownTimer = -1.0;
 	boss.bMinion = true;
 	boss.bModel = false;
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -148,7 +148,6 @@ public void SeeldierMinion_Create(SaxtonHaleBase boss)
 	boss.iHealthPerPlayer = 0;
 	boss.nClass = TFClass_Soldier;
 	boss.iMaxRageDamage = -1;
-	boss.flWeighDownTimer = -1.0;
 	boss.bMinion = true;
 	
 	EmitSoundToClient(boss.iClient, SOUND_ALERT);	//Alert player as he spawned

--- a/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_uberranger.sp
@@ -239,7 +239,6 @@ public void MinionRanger_Create(SaxtonHaleBase boss)
 	boss.iHealthPerPlayer = 40;
 	boss.nClass = TFClass_Medic;
 	boss.iMaxRageDamage = -1;
-	boss.flWeighDownTimer = -1.0;
 	boss.bMinion = true;
 	boss.bHealthPerPlayerAlive = true;
 	

--- a/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
@@ -4,7 +4,6 @@ public void Zombie_Create(SaxtonHaleBase boss)
 {
 	boss.nClass = TFClass_Scout;
 	boss.flSpeed = -1.0;
-	boss.flWeighDownTimer = -1.0;
 	boss.iMaxRageDamage = -1;
 	boss.bMinion = true;
 	boss.bModel = false;

--- a/addons/sourcemod/scripting/vsh/property.sp
+++ b/addons/sourcemod/scripting/vsh/property.sp
@@ -7,8 +7,6 @@ static bool g_bHealthPerPlayerAlive[TF_MAXPLAYERS];
 static float g_flSpeed[TF_MAXPLAYERS];
 static float g_flSpeedMult[TF_MAXPLAYERS];
 static float g_flEnvDamageCap[TF_MAXPLAYERS];
-static float g_flWeighDownTimer[TF_MAXPLAYERS];
-static float g_flWeighDownForce[TF_MAXPLAYERS];
 static float g_flGlowTime[TF_MAXPLAYERS];
 static float g_flRageLastTime[TF_MAXPLAYERS];
 static float g_flMaxRagePercentage[TF_MAXPLAYERS];
@@ -41,10 +39,6 @@ void Property_AskLoad()
 	CreateNative("SaxtonHaleBase.flSpeedMult.get", Property_GetSpeedMult);
 	CreateNative("SaxtonHaleBase.flEnvDamageCap.set", Property_SetEnvDamageCap);
 	CreateNative("SaxtonHaleBase.flEnvDamageCap.get", Property_GetEnvDamageCap);
-	CreateNative("SaxtonHaleBase.flWeighDownTimer.set", Property_SetWeighDownTimer);
-	CreateNative("SaxtonHaleBase.flWeighDownTimer.get", Property_GetWeighDownTimer);
-	CreateNative("SaxtonHaleBase.flWeighDownForce.set", Property_SetWeighDownForce);
-	CreateNative("SaxtonHaleBase.flWeighDownForce.get", Property_GetWeighDownForce);
 	CreateNative("SaxtonHaleBase.flGlowTime.set", Property_SetGlowTime);
 	CreateNative("SaxtonHaleBase.flGlowTime.get", Property_GetGlowTime);
 	CreateNative("SaxtonHaleBase.flRageLastTime.set", Property_SetRageLastTime);
@@ -166,28 +160,6 @@ public any Property_SetEnvDamageCap(Handle hPlugin, int iNumParams)
 public any Property_GetEnvDamageCap(Handle hPlugin, int iNumParams)
 {
 	return g_flEnvDamageCap[GetNativeCell(1)];
-}
-
-public any Property_SetWeighDownTimer(Handle hPlugin, int iNumParams)
-{
-	g_flWeighDownTimer[GetNativeCell(1)] = GetNativeCell(2);
-	return 0;
-}
-
-public any Property_GetWeighDownTimer(Handle hPlugin, int iNumParams)
-{
-	return g_flWeighDownTimer[GetNativeCell(1)];
-}
-
-public any Property_SetWeighDownForce(Handle hPlugin, int iNumParams)
-{
-	g_flWeighDownForce[GetNativeCell(1)] = GetNativeCell(2);
-	return 0;
-}
-
-public any Property_GetWeighDownForce(Handle hPlugin, int iNumParams)
-{
-	return g_flWeighDownForce[GetNativeCell(1)];
 }
 
 public any Property_SetGlowTime(Handle hPlugin, int iNumParams)


### PR DESCRIPTION
Ground pound can be achieved by hitting ground with enough gravity force while in weighdown. Weighdown also updated to replace instant down velocity to strong gravity. Preforming brave jump allows to to use weighdown instantly.