### PR TITLE
Few small changes

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -793,7 +793,7 @@ public void OnPluginEnd()
 			boss.DestroyAllClass();
 		}
 		
-		if (!StrEmpty(g_sBossMusic))
+		if (IsClientInGame(iClient) && !StrEmpty(g_sBossMusic))
 			StopSound(iClient, SNDCHAN_STATIC, g_sBossMusic);
 		
 		RemoveClientGlowEnt(iClient);

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1094,7 +1094,7 @@ public Action ItemPack_OnTouch(int iEntity, int iToucher)
 	if (SaxtonHale_IsValidBoss(iToucher))
 	{
 		bool bResult;
-		bResult = SaxtonHaleBase(iToucher).CallFunction("OnPickupTouch", iEntity, bResult);
+		SaxtonHaleBase(iToucher).CallFunction("OnPickupTouch", iEntity, bResult);
 		
 		if (!bResult)
 			return Plugin_Handled;

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -579,6 +579,7 @@ public void OnPluginStart()
 	SaxtonHaleFunction("OnAttackCritical", ET_Hook, Param_Cell, Param_CellByRef);
 	SaxtonHaleFunction("OnVoiceCommand", ET_Hook, Param_String, Param_String);
 	SaxtonHaleFunction("OnStartTouch", ET_Hook, Param_Cell);
+	SaxtonHaleFunction("OnPickupTouch", ET_Ignore, Param_Cell, Param_CellByRef);
 	SaxtonHaleFunction("OnWeaponSwitchPost", ET_Ignore, Param_Cell);
 	SaxtonHaleFunction("OnConditionAdded", ET_Ignore, Param_Cell);
 	SaxtonHaleFunction("OnConditionRemoved", ET_Ignore, Param_Cell);
@@ -791,6 +792,9 @@ public void OnPluginEnd()
 			SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 			boss.DestroyAllClass();
 		}
+		
+		if (!StrEmpty(g_sBossMusic))
+			StopSound(iClient, SNDCHAN_STATIC, g_sBossMusic);
 		
 		RemoveClientGlowEnt(iClient);
 	}
@@ -1087,10 +1091,15 @@ public Action ItemPack_OnTouch(int iEntity, int iToucher)
 	if (!g_bEnabled) return Plugin_Continue;
 	if (g_iTotalRoundPlayed <= 0) return Plugin_Continue;
 	
-	//Don't allow valid non-attack players pick health and ammo packs
-	if (!SaxtonHale_IsValidAttack(iToucher))
-		return Plugin_Handled;
-
+	if (SaxtonHale_IsValidBoss(iToucher))
+	{
+		bool bResult;
+		bResult = SaxtonHaleBase(iToucher).CallFunction("OnPickupTouch", iEntity, bResult);
+		
+		if (!bResult)
+			return Plugin_Handled;
+	}
+	
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_spells.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_spells.sp
@@ -236,6 +236,23 @@ public void WeaponSpells_OnButtonPress(SaxtonHaleBase boss, int button)
 	}
 }
 
+public void WeaponSpells_OnEntityCreated(SaxtonHaleBase boss, int iEntity, const char[] sClassname)
+{
+	if (IsValidEntity(iEntity) && StrEqual(sClassname, "eyeball_boss"))
+		SDKHook(iEntity, SDKHook_SpawnPost, WeaponSpells_OnMonoculusSpawnPost);
+}
+
+void WeaponSpells_OnMonoculusSpawnPost(int iEntity)
+{
+	int iOwner = GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity");
+	if (iOwner <= 0 || iOwner > MaxClients || !IsClientInGame(iOwner))
+		return;
+	
+	SaxtonHaleBase boss = SaxtonHaleBase(iOwner);
+	if (boss.HasClass("WeaponSpells"))
+		SetEntProp(iEntity, Prop_Data, "m_takedamage", DAMAGE_NO);
+}
+
 //GetPlayerWeaponSlot is not that great into getting spellbook
 stock int GetSpellbook(int iClient)
 {

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_spells.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_spells.sp
@@ -238,7 +238,7 @@ public void WeaponSpells_OnButtonPress(SaxtonHaleBase boss, int button)
 
 public void WeaponSpells_OnEntityCreated(SaxtonHaleBase boss, int iEntity, const char[] sClassname)
 {
-	if (IsValidEntity(iEntity) && StrEqual(sClassname, "eyeball_boss"))
+	if (StrEqual(sClassname, "eyeball_boss"))
 		SDKHook(iEntity, SDKHook_SpawnPost, WeaponSpells_OnMonoculusSpawnPost);
 }
 

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -349,6 +349,11 @@ public Action SaxtonHaleBoss_OnTakeDamage(SaxtonHaleBase boss, int &attacker, in
 	return action;
 }
 
+public void SaxtonHaleBoss_OnPickupTouch(SaxtonHaleBase boss, int iEntity, bool &bResult)
+{
+	bResult = false;
+}
+
 public void SaxtonHaleBoss_UpdateHudInfo(SaxtonHaleBase boss, float flinterval, float flDuration)
 {
 	Hud_UpdateBossInfo(boss.iClient, flinterval, flDuration);

--- a/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_announcer.sp
@@ -173,7 +173,7 @@ public void Announcer_OnRage(SaxtonHaleBase boss)
 		if (iClip > 8) iClip = 8;
 		
 		SetEntProp(iPrimaryWep, Prop_Send, "m_iClip1", iClip);
-		SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", iPrimaryWep);
+		TF2_SwitchToWeapon(boss.iClient, iPrimaryWep);
 	}
 }
 
