### PR TITLE
Shotgun accuracy buff

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -226,6 +226,11 @@
 					}
 				}
 			}
+   			"Secondary"
+      			{
+	 			"desp"		"Secondary: {positive}Shotguns are 70% more accurate"
+				"attrib"		"106 ; 0.3"
+     			}
 		}
 		
 		"Pyro"
@@ -245,7 +250,11 @@
 					}
 				}
 			}
-			
+			"Secondary"
+      			{
+	 			"desp"		"Secondary: {positive}Shotguns are 70% more accurate"
+				"attrib"		"106 ; 0.3"
+     			}
 			"Melee"
 			{
 				"crit"		"1"
@@ -288,9 +297,11 @@
 			
 			"Secondary"
 			{
+   				"desp"		"Secondary: {positive}Shotguns are 70% more accurate"
+				"attrib"	"106 ; 0.3"
 				"minicrit"	"1"
+    				
 			}
-			
 			"Melee"
 			{
 				"crit"		"1"
@@ -299,6 +310,12 @@
 		
 		"Engineer"
 		{
+  			"Primary"
+			{
+   				"desp"		"Primary: {positive}Shotguns are 70% more accurate"
+				"attrib"	"106 ; 0.3"
+			}
+   
 			"Melee"
 			{
 				"crit"		"1"
@@ -1619,8 +1636,8 @@
 
 		"141"	//Frontier Justice
 		{
-			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}50% slower reload time"
-			"attrib"		"96 ; 1.50"
+			"desp"			"Frontier Justice: {positive}Crits when your sentry is targeting the boss, {negative}50% slower reload time, normal accuracy"
+			"attrib"		"96 ; 1.50 ; 106 ; 1.0"
 			
 			"think"
 			{


### PR DESCRIPTION
Makes all shotguns besides Frontier Justice way more accurate in an attempt to make them viable. Was unsure whether to keep mini-crits on heavy, but I want to see if it will be viable alternative to minigun, something heavy uses even less than other classes