### PR TITLE
Add CTakeDamageInfo struct for damage hooks

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -28,6 +28,7 @@
 //- multiply              - From 'attackdamage' and 'takedamage', multiplies damage by X
 //- max                   - From 'attackdamage' and 'takedamage', max possible damage to be made
 //- damagetype            - From 'attackdamage' and 'takedamage', damage types to add/remove
+//- crittype              - From 'attackdamage' and 'takedamage', set damage crit type
 //- attackcrit            - From 'attack' key, set whenever if weapon should crit or not
 //- healbuilding          - From 'heal' key, enable/disable healing building
 //
@@ -41,6 +42,7 @@
 //- damagemin             - Did client deal more than X amount of damage
 //- damagetype            - Does damagetype have X, only works on 'attackdamage' and 'takedamage'
 //- damagecustom          - Is damagecustom X, only works on 'attackdamage' and 'takedamage'
+//- crittype              - Is crittype X (Valid values: none, minicrit, nominicrit, crit, nocrit), only works on 'attackdamage' and 'takedamage'
 //- backstabcount         - X consecutive backstabs required
 //- feigndeath            - Does client have feign death ready
 //- victimuber            - Is victim ubered or not, only works on 'attackdamage' and 'takedamage'

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -40,6 +40,12 @@
 				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x38\x01\x00\x00"
 			}
