### PR TITLE
Shahanshah balance changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2017,8 +2017,8 @@
 				{
 					"override"		"sniper-melee-climb"
 
-					"height"		"500"
-					"horizontal"	"2.5"	//From 1 to 2.5 horizontal speed multiplier
+					"height"		"610"	//From 750 to 610 (tribalmans shiv height)
+					"horizontal"	"2"	//From 1 to 2 horizontal speed multiplier
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1961,6 +1961,7 @@
 					"override"		"232-climb"
 					"selfdamage"	"0"
 				}
+    
 				"Tags_Climb"	//Prevent Shahanshah overriding damage
 				{
 					"override"		"401-climb"
@@ -2020,6 +2021,7 @@
 			{
 				"Tags_Climb"
 				{
+					"name"			"401-climb"
 					"override"		"sniper-melee-climb"
 
 					"height"		"500"	//From 750 to 500

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2009,7 +2009,7 @@
 
 		"401"	//Shahanshah
 		{
-			"desp"			"Shahanshah: {neutral}Greater horizontal speed gain but less height gain on climb, {negative}+167% extra health cost on climb"
+			"desp"			"Shahanshah: {neutral}Converts wall climb into a horizontal leap, {negative}+167% extra health cost on climb"
 
 			"attack"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1961,6 +1961,11 @@
 					"override"		"232-climb"
 					"selfdamage"	"0"
 				}
+				"Tags_Climb"	//Prevent Shahanshah overriding damage
+				{
+					"override"		"401-climb"
+					"selfdamage"	"0"
+				}
 			}
 		}
 		

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2009,7 +2009,7 @@
 
 		"401"	//Shahanshah
 		{
-			"desp"			"Shahanshah: {positive}Greater horizontal speed on climb, {negative}less climb height"
+			"desp"			"Shahanshah: {neutral}Greater horizontal speed gain but less height gain on climb, {negative}+167% extra health cost on climb"
 
 			"attack"
 			{
@@ -2017,8 +2017,9 @@
 				{
 					"override"		"sniper-melee-climb"
 
-					"height"		"610"	//From 750 to 610 (tribalmans shiv height)
-					"horizontal"	"2"	//From 1 to 2 horizontal speed multiplier
+					"height"		"500"	//From 750 to 500
+					"horizontal"	"2.5"	//From 1 to 2.5 horizontal speed multiplier
+					"selfdamage"	"40"
 				}
 			}
 		}


### PR DESCRIPTION
-Increased HP cost per climb form 15 to 40.

Shahanshah has remained stupidly good because of its ability to easily outmanoeuvre Hale by travelling half across the map with a single hit of a wall, sort of making it a lite version of Hale's super jump but without a cooldown and costing only 15hp. These changes are meant to neuter Shahanshah climb spam to make it less of a pain in the ass to deal with as Hale.