### PR TITLE
Restrict "scoutknight" to Three-Rune Blane only

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -658,10 +658,10 @@
 				}
 			}
 		}
-		
-		"325"	//Boston Basher
+	
+		"452"	//Three-Rune Blade
 		{
-			"desp"			"Boston Basher: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
+			"desp"			"Three-Rune Blade: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
 			"attrib"		"26 ; 75.0 ; 2 ; 1.60"
 			
 			"spawn"
@@ -680,11 +680,6 @@
 					"value"		"0.0"
 				}
 			}
-		}
-
-		"452"	//Three-Rune Blade
-		{
-			"prefab"		"325"
 		}		
 		
 		"355"	//Fan O'War

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -657,30 +657,7 @@
 					"call"			"2"			//Call this function twice
 				}
 			}
-		}
-	
-		"452"	//Three-Rune Blade
-		{
-			"desp"			"Three-Rune Blade: {positive}+75 max health, +60% damage bonus, {negative}only medieval weapons can be equipped"
-			"attrib"		"26 ; 75.0 ; 2 ; 1.60"
-			
-			"spawn"
-			{
-				"Tags_DestroyEntity"
-				{
-					"target"	"primary"
-					"attrib"	"2029"	//allowed_in_medieval_mode
-					"value"		"0.0"
-				}
-				
-				"Tags_DestroyEntity"
-				{
-					"target"	"secondary"
-					"attrib"	"2029"	//allowed_in_medieval_mode
-					"value"		"0.0"
-				}
-			}
-		}		
+		}	
 		
 		"355"	//Fan O'War
 		{


### PR DESCRIPTION
Keep the Boston Basher as it normally is, but let people equip the Three-Rune Blade if they _really_ want to go melee only as scout.