+			"CTFPlayer::OnTakeDamage_Alive"
+			{
+				"library"		"server"
+				"linux"			"@_ZN9CTFPlayer18OnTakeDamage_AliveERK15CTakeDamageInfo"
+				"windows"		"\x55\x8B\xEC\x83\xEC\x2A\x56\x57\x8B\xF9\x8B\x0D\x2A\x2A\x2A\x2A\x89\x7D\x2A"
+			}
 		}
 		"Functions"
 		{
@@ -68,6 +74,20 @@
 					"target"
 					{
 						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CTFPlayer::OnTakeDamage_Alive"
+			{
+				"signature"		"CTFPlayer::OnTakeDamage_Alive"
+				"callconv"		"thiscall"
+				"return"		"int"
+				"this"			"entity"
+				"arguments"
+				{
+					"damage_info"
+					{
+						"type" "int"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/include/saxtonhale.inc
+++ b/addons/sourcemod/scripting/include/saxtonhale.inc
@@ -40,6 +40,99 @@ enum SaxtonHaleArrayType
 	VSHArrayType_Dynamic,   /**< Data is Param_Cell param position for length of array, starting from 1 */
 }
 
+// CTakeDamageInfo offsets
+enum
+{
+	m_DamageForce,
+	m_DamagePosition = 12,
+	m_ReportedPosition = 24,
+
+	m_Inflictor = 36,
+	m_Attacker = 40,
+	m_Weapon = 44,
+	m_Damage = 48,
+	m_MaxDamage = 52,
+	m_BaseDamage = 56,
+	m_BitsDamageType = 60,
+	m_DamageCustom = 64,
+	m_DamageStats = 68,
+	m_AmmoType = 72,
+	m_DamagedOtherPlayers = 76,
+	m_PlayerPenetrationCount = 80,
+	m_DamageBonus = 84,
+	m_DamageBonusProvider = 88,
+	m_ForceFriendlyFire = 92,
+	m_DamageForForce = 96,
+	m_CritType = 100
+};
+
+/**
+ * Take damage structure used for damage hooks
+ */
+enum struct CTakeDamageInfo
+{
+	Address pInfo;
+
+	int m_hAttacker;
+	int m_hInflictor;
+	int m_hWeapon;
+
+	float m_flDamage;
+	float m_flDamageForForce;
+	int m_bitsDamageType;
+	int m_iDamageCustom;
+	int m_eCritType;
+
+	float m_vecDamageForce[3];
+	float m_vecDamagePosition[3];
+
+	void Init(Address pInfo)
+	{
+		this.pInfo = pInfo;
+
+		this.m_hAttacker = this.LoadEntHandle(m_Attacker);
+		this.m_hInflictor = this.LoadEntHandle(m_Inflictor);
+		this.m_hWeapon = this.LoadEntHandle(m_Weapon);
+
+		this.m_flDamage = this.Load(m_Damage);
+		this.m_flDamageForForce = this.Load(m_DamageForForce);
+		this.m_bitsDamageType = this.Load(m_BitsDamageType);
+		this.m_iDamageCustom = this.Load(m_DamageCustom);
+		this.m_eCritType = this.Load(m_CritType);
+	}
+
+	void Save()
+	{
+		this.StoreEntHandle(m_Attacker, this.m_hAttacker);
+		this.StoreEntHandle(m_Inflictor, this.m_hInflictor);
+		this.StoreEntHandle(m_Weapon, this.m_hWeapon);
+
+		this.Store(m_Damage, this.m_flDamage);
+		this.Store(m_DamageForForce, this.m_flDamageForForce);
+		this.Store(m_BitsDamageType, this.m_bitsDamageType);
+		this.Store(m_DamageCustom, this.m_iDamageCustom);
+		this.Store(m_CritType, this.m_eCritType);
+	}
+
+	any Load(int iOffset, NumberType size = NumberType_Int32)
+	{
+		return LoadFromAddress(this.pInfo + view_as<Address>(iOffset), size);
+	}
+	int LoadEntHandle(int iOffset)
+	{
+		return EntRefToEntIndex(this.Load(iOffset) | (1 << 31));
+	}
+
+	void Store(int iOffset, any value, NumberType size = NumberType_Int32)
+	{
+		StoreToAddress(this.pInfo + view_as<Address>(iOffset), value, size);
+	}
+	void StoreEntHandle(int iOffset, int iEntity)
+	{
+		this.Store(iOffset, IsValidEntity(iEntity) ? EntIndexToEntRef(iEntity) & ~(1 << 31) : 0);
+	}
+}
+
 /**
  * Boss Functions methodmap
  */

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -157,6 +157,15 @@ enum
 	EF_PARENT_ANIMATES		= (1<<9),	// always assume that the parent entity is animating
 };
 
+// Crit types
+enum
+{
+	Crit_Invalid = -3,
+	Crit_None = 0,
+	Crit_Mini,
+	Crit_Full,
+};
+
 // Beam types, encoded as a byte
 enum 
 {
@@ -313,6 +322,7 @@ bool g_bTF2Items;
 
 int g_iSpritesLaserbeam;
 int g_iSpritesGlow;
+int g_iContextCritType;
 
 Handle g_hTimerBossMusic;
 char g_sBossMusic[PLATFORM_MAX_PATH];

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_charge.sp
@@ -176,9 +176,9 @@ public void WeaponCharge_OnConditionRemoved(SaxtonHaleBase boss, TFCond nCond)
 	}
 }
 
-public Action WeaponCharge_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action WeaponCharge_OnAttackDamage(SaxtonHaleBase boss, CTakeDamageInfo info)
 {
-	if (damagecustom == TF_CUSTOM_CHARGE_IMPACT)
+	if (info.m_iDamageCustom == TF_CUSTOM_CHARGE_IMPACT)
 		return Plugin_Stop;	//We want to do the dmg, not TF2. SDKHooks_TakeDamage doesn't allow custom dmg stuff
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -177,23 +177,24 @@ public void BonkBoy_OnThink(SaxtonHaleBase boss)
 	}
 }
 
-public Action BonkBoy_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action BonkBoy_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (g_bBonkBoyRage[boss.iClient] && weapon > MaxClients && TF2_GetItemInSlot(boss.iClient, WeaponSlot_Melee) == weapon && damagecustom == 0)
+	int iWeapon = info.m_hWeapon;
+	if (g_bBonkBoyRage[boss.iClient] && iWeapon > MaxClients && TF2_GetItemInSlot(boss.iClient, WeaponSlot_Melee) == iWeapon && info.m_iDamageCustom == 0)
 	{
-		TF2_StunPlayer(victim, 5.0, _, TF_STUNFLAGS_SMALLBONK, boss.iClient);
+		TF2_StunPlayer(iVictim, 5.0, _, TF_STUNFLAGS_SMALLBONK, boss.iClient);
 		
 		float vecEye[3], vecVel[3], vecVictim[3];
 		GetClientEyeAngles(boss.iClient, vecEye);
-		
+
 		vecEye[0] = ((vecEye[0] + 90.0) / 3.0) - 90.0;	//Move eye angle more upward
-		
+
 		GetAngleVectors(vecEye, vecVel, NULL_VECTOR, NULL_VECTOR);
 		ScaleVector(vecVel, 500.0);
-		
-		GetEntPropVector(victim, Prop_Data, "m_vecVelocity", vecVictim);
+
+		GetEntPropVector(iVictim, Prop_Data, "m_vecVelocity", vecVictim);
 		AddVectors(vecVictim, vecVel, vecVictim);
-		TeleportEntity(victim, NULL_VECTOR, NULL_VECTOR, vecVictim);
+		TeleportEntity(iVictim, NULL_VECTOR, NULL_VECTOR, vecVictim);
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_gentlespy.sp
@@ -290,13 +290,11 @@ public void GentleSpy_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLeng
 	iColor[3] = 255;
 }
 
-public Action GentleSpy_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action GentleSpy_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (damagetype & DMG_FALL && TF2_IsPlayerInCondition(boss.iClient, TFCond_Cloaked))
-	{
+	if (info.m_bitsDamageType & DMG_FALL && TF2_IsPlayerInCondition(boss.iClient, TFCond_Cloaked))
 		return Plugin_Stop;
-	}
-	
+
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -255,16 +255,16 @@ public void PyroCar_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLength
 	}
 }
 
-public Action PyroCar_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action PyroCar_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (TF2_IsUbercharged(victim))
+	if (TF2_IsUbercharged(iVictim))
 		return Plugin_Continue;
 	
