### PR TITLE
Fix 'takedamage' calls including damage from teammates, among other Ullapool Caber concerns

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -45,6 +45,7 @@
 //- backstabcount         - X consecutive backstabs required
 //- hitfrombehind         - Victim is attacked from behind and within X range in hammer units (range is ignored if at or below 0), only works on 'attackdamage' and 'takedamage'
 //- feigndeath            - Does client have feign death ready
+//- selfdamage            - Is this self-damage, only works on 'attackdamage' and 'takedamage'
 //- victimuber            - Is victim ubered or not, only works on 'attackdamage' and 'takedamage'
 //
 //List of possible targets for each functions, where client is the calling function
@@ -183,6 +184,10 @@
 //
 //Tags_IgnitePlayer       - Sets target on fire
 //- duration                - Afterburn duration
+//
+//Tags_DelayNextAttack    - Delays the next weapon attack
+//- seconds                 - Amount of seconds to delay the next attack for
+
 
 "Config"
 {
@@ -1393,12 +1398,18 @@
 			
 			"spawn"
 			{
-				"Tags_SetEntProp"	//Make the caber fucking massive
+				"Tags_SetEntProp"		//Make the caber fucking massive
 				{
 					"target"		"melee"
 					"type"			"float"
 					"prop"			"m_flModelScale"
 					"value"			"2.0"
+				}
+				
+				"Tags_DelayNextAttack"	//Delay the next attack for 5 seconds
+				{
+					"target"		"melee"
+					"seconds"		"5.0"
 				}
 			}
 			
@@ -1406,12 +1417,12 @@
 			{
 				"filter"
 				{
-					"damagetype"	"blast"	//Only when the caber detonates
+					"damagecustom"	"caberexplosion"	//Only if it's the caber explosion
 				}
 				
 				"params"
 				{
-					"multiply"		"3.0"	//Multiply explosion damage by 3
+					"multiply"		"3.0"				//Multiply explosion damage by 3
 				}
 			}
 			
@@ -1419,8 +1430,8 @@
 			{
 				"filter"
 				{
-					"attackweapon"	"melee"
-					"damagetype"	"blast"	//Only when hit by melee blast damage
+					"damagecustom"	"caberexplosion"
+					"selfdamage"	"1"					//Only if it's our own caber explosion
 				}
 				
 				"Tags_Explode"

--- a/addons/sourcemod/scripting/vsh/tags.sp
+++ b/addons/sourcemod/scripting/vsh/tags.sp
@@ -896,6 +896,16 @@ public void Tags_IgnitePlayer(int iClient, int iTarget, TagsParams tParams)
 	TF2_IgnitePlayer(iTarget, iClient, tParams.GetFloat("duration"));
 }
 
+public void Tags_DelayNextAttack(int iClient, int iTarget, TagsParams tParams)
+{
+	if (iTarget <= 0 || !IsValidEdict(iTarget))
+		return;
+	
+	float flTime = GetGameTime() + tParams.GetFloat("seconds");
+	
+	SetEntPropFloat(iTarget, Prop_Send, "m_flNextPrimaryAttack", flTime);
+	SetEntPropFloat(iTarget, Prop_Send, "m_flNextSecondaryAttack", flTime);
+}
 //---------------------------
 
 public void Frame_AreaOfRange(DataPack data)

--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -98,8 +98,16 @@ void TagsDamage_CallFunctions(TagsParams tParams, int victim, int &attacker, int
 	tParams.SetInt("weapon", weapon);
 	tParams.SetInt("filter_damagecustom", damagecustom);
 	
+	TFTeam nVictimTeam = TF2_GetClientTeam(victim);
+	TFTeam nAttackerTeam
+	
+	if (0 < attacker <= MaxClients)
+		nAttackerTeam = TF2_GetClientTeam(attacker);
+	else
+		nAttackerTeam = TFTeam_Unassigned;
+	
 	//Call takedamage function
-	if (SaxtonHale_IsValidAttack(victim))
+	if (SaxtonHale_IsValidAttack(victim) && (nVictimTeam != nAttackerTeam || victim == attacker))
 	{
 		for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 		{
@@ -119,7 +127,7 @@ void TagsDamage_CallFunctions(TagsParams tParams, int victim, int &attacker, int
 	}
 	
 	//Call attackdamage function
-	if (victim != attacker && SaxtonHale_IsValidAttack(attacker) && TF2_GetClientTeam(victim) != TF2_GetClientTeam(attacker))
+	if (SaxtonHale_IsValidAttack(attacker) && nVictimTeam != nAttackerTeam)
 	{
 		for (int iSlot = 0; iSlot <= WeaponSlot_BuilderEngie; iSlot++)
 		{
@@ -172,6 +180,7 @@ int TagsDamage_GetCustom(const char[] sDamageCustom)
 		mDamageCustom.SetValue("backstab", TF_CUSTOM_BACKSTAB);
 		mDamageCustom.SetValue("stomp", TF_CUSTOM_BOOTS_STOMP);
 		mDamageCustom.SetValue("telefrag", TF_CUSTOM_TELEFRAG);
+		mDamageCustom.SetValue("caberexplosion", TF_CUSTOM_STICKBOMB_EXPLOSION);
 	}
 	
 	int iDamageCustom = 0;

--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -99,7 +99,7 @@ void TagsDamage_CallFunctions(TagsParams tParams, int victim, int &attacker, int
 	tParams.SetInt("filter_damagecustom", damagecustom);
 	
 	TFTeam nVictimTeam = TF2_GetClientTeam(victim);
-	TFTeam nAttackerTeam
+	TFTeam nAttackerTeam;
 	
 	if (0 < attacker <= MaxClients)
 		nAttackerTeam = TF2_GetClientTeam(attacker);

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -14,6 +14,7 @@ enum TagsFilterType			//List of possible filters
 	TagsFilterType_BackstabCount,
 	TagsFilterType_FeignDeath,
 	TagsFilterType_VictimUber,
+	TagsFilterType_SelfDamage,
 }
 
 enum struct TagsFilterStruct
@@ -38,7 +39,7 @@ enum struct TagsFilterStruct
 				this.nValue = TagsTarget_GetType(sValue);
 				return !(this.nValue == TagsTarget_Invalid);
 			}
-			case TagsFilterType_Aim, TagsFilterType_SentryTarget, TagsFilterType_FeignDeath, TagsFilterType_VictimUber:
+			case TagsFilterType_Aim, TagsFilterType_SentryTarget, TagsFilterType_FeignDeath, TagsFilterType_VictimUber, TagsFilterType_SelfDamage:
 			{
 				this.nValue = !!StringToInt(sValue);	//Turn into boolean
 				return true;
@@ -170,6 +171,13 @@ enum struct TagsFilterStruct
 				
 				return iDamage >= this.nValue;
 			}
+			case TagsFilterType_SelfDamage:
+			{
+				int iVictim = tParams.GetInt("victim");
+				int iAttacker = tParams.GetInt("attacker", -1);
+				bool bSelf = (iVictim == iAttacker);
+				return (this.nValue ? bSelf : !bSelf);
+			}
 		}
 		
 		return false;
@@ -252,6 +260,7 @@ TagsFilterType TagsFilter_GetType(const char[] sTarget)
 		mFilterType.SetValue("backstabcount", TagsFilterType_BackstabCount);
 		mFilterType.SetValue("feigndeath", TagsFilterType_FeignDeath);
 		mFilterType.SetValue("victimuber", TagsFilterType_VictimUber);
+		mFilterType.SetValue("selfdamage", TagsFilterType_SelfDamage);
 	}
 	
 	TagsFilterType nFilterType = TagsFilterType_Invalid;


### PR DESCRIPTION
Addresses #401.

* Adds an extra check to `takedamage` calls to exclude damage from teammates, except yourself.
    * **Should this also check for friendly fire?**
* Adds `Tags_DelayNextAttack` tag.
    * Allows setting a weapon's next attack to x seconds from now.
* Adds `selfdamage` filter.
    * Checks if damage was dealt by yourself, or exclusively not from yourself.

Changes specific to the Caber:
* Makes use of Tags_DelayNextAttack on spawn, to prevent people from continuously blowing themselves up.
* Damage detection for triggering the explosion is now more accurate:
    * Only works on self-damage.
    * Only works if damagecustom was `TF_CUSTOM_STICKBOMB_EXPLOSION`.
