### PR TITLE
Enable Jumper Weapons

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -724,8 +724,8 @@
 
 		"237"	//Rocket Jumper
 		{
-			"desp"			"Rocket Jumper: {neutral}Replaced with Rocket Launcher"
-			"restricted"	"1"
+			"desp"			"Rocket Jumper: {negative}marked-for-death while active"
+			"attrib"		"414 ; 1.0"
 		}
 		
 		"441"	//Cow Mangler 5000
@@ -1216,8 +1216,8 @@
 		
 		"265"	//Sticky Jumper
 		{
-			"desp"			"Sticky Jumper: {neutral}Replaced with Stickybomb Launcher"
-			"restricted"	"1"
+			"desp"			"Sticky Jumper: {negative}marked-for-death while active"
+			"attrib"		"414 ; 1.0"
 		}
 		
 		"131"	//Chargin' Targe


### PR DESCRIPTION
surely nothing bad will come from it :clueless:

also theyre given marked for death to start with so players caught holding them will most likely die