### PR TITLE
Ignore damage falloff distance for rockets

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -6,6 +6,7 @@
 //- minicrit              - Give minicrit when holding weapon
 //- crit                  - Give crit when holding weapon
 //- clip                  - Set given clip size on spawn
+//- ignorefalloff         - Whenever to ignore blast damage falloff
 //
 //List of calling function name
 //- banner                - Called when player uses banner
@@ -202,6 +203,11 @@
 		
 		"Soldier"
 		{
+			"Primary"
+			{
+				"ignorefalloff"	"1"
+			}
+			
 			"Melee"
 			{
 				"crit"		"1"
@@ -504,6 +510,7 @@
 		{
 			"desp"			"Back Scatter: {neutral}Fires fast rockets instead of bullets"
 			"attrib"		"280 ; 2.0 ; 2 ; 8.0 ; 103 ; 1.33"
+			"ignorefalloff"	"1"
 		}
 		
 		"772"	//Baby Face Blaster

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1237,6 +1237,8 @@ public void OnClientPutInServer(int iClient)
 	SDK_HookGiveNamedItem(iClient);
 	SDKHook(iClient, SDKHook_PreThink, Client_OnThink);
 	SDKHook(iClient, SDKHook_OnTakeDamageAlive, Client_OnTakeDamageAlive);
+	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
+	SDKHook(iClient, SDKHook_OnTakeDamagePost, Client_OnTakeDamagePost);
 	SDKHook(iClient, SDKHook_StartTouch, Client_OnStartTouch);
 	SDKHook(iClient, SDKHook_WeaponSwitchPost, Client_OnWeaponSwitchPost);
 	
@@ -1433,6 +1435,54 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 		}
 	}
 	return finalAction;
+}
+
+public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+{
+	if (!g_bEnabled) return Plugin_Continue;
+	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
+	
+	if (SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
+	{
+		TFClassType nClass = TF2_GetPlayerClass(attacker);
+		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
+		int iSlot = TF2_GetItemSlot(iIndex, nClass);
+		
+		if (0 <= iSlot < sizeof(g_ConfigClass[]))
+		{
+			int iIgnoreFalloff = g_ConfigIndex.IgnoreFalloff(iIndex);
+			if (iIgnoreFalloff == -1)
+				iIgnoreFalloff = g_ConfigClass[nClass][iSlot].IgnoreFalloff();
+			
+			if (iIgnoreFalloff == 1)
+				TF2_AddCondition(attacker, TFCond_RunePrecision, 0.05);
+		}
+	}
+	
+	return Plugin_Continue;
+}
+
+public void Client_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+{
+	if (!g_bEnabled) return;
+	if (g_iTotalRoundPlayed <= 0) return;
+	
+	if (SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
+	{
+		TFClassType nClass = TF2_GetPlayerClass(attacker);
+		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
+		int iSlot = TF2_GetItemSlot(iIndex, nClass);
+		
+		if (0 <= iSlot < sizeof(g_ConfigClass[]))
+		{
+			int iIgnoreFalloff = g_ConfigIndex.IgnoreFalloff(iIndex);
+			if (iIgnoreFalloff == -1)
+				iIgnoreFalloff = g_ConfigClass[nClass][iSlot].IgnoreFalloff();
+			
+			if (iIgnoreFalloff == 1)
+				TF2_RemoveCondition(attacker, TFCond_RunePrecision);
+		}
+	}
 }
 
 public Action Client_OnStartTouch(int iClient, int iToucher)

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1442,7 +1442,7 @@ public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, flo
 	if (!g_bEnabled) return Plugin_Continue;
 	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
 	
-	if (SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
+	if (victim != attacker && SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
 	{
 		TFClassType nClass = TF2_GetPlayerClass(attacker);
 		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");
@@ -1467,7 +1467,7 @@ public void Client_OnTakeDamagePost(int victim, int attacker, int inflictor, flo
 	if (!g_bEnabled) return;
 	if (g_iTotalRoundPlayed <= 0) return;
 	
-	if (SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
+	if (victim != attacker && SaxtonHale_IsValidAttack(attacker) && weapon != INVALID_ENT_REFERENCE && HasEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"))
 	{
 		TFClassType nClass = TF2_GetPlayerClass(attacker);
 		int iIndex = GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex");

--- a/addons/sourcemod/scripting/vsh/config.sp
+++ b/addons/sourcemod/scripting/vsh/config.sp
@@ -94,6 +94,16 @@ methodmap ConfigClass < StringMap
 		
 		else return -1;
 	}
+	
+	//Return whenever to ignore damage falloff
+	public int IgnoreFalloff()
+	{
+		char sValue[MAXLEN_CONFIG_VALUE];
+		if (this.GetString("ignorefalloff", sValue, sizeof(sValue)))
+			return StringToInt(sValue);
+		
+		else return -1;
+	}
 };
 
 methodmap ConfigIndex < ArrayList
@@ -272,6 +282,19 @@ methodmap ConfigIndex < ArrayList
 		
 		char sValue[MAXLEN_CONFIG_VALUE];
 		if (sMap.GetString("clip", sValue, sizeof(sValue)))
+			return StringToInt(sValue);
+		
+		else return -1;
+	}
+	
+	//Return whenever to ignore damage falloff
+	public int IgnoreFalloff(int iIndex)
+	{
+		StringMap sMap = this.GetStringMap(iIndex);
+		if (sMap == null) return -1;
+		
+		char sValue[MAXLEN_CONFIG_VALUE];
+		if (sMap.GetString("ignorefalloff", sValue, sizeof(sValue)))
 			return StringToInt(sValue);
 		
 		else return -1;


### PR DESCRIPTION
Uses Precision Powerup to remove distance damage falloff, affects all Soldier Rocket Launchers and Back Scatter