### PR TITLE
Market gardener

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -933,7 +933,7 @@
 		
 		"416"	//Market Gardener
 		{
-			"desp"			"Market Gardener: {positive}Airborne hit deals 750 damage, {negative}no crits"
+			"desp"			"Market Gardener: {positive}Airborne hit deals 1000 damage, {negative}no crits"
 			"minicrit"		"0"
 			"crit"			"0"
 			
@@ -947,7 +947,7 @@
 				
 				"params"
 				{
-					"set"			"750.0"		//Set damage to 750
+					"set"			"1000.0"		//Set damage to 1000
 					"damagetype"	"crit"		//Force crit
 				}
 				


### PR DESCRIPTION
A rocket jumping soldier more often than not will not have enough health to survive next hit from the boss, and although he can quickly rocket jump away after failed/successful Market Gardener, same can be said about the spy with cloak activation. 
This buff is aimed to bring MG in the same spot as backstabs. 

On a side note, although it is possible to do both MG and stomp with Mantreads, it is very difficult to pull off, and I don't feel like should be considered when it comes to Market Gardener balancing. A 1000 is a good value backstabs, Booties, and Thermal Thruster already use.