-	if (damagetype & DMG_IGNITE)
+	if (info.m_bitsDamageType & DMG_IGNITE)
 	{
 		//Direct flamethrower damage
 		float flGameTime = GetGameTime();
-		float flDuration = g_flPyrocarBurnEnd[victim] - flGameTime;
+		float flDuration = g_flPyrocarBurnEnd[iVictim] - flGameTime;
 		if (flDuration < 0.0)
 			flDuration = 0.0;
 		
@@ -272,11 +272,11 @@ public Action PyroCar_OnAttackDamage(SaxtonHaleBase boss, int victim, int &infli
 		if (flDuration > 10.0)
 			flDuration = 10.0;
 		
-		g_flPyrocarBurnEnd[victim] = flGameTime + flDuration;
-		TF2_IgnitePlayer(victim, boss.iClient, flDuration);
+		g_flPyrocarBurnEnd[iVictim] = flGameTime + flDuration;
+		TF2_IgnitePlayer(iVictim, boss.iClient, flDuration);
 		
 		//Give victim less healing while damaged by pyrocar
-		if (!g_hPyrocarHealTimer[victim])
+		if (!g_hPyrocarHealTimer[iVictim])
 		{
 			for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 			{
@@ -289,11 +289,11 @@ public Action PyroCar_OnAttackDamage(SaxtonHaleBase boss, int victim, int &infli
 			}
 		}
 		
-		g_hPyrocarHealTimer[victim] = CreateTimer(0.4, Timer_RemoveLessHealing, GetClientSerial(victim));
+		g_hPyrocarHealTimer[iVictim] = CreateTimer(0.4, Timer_RemoveLessHealing, GetClientSerial(iVictim));
 	}
 	
 	if (g_flPyrocarGasCharge[boss.iClient] <= g_iMaxGasPassers * g_flGasMinCharge)
-		g_flPyrocarGasCharge[boss.iClient] += damage;
+		g_flPyrocarGasCharge[boss.iClient] += info.m_flDamage;
 		
 	if (g_flPyrocarGasCharge[boss.iClient] > g_iMaxGasPassers * g_flGasMinCharge)
 		g_flPyrocarGasCharge[boss.iClient] = g_iMaxGasPassers * g_flGasMinCharge;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_redmond.sp
@@ -80,22 +80,22 @@ public void Redmond_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int length)
 	StrCat(sInfo, length, "\n- 200%% Rage: Grants 3 MONOCULUS! spells");
 }
 
-public Action Redmond_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action Redmond_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
 	//Monos spell damage sucks, buff it
-	if (weapon > MaxClients)
+	int iWeapon = info.m_hWeapon;
+	if (iWeapon > MaxClients)
 	{
 		char sClassname[256];
-		GetEntityClassname(weapon, sClassname, sizeof(sClassname));
+		GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
 		if (StrEqual(sClassname, "eyeball_boss"))
 		{
-			damage *= 2.0;
+			info.m_flDamage *= 2.0;
 			return Plugin_Changed;
 		}
 	}
-	
+
 	return Plugin_Continue;
-	
 }
 
 public void Redmond_GetModel(SaxtonHaleBase boss, char[] sModel, int length)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -94,7 +94,7 @@ public void Seeldier_OnRage(SaxtonHaleBase boss)
 	delete aValidMinions;
 }
 
-public Action Seeldier_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action Seeldier_OnTakeDamage(SaxtonHaleBase boss, CTakeDamageInfo info)
 {
 	EmitSoundToAll(SEELDIER_SEE_SND, boss.iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeman.sp
@@ -56,13 +56,13 @@ public void SeeMan_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int length)
 	StrCat(sInfo, length, "\n- 200%% Rage: instakill nuke at end of rage");
 }
 
-public Action SeeMan_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action SeeMan_OnTakeDamage(SaxtonHaleBase boss, CTakeDamageInfo info)
 {
 	char sWeaponClassName[32];
-	if (inflictor >= 0) GetEdictClassname(inflictor, sWeaponClassName, sizeof(sWeaponClassName));
-	
+	if (info.m_hInflictor >= 0) GetEdictClassname(info.m_hInflictor, sWeaponClassName, sizeof(sWeaponClassName));
+
 	//Disable self-damage from bomb rage ability
-	if (boss.iClient == attacker && strcmp(sWeaponClassName, "tf_generic_bomb") == 0) return Plugin_Stop;
+	if (boss.iClient == info.m_hAttacker && strcmp(sWeaponClassName, "tf_generic_bomb") == 0) return Plugin_Stop;
 
 	EmitSoundToAll(SEEMAN_SEE_SND, boss.iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -151,14 +151,11 @@ public Action Yeti_OnSoundPlayed(SaxtonHaleBase boss, int clients[MAXPLAYERS], i
 	return Plugin_Continue;
 }
 
-public Action Yeti_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action Yeti_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
 	// Prevent kill taunt
-	if (victim != boss.iClient && damagecustom == TF_CUSTOM_TAUNT_HIGH_NOON)
-	{
-		damage = 0.0;
-		return Plugin_Changed;
-	}
+	if (iVictim != boss.iClient && info.m_iDamageCustom == TF_CUSTOM_TAUNT_HIGH_NOON)
+		return Plugin_Stop;
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
@@ -46,11 +46,11 @@ public void Zombie_OnThink(SaxtonHaleBase boss)
 		TF2_MakeBleed(iClient, iClient, 99999.0);
 }
 
-public Action Zombie_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action Zombie_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (boss.iClient != victim && GetClientTeam(boss.iClient) != GetClientTeam(victim))
+	if (boss.iClient != iVictim && GetClientTeam(boss.iClient) != GetClientTeam(iVictim))
 	{
-		int iHeal = RoundToNearest(damage);
+		int iHeal = RoundToNearest(info.m_flDamage);
 		if (iHeal > 20) iHeal = 20;
 		
 		Client_AddHealth(boss.iClient, iHeal, 0);

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -802,13 +802,13 @@ public void Event_PlayerInventoryUpdate(Event event, const char[] sName, bool bD
 		TagsCore_CallAll(iClient, TagsCall_Spawn);
 }
 
-public void Event_PlayerHurt(Event event, const char[] sName, bool bDontBroadcast)
+public Action Event_PlayerHurt(Event event, const char[] sName, bool bDontBroadcast)
 {
-	if (!g_bEnabled) return;
-	if (g_iTotalRoundPlayed <= 0) return;
+	if (!g_bEnabled) return Plugin_Continue;
+	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
 
 	int iClient = GetClientOfUserId(event.GetInt("userid"));
-	if (GetClientTeam(iClient) <= 1) return;
+	if (GetClientTeam(iClient) <= 1) return Plugin_Continue;
 	
 	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 	if (boss.bValid)
@@ -872,6 +872,14 @@ public void Event_PlayerHurt(Event event, const char[] sName, bool bDontBroadcas
 			}
 		}
 	}
+
+	if (g_iContextCritType == Crit_Mini)
+	{
+		event.SetInt("bonuseffect", Crit_Mini);
+		g_iContextCritType = Crit_None;
+	}
+
+	return Plugin_Continue;
 }
 
 public void Event_BuffBannerDeployed(Event event, const char[] sName, bool bDontBroadcast)

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_electric.sp
@@ -27,21 +27,21 @@ public void ModifiersElectric_GetRenderColor(SaxtonHaleBase boss, int iColor[4])
 	iColor[3] = 255;
 }
 
