### PR TITLE
Direct rocket crits

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -211,15 +211,24 @@
 		{
 			"Primary"
 			{
-				"ignorefalloff"	"1"
-			}
-			
-			"Melee"
-			{
-				"crit"		"1"
-			}
+				"desp"		"Primary: {positive}Crits when aiming directly at the boss"
+
+				"attack"
+				{
+					"filter"
+					{
+						"aim"			"1"		//Is client aiming at boss
+					}
+
+					"params"
+					{
+						"attackcrit"	"1"
+					}
+				}
 		}
-		
+
+
+  
 		"Pyro"
 		{
 			"Primary"


### PR DESCRIPTION
Returning old critical rocket on line of sight mechanic that was changed to no falloff in 2023. 

I feel like critical rockets are a necessary part of soldier in versus saxton hale, as splash damage from rocket launcher was meant to help fighting multiple people at once, with much lower health breakpoints. Here, although splash helps to hit rapidly moving bosses, the damage is just not enough. Critical rockets cover both damage and no falloff. I don't think people had issues with them, and if banners will be problematic, damage requirements for them can be raised.