### PR TITLE
Fix Bonk Boy incorrectly critting during rage

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_bonkboy.sp
@@ -177,7 +177,7 @@ public void BonkBoy_OnThink(SaxtonHaleBase boss)
 	}
 }
 
-public Action BonkBoy_OnAttackDamage(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+public Action BonkBoy_OnAttackDamageAlive(SaxtonHaleBase boss, int victim, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	if (g_bBonkBoyRage[boss.iClient] && weapon > MaxClients && TF2_GetItemInSlot(boss.iClient, WeaponSlot_Melee) == weapon && damagecustom == 0)
 	{


### PR DESCRIPTION
Makes Bonk Boy use OnAttackDamageAlive, which makes it so the rage's stun on hit comes after the "100% crits against stunned players" attribute takes effect.