### PR TITLE
Update ammo interactions

### DIFF
--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -4,12 +4,6 @@
 	{
 		"Signatures"
 		{
-			"CTFPlayer::GetMaxAmmo"
-			{
-				"library"	"server"
-				"linux"		"@_ZN9CTFPlayer10GetMaxAmmoEii"
-				"windows"	"\x55\x8B\xEC\x8B\x45\x0C\x56\x57\x8B\xF9\x83\xF8\xFF\x75\x2A\xFF\xB7\x2A\x2A\x2A\x2A\xEB\x01\x50\xE8"
-			}
 			"CTFPlayer::GetEquippedWearableForLoadoutSlot"
 			{
 				"library"	"server"

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -179,6 +179,20 @@ enum
 	DAMAGE_AIM,
 };
 
+// TF ammo types - from tf_shareddefs.h
+enum
+{
+	TF_AMMO_DUMMY = 0,
+	TF_AMMO_PRIMARY,
+	TF_AMMO_SECONDARY,
+	TF_AMMO_METAL,
+	TF_AMMO_GRENADES1,
+	TF_AMMO_GRENADES2,
+	TF_AMMO_GRENADES3,
+
+	TF_AMMO_COUNT,
+};
+
 enum
 {
 	CHANNEL_INTRO = 0,

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_ball.sp
@@ -24,7 +24,7 @@ public void WeaponBall_OnSpawn(SaxtonHaleBase boss)
 		TF2Attrib_ClearCache(iMelee);
 		
 		//Correctly set ammo
-		TF2_SetAmmo(boss.iClient, WeaponSlot_Melee, boss.GetPropInt("WeaponBall", "MaxBall"));
+		TF2_SetAmmo(boss.iClient, TF_AMMO_GRENADES1, boss.GetPropInt("WeaponBall", "MaxBall"));
 	}
 }
 
@@ -37,7 +37,7 @@ public void WeaponBall_OnThink(SaxtonHaleBase boss)
 {
 	//Unlimited ball during rage
 	if (g_flWeaponBallRageEnd[boss.iClient] > GetGameTime())
-		TF2_SetAmmo(boss.iClient, WeaponSlot_Melee, boss.GetPropInt("WeaponBall", "MaxBall"));
+		TF2_SetAmmo(boss.iClient, TF_AMMO_GRENADES1, boss.GetPropInt("WeaponBall", "MaxBall"));
 }
 
 public void WeaponBall_OnEntityCreated(SaxtonHaleBase boss, int iEntity, const char[] sClassname)

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_sentry.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_sentry.sp
@@ -7,7 +7,7 @@ public void WeaponSentry_Create(SaxtonHaleBase boss)
 
 public void WeaponSentry_OnSpawn(SaxtonHaleBase boss)
 {
-	SetEntProp(boss.iClient, Prop_Send, "m_iAmmo", 0, 4, 3);
+	TF2_SetAmmo(boss.iClient, TF_AMMO_METAL, 0);
 	boss.CallFunction("CreateWeapon", 25, "tf_weapon_pda_engineer_build", 100, TFQual_Unusual, "");
 }
 
@@ -64,7 +64,7 @@ public Action WeaponSentry_OnObjectSapped(SaxtonHaleBase boss, Event event)
 
 public void WeaponSentry_OnRage(SaxtonHaleBase boss)
 {
-	SetEntProp(boss.iClient, Prop_Send, "m_iAmmo", 130, 4, 3);
+	TF2_SetAmmo(boss.iClient, TF_AMMO_METAL, 130);
 	FakeClientCommand(boss.iClient, "build 2 0");
 }
 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -98,7 +98,7 @@ public void Announcer_OnSpawn(SaxtonHaleBase boss)
 	if (iWeapon > MaxClients)
 	{
 		SetEntProp(iWeapon, Prop_Send, "m_iClip1", 0);
-		SetEntProp(iClient, Prop_Send, "m_iAmmo", 0, _, 2);
+		TF2_SetAmmo(iClient, TF_AMMO_SECONDARY, 0);
 	}
 	/*
 	Diamondback attributes:

--- a/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_brutalsniper.sp
@@ -120,7 +120,7 @@ public void BrutalSniper_OnSpawn(SaxtonHaleBase boss)
 	if (IsValidEntity(iWeapon)) 
 	{
 		SetEntProp(iWeapon, Prop_Send, "m_iClip1", 0);
-		SetEntProp(iClient, Prop_Send, "m_iAmmo", 0, _, 1);
+		TF2_SetAmmo(iClient, TF_AMMO_PRIMARY, 0);
 	}
 	/*
 	Huntsman attributes:
@@ -284,11 +284,11 @@ public void BrutalSniper_OnRage(SaxtonHaleBase boss)
 	int iPrimaryWep = GetPlayerWeaponSlot(iClient, WeaponSlot_Primary);
 	if (IsValidEntity(iPrimaryWep))
 	{
-		int iAmmo = GetEntProp(iClient, Prop_Send, "m_iAmmo", _, 1);
+		int iAmmo = TF2_GetAmmo(iClient, TF_AMMO_PRIMARY);
 		iAmmo += (1 + RoundToFloor(iPlayerCount / 4.0));
 		if (iAmmo > 6)
 			iAmmo = 6;
-		SetEntProp(iClient, Prop_Send, "m_iAmmo", iAmmo, _, 1);
+		TF2_SetAmmo(iClient, TF_AMMO_PRIMARY, iAmmo);
 		SetEntProp(iPrimaryWep, Prop_Send, "m_iClip1", 1);
 		SetEntPropEnt(iClient, Prop_Send, "m_hActiveWeapon", iPrimaryWep);
 	}

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -106,7 +106,7 @@ public void GentleSpy_OnSpawn(SaxtonHaleBase boss)
 	if (iWeapon > MaxClients)
 	{
 		SetEntProp(iWeapon, Prop_Send, "m_iClip1", 0);
-		SetEntProp(iClient, Prop_Send, "m_iAmmo", 0, _, 2);
+		TF2_SetAmmo(iClient, TF_AMMO_SECONDARY, 0);
 	}
 	/*
 	Ambassador attributes:

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -118,7 +118,7 @@ public void PyroCar_OnSpawn(SaxtonHaleBase boss)
 	if (g_iPyrocarPrimary[boss.iClient] > MaxClients)
 	{
 		SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", g_iPyrocarPrimary[boss.iClient]);
-		//TF2_SetAmmo(boss.iClient, WeaponSlot_Primary, 0);	//Reset ammo for TF2 to give correct amount of ammo
+		//TF2_SetAmmo(boss.iClient, TF_AMMO_PRIMARY, 0);	//Reset ammo for TF2 to give correct amount of ammo
 	}
 	
 	boss.CallFunction("CreateWeapon", ITEM_THERMAL_THRUSTER, "tf_weapon_rocketpack", 100, TFQual_Unusual, PYROCAR_THERMAL_THRUSTER_ATTRIBUTES);

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -5,7 +5,6 @@ static Handle g_hHookGiveNamedItem;
 static Handle g_hHookBallImpact;
 static Handle g_hHookShouldBallTouch;
 static Handle g_hSDKGetMaxHealth;
-static Handle g_hSDKGetMaxAmmo;
 static Handle g_hSDKSendWeaponAnim;
 static Handle g_hSDKPlaySpecificSequence;
 static Handle g_hSDKGetMaxClip;
@@ -76,16 +75,6 @@ void SDK_Init()
 		LogMessage("Failed to create hook: CTFGameRules::GetCaptureValueForPlayer");
 	else
 		DHookAddParam(g_hHookGetCaptureValueForPlayer, HookParamType_CBaseEntity);
-	
-	// This call gets the weapon max ammo
-	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetMaxAmmo");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	g_hSDKGetMaxAmmo = EndPrepSDKCall();
-	if (g_hSDKGetMaxAmmo == null)
-		LogMessage("Failed to create call: CTFPlayer::GetMaxAmmo!");
 
 	// This call gets wearable equipped in loadout slots
 	StartPrepSDKCall(SDKCall_Player);
@@ -405,13 +394,6 @@ public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hP
 	}
 	
 	return MRES_Ignored;
-}
-
-int SDK_GetMaxAmmo(int iClient, int iSlot)
-{
-	if (g_hSDKGetMaxAmmo != null)
-		return SDKCall(g_hSDKGetMaxAmmo, iClient, iSlot, -1);
-	return -1;
 }
 
 void SDK_SendWeaponAnim(int weapon, int anim)

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -421,28 +421,14 @@ stock void TF2_CheckClientWeapons(int iClient)
 	}
 }
 
-stock int TF2_GetAmmo(int iClient, int iSlot)
+stock int TF2_GetAmmo(int iClient, int iAmmoType)
 {
-	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
-	if (iWeapon > MaxClients)
-	{
-		int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
-		if (iAmmoType > -1)
-			return GetEntProp(iClient, Prop_Send, "m_iAmmo", _, iAmmoType);
-	}
-	
-	return -1;
+	return GetEntProp(iClient, Prop_Send, "m_iAmmo", _, iAmmoType);
 }
 
-stock void TF2_SetAmmo(int iClient, int iSlot, int iAmmo)
+stock void TF2_SetAmmo(int iClient, int iAmmoType, int iAmmo)
 {
-	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
-	if (iWeapon > MaxClients)
-	{
-		int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
-		if (iAmmoType > -1)
-			SetEntProp(iClient, Prop_Send, "m_iAmmo", iAmmo, _, iAmmoType);
-	}
+	SetEntProp(iClient, Prop_Send, "m_iAmmo", iAmmo, _, iAmmoType);
 }
 
 stock int TF2_GetPatient(int iClient)
@@ -622,7 +608,7 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 			int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
 			if (iAmmoType > -1)
 			{
-				SetEntProp(iClient, Prop_Send, "m_iAmmo", 0, 4, iAmmoType);
+				TF2_SetAmmo(iClient, iAmmoType, 0);
 				GivePlayerAmmo(iClient, 9999, iAmmoType, true);
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -619,12 +619,12 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 			EquipPlayerWeapon(iClient, iWeapon);
 			
 			//Make sure max ammo is set correctly
-			int iSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(iClient));
-			int iMaxAmmo = SDK_GetMaxAmmo(iClient, iSlot);
 			int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
-			
-			if (iMaxAmmo > 0 && iAmmoType > -1)
-				SetEntProp(iClient, Prop_Send, "m_iAmmo", iMaxAmmo, 4, iAmmoType);
+			if (iAmmoType > -1)
+			{
+				SetEntProp(iClient, Prop_Send, "m_iAmmo", 0, 4, iAmmoType);
+				GivePlayerAmmo(iClient, 9999, iAmmoType, true);
+			}
 		}
 		
 		char atts[32][32];

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -83,7 +83,7 @@ void Tags_OnThink(int iClient)
 			int iAmmoType = GetEntProp(iSecondary, Prop_Send, "m_iPrimaryAmmoType");
 			if (iAmmoType > -1)
 			{
-				int iAmmo = GetEntProp(iClient, Prop_Send, "m_iAmmo", 4, iAmmoType);
+				int iAmmo = TF2_GetAmmo(iClient, iAmmoType);
 				
 				if (iAmmo == 1)
 				{
@@ -729,13 +729,13 @@ public void Tags_AddAmmo(int iClient, int iTarget, TagsParams tParams)
 		if (TF2_GetItemInSlot(iClient, iSlot) == iTarget)
 		{
 			//Slot found
-			int iAmmo = tParams.GetInt("amount") + GetEntProp(iClient, Prop_Send, "m_iAmmo", 4, iAmmoType);	//Primary weapon ammo
+			int iAmmo = tParams.GetInt("amount") + TF2_GetAmmo(iClient, iAmmoType);	//Primary weapon ammo
 			
 			int iMaxAmmo;
 			if (tParams.GetIntEx("max", iMaxAmmo) && iAmmo > iMaxAmmo)
 				iAmmo = iMaxAmmo;
 			
-			SetEntProp(iClient, Prop_Send, "m_iAmmo", iAmmo, 4, iAmmoType);
+			TF2_SetAmmo(iClient, iAmmoType, iAmmo);
 			return;
 		}
 	}


### PR DESCRIPTION
As much as `CTFPlayer::GetMaxAmmo` uses `m_iPrimaryAmmoType` as ammo slot, `SDK_GetMaxAmmo` should use that netvar for ammo slot (not weapon slot)
This SDKCall even not necessary, we can just set ammo to 0 and `GivePlayerAmmo` will give max ammo for given `m_iPrimaryAmmoType`

Also this pull request includes update to `TF2_Get/SetAmmo` stocks to use `m_iPrimaryAmmoType` netvar, also replaces all `m_iAmmo` calls to those stocks