@@ -273,16 +273,6 @@ public void Announcer_Precache(SaxtonHaleBase boss)
 	AddFileToDownloadsTable("models/player/kirillian/boss/sedisocks_administrator.mdl");
 	AddFileToDownloadsTable("models/player/kirillian/boss/sedisocks_administrator.phy");
 	AddFileToDownloadsTable("models/player/kirillian/boss/sedisocks_administrator.vvd");
-}
-
-Action Announcer_OnRageAmmoPackTouch(int iEntity, int iClient)
-{
-	int iOwner = GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity");
-	PrintToChatAll("touching ammo pack: client: %N owner: %N", iClient, iOwner);
-	if (iClient != iOwner)
-		return Plugin_Handled;
-	
-	return Plugin_Continue;
 }
 
 static Handle g_hAnnouncerMinionTimer[MAXPLAYERS];
@@ -467,7 +457,7 @@ public Action Timer_AnnouncerChangeTeam(Handle hTimer, int iClient)
 	//Refill ammo (jank)
 	int iAmmoPack = CreateEntityByName("item_ammopack_full");
 	SetEntityOwner(iAmmoPack, iClient);
-	SDKHook(iAmmoPack, SDKHook_Touch, Announcer_OnRageAmmoPackTouch);
+	SDKHook(iAmmoPack, SDKHook_Touch, AnnouncerMinion_OnRageAmmoPackTouch);
 	
 	DispatchSpawn(iAmmoPack);
 	SetEntityRenderMode(iAmmoPack, RENDER_NONE);
@@ -505,4 +495,13 @@ public void Announcer_ShowAnnotation(int iTarget, char[] sMessage, float flDurat
 		return;
 	
 	TF2_ShowAnnotation(iClients, iCount, iTarget, sMessage, flDuration);
+}
+
+Action AnnouncerMinion_OnRageAmmoPackTouch(int iEntity, int iClient)
+{
+	int iOwner = GetEntPropEnt(iEntity, Prop_Send, "m_hOwnerEntity");
+	if (iClient != iOwner)
+		return Plugin_Handled;
+	
+	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -601,13 +601,6 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 		DispatchSpawn(iWeapon);
 		SetEntProp(iWeapon, Prop_Send, "m_bValidatedAttachedEntity", true);
 		
-		if (HasEntProp(iWeapon, Prop_Send, "m_hExtraWearable"))
-		{
-			int iExtraWearable = GetEntPropEnt(iWeapon, Prop_Send, "m_hExtraWearable");
-			if (iExtraWearable != INVALID_ENT_REFERENCE)
-				SetEntProp(iExtraWearable, Prop_Send, "m_bValidatedAttachedEntity", true);
-		}
-		
 		if (StrContains(sClassname, "tf_wearable") == 0)
 		{
 			SDK_EquipWearable(iClient, iWeapon);
@@ -623,6 +616,10 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 				TF2_SetAmmo(iClient, iAmmoType, 0);
 				GivePlayerAmmo(iClient, 9999, iAmmoType, true);
 			}
+			
+			int iExtraWearable = GetEntPropEnt(iWeapon, Prop_Send, "m_hExtraWearable");
+			if (iExtraWearable != INVALID_ENT_REFERENCE)
+				SetEntProp(iExtraWearable, Prop_Send, "m_bValidatedAttachedEntity", true);
 		}
 		
 		char atts[32][32];

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -601,6 +601,13 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, char[] sClassnameTem
 		DispatchSpawn(iWeapon);
 		SetEntProp(iWeapon, Prop_Send, "m_bValidatedAttachedEntity", true);
 		
+		if (HasEntProp(iWeapon, Prop_Send, "m_hExtraWearable"))
+		{
+			int iExtraWearable = GetEntPropEnt(iWeapon, Prop_Send, "m_hExtraWearable");
+			if (iExtraWearable != INVALID_ENT_REFERENCE)
+				SetEntProp(iExtraWearable, Prop_Send, "m_bValidatedAttachedEntity", true);
+		}
+		
 		if (StrContains(sClassname, "tf_wearable") == 0)
 		{
 			SDK_EquipWearable(iClient, iWeapon);


### PR DESCRIPTION
* Weapons created by the gamemode that come with wearables (such as Pyrocar's Thermal Thruster) will now be fully visible.

* Boss Base:
    * Added `OnPickupTouch` boss function, which controls whether bosses can pick up ammo packs and health kits, as well as possibly doing stuff when that happens.

* Announcer:
    * Minions will receive an ammo refill when converted. Addresses #407.
    * Minions can now pick up... pickups on the map.

* Redmond:
    * The Monoculus from his Monoculus Spell rage can no longer take damage, preventing some on-hit effects from happening. Addresses [this Red Sun Forums post](https://forum.redsun.tf/threads/blutarch-uber-exploit.4627/#post-40938).