-public Action ModifiersElectric_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action ModifiersElectric_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {		
-	if (damage < 3.0 || g_bElectricDamage[victim] || TF2_IsUbercharged(victim))
+	if (info.m_flDamage < 3.0 || g_bElectricDamage[iVictim] || TF2_IsUbercharged(iVictim))
 		return Plugin_Continue;
 	
-	TFTeam nTeam = TF2_GetClientTeam(victim);
+	TFTeam nTeam = TF2_GetClientTeam(iVictim);
 	
 	float vecVictimPos[3];
-	GetClientAbsOrigin(victim, vecVictimPos);
+	GetClientAbsOrigin(iVictim, vecVictimPos);
 	vecVictimPos[2] += 40.0;
 	
-	damage *= 0.85;
+	info.m_flDamage *= 0.85;
 	
 	//Mark victim as currently taking damage to avoid endless loop
-	g_bElectricDamage[victim] = true;
+	g_bElectricDamage[iVictim] = true;
 	
 	//Create entity at centre so lasers can connect
 	int iTarget = CreateEntityByName("info_target");
@@ -55,7 +55,7 @@ public Action ModifiersElectric_OnAttackDamage(SaxtonHaleBase boss, int victim, 
 	
 	for (int i = 1; i <= MaxClients; i++)
 	{
-		if (IsClientInGame(i) && IsPlayerAlive(i) && TF2_GetClientTeam(i) == nTeam && i != victim)
+		if (IsClientInGame(i) && IsPlayerAlive(i) && TF2_GetClientTeam(i) == nTeam && i != iVictim)
 		{
 			float vecTargetPos[3];
 			GetClientAbsOrigin(i, vecTargetPos);
@@ -65,7 +65,7 @@ public Action ModifiersElectric_OnAttackDamage(SaxtonHaleBase boss, int victim, 
 			{
 				//Mark victim as currently taking damage to avoid endless loop
 				g_bElectricDamage[i] = true;
-				SDKHooks_TakeDamage(i, 0, boss.iClient, (damage * 0.40), DMG_SHOCK, _, _, vecVictimPos);
+				SDKHooks_TakeDamage(i, 0, boss.iClient, (info.m_flDamage * 0.40), DMG_SHOCK, _, _, vecVictimPos);
 				g_bElectricDamage[i] = false;
 				
 				int iLaser = CreateEntityByName("env_laser");
@@ -96,7 +96,6 @@ public Action ModifiersElectric_OnAttackDamage(SaxtonHaleBase boss, int victim, 
 		}
 	}
 	
-	g_bElectricDamage[victim] = false;
-	
+	g_bElectricDamage[iVictim] = false;
 	return Plugin_Changed;
 }

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_hot.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_hot.sp
@@ -45,31 +45,32 @@ public void ModifiersHot_OnThink(SaxtonHaleBase boss)
 	}
 }
 
-public Action ModifiersHot_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action ModifiersHot_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (damagetype & DMG_BURN)
+	if (info.m_bitsDamageType & DMG_BURN)
 	{
-		damage *= 0.75;
+		info.m_flDamage *= 0.75;
 		return Plugin_Changed;
 	}
 	
 	return Plugin_Continue;
 }
 
-public Action ModifiersHot_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action ModifiersHot_OnTakeDamage(SaxtonHaleBase boss, CTakeDamageInfo info)
 {
 	if (TF2_IsUbercharged(boss.iClient))
 		return Plugin_Continue;
 	
-	if (damagetype & DMG_BURN)
+	if (info.m_bitsDamageType & DMG_BURN)
 	{
-		damage *= 3.0;
-		if (damage > 12.0) damage = 12.0;
-		return Plugin_Continue;
+		info.m_flDamage *= 3.0;
+		if (info.m_flDamage > 12.0) info.m_flDamage = 12.0;
+		return Plugin_Changed;
 	}
 	
-	if (0 < attacker <= MaxClients && IsClientInGame(attacker))
-		TF2_IgnitePlayer(boss.iClient, attacker);
+	int iAttacker = info.m_hAttacker;
+	if (0 < iAttacker <= MaxClients && IsClientInGame(iAttacker))
+		TF2_IgnitePlayer(boss.iClient, iAttacker);
 	
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/vsh/modifiers/modifiers_ice.sp
+++ b/addons/sourcemod/scripting/vsh/modifiers/modifiers_ice.sp
@@ -50,10 +50,10 @@ public void ModifiersIce_OnEntityCreated(SaxtonHaleBase boss, int iEntity, const
 	}
 }
 
-public Action ModifiersIce_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action ModifiersIce_OnTakeDamage(SaxtonHaleBase boss, CTakeDamageInfo info)
 {
 	//OnTakeDamageAlive takes stomping as dealing damage through falling, so we only trigger the effect if the server deals damage
-	if (!(damagetype & DMG_FALL) || attacker != 0)
+	if (!(info.m_bitsDamageType & DMG_FALL) || info.m_hAttacker != 0)
 		return Plugin_Continue;
 	
 	int iTeam = GetClientTeam(boss.iClient);
@@ -95,9 +95,9 @@ public Action ModifiersIce_OnTakeDamage(SaxtonHaleBase boss, int &attacker, int 
 	return Plugin_Stop;
 }
 
-public Action ModifiersIce_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action ModifiersIce_OnAttackDamage(SaxtonHaleBase boss, int iVictim, CTakeDamageInfo info)
 {
-	if (damagecustom == TF_CUSTOM_BOOTS_STOMP)
+	if (info.m_iDamageCustom == TF_CUSTOM_BOOTS_STOMP)
 		return Plugin_Stop;
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -1,9 +1,9 @@
-static Handle g_hHookGetCaptureValueForPlayer;
-static Handle g_hHookGetMaxHealth;
-static Handle g_hHookShouldTransmit;
-static Handle g_hHookGiveNamedItem;
-static Handle g_hHookBallImpact;
-static Handle g_hHookShouldBallTouch;
+static DynamicHook g_hHookGetCaptureValueForPlayer;
+static DynamicHook g_hHookGetMaxHealth;
+static DynamicHook g_hHookShouldTransmit;
+static DynamicHook g_hHookGiveNamedItem;
+static DynamicHook g_hHookBallImpact;
+static DynamicHook g_hHookShouldBallTouch;
 static Handle g_hSDKGetMaxHealth;
 static Handle g_hSDKSendWeaponAnim;
 static Handle g_hSDKPlaySpecificSequence;
@@ -27,7 +27,7 @@ void SDK_Init()
 
 	//This function is used to control player's max health
 	int iOffset = hGameData.GetOffset("GetMaxHealth");
-	g_hHookGetMaxHealth = DHookCreate(iOffset, HookType_Entity, ReturnType_Int, ThisPointer_CBaseEntity, Hook_GetMaxHealth);
+	g_hHookGetMaxHealth = new DynamicHook(iOffset, HookType_Entity, ReturnType_Int, ThisPointer_CBaseEntity);
 	if (g_hHookGetMaxHealth == null)
 		LogMessage("Failed to create hook: CTFPlayer::GetMaxHealth!");
 
@@ -70,11 +70,11 @@ void SDK_Init()
 	
 	// This hook allows to change capture rate
 	iOffset = hGameData.GetOffset("CTFGameRules::GetCaptureValueForPlayer");
-	g_hHookGetCaptureValueForPlayer = DHookCreate(iOffset, HookType_GameRules, ReturnType_Int, ThisPointer_Ignore);
+	g_hHookGetCaptureValueForPlayer = new DynamicHook(iOffset, HookType_GameRules, ReturnType_Int, ThisPointer_Ignore);
 	if (g_hHookGetCaptureValueForPlayer == null)
 		LogMessage("Failed to create hook: CTFGameRules::GetCaptureValueForPlayer");
 	else
-		DHookAddParam(g_hHookGetCaptureValueForPlayer, HookParamType_CBaseEntity);
+		g_hHookGetCaptureValueForPlayer.AddParam(HookParamType_CBaseEntity);
 
 	// This call gets wearable equipped in loadout slots
 	StartPrepSDKCall(SDKCall_Player);
@@ -133,57 +133,57 @@ void SDK_Init()
 	
 	// This hook allows entity to always transmit
 	iOffset = hGameData.GetOffset("CBaseEntity::ShouldTransmit");
-	g_hHookShouldTransmit = DHookCreate(iOffset, HookType_Entity, ReturnType_Int, ThisPointer_CBaseEntity, Hook_EntityShouldTransmit);
+	g_hHookShouldTransmit = new DynamicHook(iOffset, HookType_Entity, ReturnType_Int, ThisPointer_CBaseEntity);
 	if (g_hHookShouldTransmit == null)
 		LogMessage("Failed to create hook: CBaseEntity::ShouldTransmit!");
 	else
-		DHookAddParam(g_hHookShouldTransmit, HookParamType_ObjectPtr);
+		g_hHookShouldTransmit.AddParam(HookParamType_ObjectPtr);
 	
 	iOffset = hGameData.GetOffset("CTFPlayer::GiveNamedItem");
-	g_hHookGiveNamedItem = DHookCreate(iOffset, HookType_Entity, ReturnType_CBaseEntity, ThisPointer_CBaseEntity);
+	g_hHookGiveNamedItem = new DynamicHook(iOffset, HookType_Entity, ReturnType_CBaseEntity, ThisPointer_CBaseEntity);
 	if (g_hHookGiveNamedItem == null)
 	{
 		LogMessage("Failed to create hook: CTFPlayer::GiveNamedItem!");
 	}
 	else
 	{
-		DHookAddParam(g_hHookGiveNamedItem, HookParamType_CharPtr);
-		DHookAddParam(g_hHookGiveNamedItem, HookParamType_Int);
-		DHookAddParam(g_hHookGiveNamedItem, HookParamType_ObjectPtr);
-		DHookAddParam(g_hHookGiveNamedItem, HookParamType_Bool);
+		g_hHookGiveNamedItem.AddParam(HookParamType_CharPtr);
+		g_hHookGiveNamedItem.AddParam(HookParamType_Int);
+		g_hHookGiveNamedItem.AddParam(HookParamType_ObjectPtr);
+		g_hHookGiveNamedItem.AddParam(HookParamType_Bool);
 	}
 	
 	// This hook calls when Sandman Ball stuns a player
 	iOffset = hGameData.GetOffset("CTFStunBall::ApplyBallImpactEffectOnVictim");
-	g_hHookBallImpact = DHookCreate(iOffset, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity);
+	g_hHookBallImpact = new DynamicHook(iOffset, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity);
 	if (g_hHookBallImpact == null)
 		LogMessage("Failed to create hook: CTFStunBall::ApplyBallImpactEffectOnVictim!");
 	else
-		DHookAddParam(g_hHookBallImpact, HookParamType_CBaseEntity);
+		g_hHookBallImpact.AddParam(HookParamType_CBaseEntity);
 	
 	// This hook calls when Sandman Ball want to touch
 	iOffset = hGameData.GetOffset("CTFStunBall::ShouldBallTouch");
-	g_hHookShouldBallTouch = DHookCreate(iOffset, HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
+	g_hHookShouldBallTouch = new DynamicHook(iOffset, HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
 	if (g_hHookShouldBallTouch == null)
 		LogMessage("Failed to create hook: CTFStunBall::ApplyBallImpactEffectOnVictim!");
 	else
-		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
+		g_hHookShouldBallTouch.AddParam(HookParamType_CBaseEntity);
 	
 	// This hook allows to allow/block medigun heals
-	DynamicDetour hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
+	DynamicDetour hHook = DynamicDetour.FromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");
 	if (hHook == null)
 		LogMessage("Failed to create hook: CWeaponMedigun::AllowedToHealTarget!");
 	else
-		DHookEnableDetour(hHook, true, Hook_AllowedToHealTarget);
+		hHook.Enable(Hook_Post, Hook_AllowedToHealTarget);
 	
 	delete hHook;
 	
 	// This hook allows to allow/block dispenser heals
-	hHook = DHookCreateFromConf(hGameData, "CObjectDispenser::CouldHealTarget");
+	hHook = DynamicDetour.FromConf(hGameData, "CObjectDispenser::CouldHealTarget");
 	if (hHook == null)
 		LogMessage("Failed to create hook: CObjectDispenser::CouldHealTarget!");
 	else
-		DHookEnableDetour(hHook, true, Hook_CouldHealTarget);
+		hHook.Enable(Hook_Post, Hook_CouldHealTarget);
 	
 	delete hHook;
 
@@ -215,14 +215,14 @@ static bool LookupOffset(int &iOffset, const char[] sClass, const char[] sProp)
 void SDK_HookGiveNamedItem(int iClient)
 {
 	if (g_hHookGiveNamedItem && !g_bTF2Items)
-		g_iHookIdGiveNamedItem[iClient] = DHookEntity(g_hHookGiveNamedItem, false, iClient, Hook_GiveNamedItemRemoved, Hook_GiveNamedItem);
+		g_iHookIdGiveNamedItem[iClient] = g_hHookGiveNamedItem.HookEntity(Hook_Pre, iClient, Hook_GiveNamedItem, Hook_GiveNamedItemRemoved);
 }
 
 void SDK_UnhookGiveNamedItem(int iClient)
 {
 	if (g_iHookIdGiveNamedItem[iClient])
 	{
-		DHookRemoveHookID(g_iHookIdGiveNamedItem[iClient]);
+		DynamicHook.RemoveHook(g_iHookIdGiveNamedItem[iClient]);
 		g_iHookIdGiveNamedItem[iClient] = 0;	
 	}
 }
@@ -239,63 +239,63 @@ bool SDK_IsGiveNamedItemActive()
 void SDK_HookGetCaptureValueForPlayer(DHookCallback callback)
 {
 	if (g_hHookGetCaptureValueForPlayer)
-		DHookGamerules(g_hHookGetCaptureValueForPlayer, true, _, callback);
+		g_hHookGetCaptureValueForPlayer.HookGamerules(Hook_Post, callback);
 }
 
 void SDK_HookGetMaxHealth(int iClient)
 {
 	if (g_hHookGetMaxHealth)
-		DHookEntity(g_hHookGetMaxHealth, false, iClient);
+		g_hHookGetMaxHealth.HookEntity(Hook_Pre, iClient, Hook_GetMaxHealth);
 }
 
 void SDK_AlwaysTransmitEntity(int iEntity)
 {
 	if (g_hHookShouldTransmit)
-		DHookEntity(g_hHookShouldTransmit, true, iEntity);
+		g_hHookShouldTransmit.HookEntity(Hook_Post, iEntity, Hook_EntityShouldTransmit);
 }
 
 void SDK_HookBallImpact(int iEntity, DHookCallback callback)
 {
 	if (g_hHookBallImpact)
-		DHookEntity(g_hHookBallImpact, false, iEntity, _, callback);
+		g_hHookBallImpact.HookEntity(Hook_Pre, iEntity, callback);
 }
 
 void SDK_HookBallTouch(int iEntity, DHookCallback callback)
 {
 	if (g_hHookShouldBallTouch)
-		DHookEntity(g_hHookShouldBallTouch, false, iEntity, _, callback);
+		g_hHookShouldBallTouch.HookEntity(Hook_Pre, iEntity, callback);
 }
 
-public MRESReturn Hook_GetMaxHealth(int iClient, Handle hReturn)
+public MRESReturn Hook_GetMaxHealth(int iClient, DHookReturn ret)
 {
 	SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 	if (boss.bValid && boss.iMaxHealth > 0)
 	{
-		DHookSetReturn(hReturn, boss.iMaxHealth);
+		ret.Value = boss.iMaxHealth;
 		return MRES_Supercede;
 	}
 	return MRES_Ignored;
 }
 
-public MRESReturn Hook_EntityShouldTransmit(int iEntity, Handle hReturn, Handle hParams)
+public MRESReturn Hook_EntityShouldTransmit(int iEntity, DHookReturn ret, DHookParam params)
 {
-	DHookSetReturn(hReturn, FL_EDICT_ALWAYS);
+	ret.Value = FL_EDICT_ALWAYS;
 	return MRES_Supercede;
 }
 
-public MRESReturn Hook_GiveNamedItem(int iClient, Handle hReturn, Handle hParams)
+public MRESReturn Hook_GiveNamedItem(int iClient, DHookReturn ret, DHookParam params)
 {
-	if (DHookIsNullParam(hParams, 1) || DHookIsNullParam(hParams, 3))
+	if (params.IsNull(1) || params.IsNull(3))
 		return MRES_Ignored;
 	
 	char sClassname[256];
-	DHookGetParamString(hParams, 1, sClassname, sizeof(sClassname));
-	int iIndex = DHookGetParamObjectPtrVar(hParams, 3, 4, ObjectValueType_Int) & 0xFFFF;
+	params.GetString(1, sClassname, sizeof(sClassname));
+	int iIndex = params.GetObjectVar(3, 4, ObjectValueType_Int) & 0xFFFF;
 	
 	Action action = GiveNamedItem(iClient, sClassname, iIndex);
 	if (action >= Plugin_Handled)
 	{
-		DHookSetReturn(hReturn, 0);
+		ret.Value = 0;
 		return MRES_Supercede;
 	}
 	
@@ -314,12 +314,12 @@ public void Hook_GiveNamedItemRemoved(int iHookId)
 	}
 }
 
-public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle hParams)
+public MRESReturn Hook_AllowedToHealTarget(int iMedigun, DHookReturn ret, DHookParam params)
 {
 	if (!g_bEnabled) return MRES_Ignored;
 	if (g_iTotalRoundPlayed <= 0) return MRES_Ignored;
 	
-	int iHealTarget = DHookGetParam(hParams, 1);
+	int iHealTarget = params.Get(1);
 	int iClient = GetEntPropEnt(iMedigun, Prop_Send, "m_hOwnerEntity");
 	
 	if (0 < iClient <= MaxClients && IsClientInGame(iClient))
@@ -327,11 +327,11 @@ public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle 
 		SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 		if (boss.bValid)
 		{
-			bool bReturn = DHookGetReturn(hReturn);
+			bool bReturn = ret.Value;
 			Action action = boss.CallFunction("CanHealTarget", iHealTarget, bReturn);
 			if (action >= Plugin_Changed)
 			{
-				DHookSetReturn(hReturn, bReturn);
+				ret.Value = bReturn;
 				return MRES_Supercede;
 			}
 			
@@ -341,7 +341,7 @@ public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle 
 		if (SaxtonHale_IsValidBoss(iHealTarget))
 		{
 			//Never allow heal boss from any other sources
-			DHookSetReturn(hReturn, false);
+			ret.Value = false;
 			return MRES_Supercede;
 		}
 		
@@ -361,7 +361,7 @@ public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle 
 				&& tParams.GetIntEx("healbuilding", iResult))
 			{
 				bool bResult = !!iResult;
-				DHookSetReturn(hReturn, bResult);
+				ret.Value = bResult;
 				delete tParams;
 				return MRES_Supercede;
 			}
@@ -373,21 +373,21 @@ public MRESReturn Hook_AllowedToHealTarget(int iMedigun, Handle hReturn, Handle 
 	return MRES_Ignored;
 }
 
-public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hParams)
+public MRESReturn Hook_CouldHealTarget(int iDispenser, DHookReturn ret, DHookParam params)
 {
 	int iClient = GetEntPropEnt(iDispenser, Prop_Send, "m_hBuilder");
-	int iHealTarget = DHookGetParam(hParams, 1);
+	int iHealTarget = params.Get(1);
 	
 	if (0 < iClient <= MaxClients)
 	{
 		SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 		if (boss.bValid)
 		{
-			bool bReturn = DHookGetReturn(hReturn);
+			bool bReturn = ret.Value;
 			Action action = boss.CallFunction("CanHealTarget", iHealTarget, bReturn);
 			if (action >= Plugin_Changed)
 			{
-				DHookSetReturn(hReturn, bReturn);
+				ret.Value = bReturn;
 				return MRES_Supercede;
 			}
 			
@@ -397,7 +397,7 @@ public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hP
 		if (SaxtonHale_IsValidBoss(iHealTarget))
 		{
 			//Never allow heal boss from any other sources
-			DHookSetReturn(hReturn, false);
+			ret.Value = false;
 			return MRES_Supercede;
 		}
 	}

--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -11,6 +11,7 @@ public Action TagsDamage_OnTakeDamage(int victim, CTakeDamageInfo info)
 	tParams.SetInt("filter_damagetype", info.m_bitsDamageType);	//Because 'damagetype' is already used from config to set
 	tParams.SetInt("weapon", info.m_hWeapon);
 	tParams.SetInt("filter_damagecustom", info.m_iDamageCustom);
+	tParams.SetInt("filter_crittype", info.m_eCritType);
 	
 	//Call takedamage function
 	if (SaxtonHale_IsValidAttack(victim))
@@ -105,6 +106,18 @@ public Action TagsDamage_OnTakeDamage(int victim, CTakeDamageInfo info)
 		delete aDamageType;
 		action = Plugin_Changed;
 	}
+
+	char sCritType[32];
+	if (tParams.GetString("crittype", sCritType, sizeof(sCritType)))
+	{
+		int iCritType = TagsDamage_GetCrit(sCritType);
+		if (iCritType != Crit_Invalid)
+		{
+			info.m_eCritType = iCritType;
+			g_iContextCritType = iCritType;
+			action = Plugin_Changed;
+		}
+	}
 	
 	delete tParams;
 	return action;
@@ -149,4 +162,23 @@ int TagsDamage_GetCustom(const char[] sDamageCustom)
 	int iDamageCustom = 0;
 	mDamageCustom.GetValue(sDamageCustom, iDamageCustom);
 	return iDamageCustom;
+}
+
+int TagsDamage_GetCrit(const char[] sCritType)
+{
+	static StringMap mCritType;
+	
+	if (!mCritType)
+	{
+		mCritType = new StringMap();
+		mCritType.SetValue("none", Crit_None);
+		mCritType.SetValue("minicrit", Crit_Mini);
+		mCritType.SetValue("nominicrit", -Crit_Mini);
+		mCritType.SetValue("crit", Crit_Full);
+		mCritType.SetValue("nocrit", -Crit_Full);
+	}
+	
+	int iCritType = Crit_Invalid;
+	mCritType.GetValue(sCritType, iCritType);
+	return iCritType;
 }

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -13,6 +13,7 @@ enum TagsFilterType			//List of possible filters
 	TagsFilterType_BackstabCount,
 	TagsFilterType_FeignDeath,
 	TagsFilterType_VictimUber,
+	TagsFilterType_CritType
 }
 
 enum struct TagsFilterStruct
@@ -51,6 +52,11 @@ enum struct TagsFilterStruct
 			{
 				this.nValue = TagsDamage_GetCustom(sValue);
 				return this.nValue != 0;
+			}
+			case TagsFilterType_CritType:
+			{
+				this.nValue = TagsDamage_GetCrit(sValue);
+				return this.nValue != Crit_Invalid;
 			}
 		}
 		
@@ -148,6 +154,17 @@ enum struct TagsFilterStruct
 				
 				return iDamage >= this.nValue;
 			}
