### PR TITLE
Revert Back Scatter changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -500,12 +500,6 @@
 			"prefab"		"45"
 		}
 		
-		"1103"	//Back Scatter
-		{
-			"desp"			"Back Scatter: {neutral}Fires fast rockets instead of bullets"
-			"attrib"		"280 ; 2.0 ; 2 ; 8.0 ; 103 ; 1.33"
-		}
-		
 		"772"	//Baby Face Blaster
 		{
 			"desp"			"Baby Face Blaster: {negative}Boost takes up to 400 damage to fully charge and is reset on stun"


### PR DESCRIPTION
my original intention for this weapon was to have it so the crit aim that existed for soldier would work here. it'd deal less damage than a regular scattergun, but the crit aim was the primary benefit and to mix-up the weapon.

crit aim is gone now, and as such, this weapon's primary purpose is also gone. right now, it is just a less useful scattergun/rocket launcher that does worse damage and is overall not worth using. for now, i'd just like this to be reverted back to its regular stats. maybe someone can come up with something like replacing the specific back minicrits with crits at some point.