### PR TITLE
Half-Zatoichi marked-for-death penalty

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -456,8 +456,10 @@
 		
 		"357"	//Half-Zatoichi
 		{
-			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit"
-			
+			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, {negative}marked-for-death while active"
+
+			"attrib"		"414 ; 1.0"
+   			
 			"attackdamage"
 			{
 				"filter"


### PR DESCRIPTION
Nerfs Half-Zatoichi by applying marked-for-death effect while it's active. Current version of this weapon lets demoknight easily tank hits from Hale with little risk compared to other melee options. This change makes it require more risk to heal off Hale and brings it down in line to other melee options.