+			case TagsFilterType_CritType:
+			{
+				int iCritType;
+				if (!tParams.GetIntEx("filter_crittype", iCritType))
+					return false;
+
+				if (!this.nValue)
+					return iCritType != -this.nValue;
+
+				return iCritType == this.nValue;
+			}
 		}
 		
 		return false;
@@ -229,6 +246,7 @@ TagsFilterType TagsFilter_GetType(const char[] sTarget)
 		mFilterType.SetValue("backstabcount", TagsFilterType_BackstabCount);
 		mFilterType.SetValue("feigndeath", TagsFilterType_FeignDeath);
 		mFilterType.SetValue("victimuber", TagsFilterType_VictimUber);
+		mFilterType.SetValue("crittype", TagsFilterType_CritType);
 	}
 	
 	TagsFilterType nFilterType = TagsFilterType_Invalid;


### PR DESCRIPTION
This PR is used to replace `SDKHook_OnTakeDamageAlive` with detour `CTFPlayer::OnTakeDamage_Alive` for accessing CTakeDamageInfo object, which is used to structure damage hooks code a bit, and also to access `m_eCritType`, for example.
P.S.: PR also adds `crittype` filter and param for `(attack/take)damage` tags

Previously, I made these changes for my own fork of vsh - all worked fine. Can't say guaranteed that this PR will make it work fine, need more tests.

This PR also updates dhooks code to use methodmaps.