### PR TITLE
Enforcer Rework

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2145,23 +2145,8 @@
 		
 		"460"	//Enforcer
 		{
-			"desp"			"Enforcer: {positive}Receive crits while disguised, {negative}critical damage is affected by range, no minicrits"
-			"attrib"		"868 ; 1.0"
-			"minicrit"		"0"
-			
-			"think"
-			{
-				"filter"
-				{
-					"cond"			"3"	//Disguised
-					"activeweapon"	"primary"	//Is active weapon primary
-				}
-				
-				"Tags_AddCond"
-				{
-					"cond"			"56"	//Crit
-				}
-			}
+			"desp"			"Enforcer: {positive}On Hit: Bleed for 8 seconds, Damage bonus active at all time, {negative}critical damage is affected by range, 0.5 sec increase in time taken to cloak, Attacks no longer pierce damage resistance effects and bonuses"
+			"attrib"		"2 ; 1.2 ; 149 ; 8.0 ; 253 ; 0.5 ; 410 ; 0 ; 797 ; 0 ; 868 ; 1.0"
 		}
 		
 		"810"	//Red-Tape Recorder


### PR DESCRIPTION
Enforcer Rework
Has two stats from Uber update: 20% damage bonus at all times (replacing conditional damage bonus), and cloak delay Has bleed
No longer pierces resists or gain crits when disguised Still has critical damage fall-off and firing rate penalty

Specializes the Enforcer more into a higher-damage revolver at closer ranges with increased risk of getting caught. Could probably be readjusted but the current core functionality of Enforcer relying on disguising doesn't really belong in VSH imo and resist piercing could end up having some niche, scuffed interactions with bosses in the future.