### PR TITLE
Fix Manmelter getting buffs from hitting teammates

### DIFF
--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -119,7 +119,7 @@ void TagsDamage_CallFunctions(TagsParams tParams, int victim, int &attacker, int
 	}
 	
 	//Call attackdamage function
-	if (victim != attacker && SaxtonHale_IsValidAttack(attacker))
+	if (victim != attacker && SaxtonHale_IsValidAttack(attacker) && TF2_GetClientTeam(victim) != TF2_GetClientTeam(attacker))
 	{
 		for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 		{


### PR DESCRIPTION
This PR adds a team check to the attackdamage function in the config. In normal play, all this does is prevent the Manmelter from receiving a fire rate buff when hitting a teammate, but it's good to do this anyway to prevent people from getting buffs in general from hurting teammates in case friendly fire is enabled, for whatever reason.