### PR TITLE
Few changes to Zombie Scout

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_zombie.sp
@@ -48,13 +48,11 @@ public void Zombie_OnThink(SaxtonHaleBase boss)
 
 public Action Zombie_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
-	if (boss.iClient != victim && GetClientTeam(boss.iClient) != GetClientTeam(victim))
-	{
-		int iHeal = RoundToNearest(damage);
-		if (iHeal > 20) iHeal = 20;
-		
-		Client_AddHealth(boss.iClient, iHeal, 0);
-	}
+	int iClient = boss.iClient;
+	
+	//Reset the last-hurt timer on hit
+	if (iClient != victim && GetClientTeam(iClient) != GetClientTeam(victim))
+		g_flZombieLastDamage[iClient] = GetGameTime();
 	
 	return Plugin_Continue;
 }
@@ -66,6 +64,18 @@ public Action Zombie_OnVoiceCommand(SaxtonHaleBase boss, char sCmd1[8], char sCm
 		//Since zombie scout cant get healed from medic, dont allow him to call medic
 		PrintHintText(boss.iClient, "You can't heal as zombie!");
 		return Plugin_Handled;
+	}
+	
+	return Plugin_Continue;
+}
+
+public Action Zombie_CanHealTarget(SaxtonHaleBase boss, int iTarget, bool &bResult)
+{
+	//Don't heal other bosses
+	if (SaxtonHale_IsValidBoss(iTarget))
+	{
+		bResult = false;
+		return Plugin_Changed;
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -384,13 +384,13 @@ public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hP
 			
 			return MRES_Ignored;
 		}
-		
-		if (SaxtonHale_IsValidBoss(iHealTarget))
-		{
-			//Never allow heal boss from any other sources
-			DHookSetReturn(hReturn, false);
-			return MRES_Supercede;
-		}
+	}
+	
+	if (SaxtonHale_IsValidBoss(iHealTarget))
+	{
+		//Never allow heal boss from any other sources
+		DHookSetReturn(hReturn, false);
+		return MRES_Supercede;
 	}
 	
 	return MRES_Ignored;


### PR DESCRIPTION
* Fixed zombie scouts sometimes being able to be healed by dispensers.
    * This happens when an engineer turns into a zombie scout, as even though attackers can't heal bosses/minions, bosses/minions can heal themselves by default. Since the dispenser is left up when the engie switches classes, they can use the dispenser to heal.
    * The fix is just disallowing zombie scouts from healing other bosses/minions, which may not be the best solution. Could maybe re-add a "can be healed" property in the future for cases like these.
* Removed the self-heal on hit for zombie scouts. Instead, the passive damage they take is delayed for a second.
    * Prevents them from being alive for more time than they should or surviving more hits than they should take (especially from weaker bosses, when the backup buff is still up), while still rewarding them for dealing damage, even if a bit less.
* Also fixed bosses in general being able to use dispensers without an owner (such as ones that come with the map).