### PR TITLE
Add blast jumping condition to some boss movement abilities + add a new config filter

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -34,6 +34,7 @@
 //
 //List of possible filters
 //- cond                  - Does client have cond id X
+//- victimcond            - Does the victim have cond id X, only meant for 'attackdamage', use 'cond' for 'takedamage'
 //- activeweapon          - Is client active weapon X
 //- attackweapon          - Is attacked weapon in slot X, only works on 'attackdamage' and 'takedamage'
 //- aim                   - Is client aiming at boss
@@ -506,6 +507,27 @@
 			"desp"			"Pain Train: {positive}5x capture rate, {negative}+10% damage vulnerability from all sources"
 			"attrib"		"67 ; 1.0 ; 68 ; 4.0 ; 412 ; 1.1"
 		}
+		
+		"415"	//Reserve Shooter
+		{
+			"attackdamage"
+			{
+				"filter"
+				{
+					"victimcond"		"81" // Blast jumping
+				}
+				
+				// Scuffed way of dealing minicrits
+				"Tags_AddCond"
+				{
+					"target"	"victim"
+					"cond"		"48" 		// Silent marked-for-death
+					"duration"	"0.001"
+				}
+			}
+		}
+		
+		
 
 		// SCOUT
 		
@@ -788,6 +810,25 @@
 					
 					"math"			"damage"	//Requires "value" to get every head
 					"value"			"200"		//200 damage required for every 1 head
+				}
+			}
+		}
+		
+		"127"	//Direct Hit
+		{
+			"attackdamage"
+			{
+				"filter"
+				{
+					"victimcond"		"81" // Blast jumping
+				}
+				
+				// Scuffed way of dealing minicrits
+				"Tags_AddCond"
+				{
+					"target"	"victim"
+					"cond"		"48" 		// Silent marked-for-death
+					"duration"	"0.001"
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -520,8 +520,7 @@
 				// Scuffed way of dealing minicrits
 				"Tags_AddCond"
 				{
-					"target"	"victim"
-					"cond"		"48" 		// Silent marked-for-death
+					"cond"		"78" 		// On-kill minicrit
 					"duration"	"0.001"
 				}
 			}
@@ -826,8 +825,7 @@
 				// Scuffed way of dealing minicrits
 				"Tags_AddCond"
 				{
-					"target"	"victim"
-					"cond"		"48" 		// Silent marked-for-death
+					"cond"		"78" 		// On-kill minicrit
 					"duration"	"0.001"
 				}
 			}

--- a/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_brave_jump.sp
@@ -101,6 +101,7 @@ public void BraveJump_OnButtonRelease(SaxtonHaleBase boss, int button)
 			
 			SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
 			SetEntityFlags(boss.iClient, GetEntityFlags(boss.iClient) & ~FL_ONGROUND);
+			TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 			
 			float flCooldownTime = (boss.GetPropFloat("BraveJump", "Cooldown")*(float(boss.GetPropInt("BraveJump", "JumpCharge"))/float(boss.GetPropInt("BraveJump", "MaxJumpCharge"))));
 			if (flCooldownTime < boss.GetPropFloat("BraveJump", "MinCooldown"))

--- a/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
@@ -53,6 +53,7 @@ public void DashJump_OnButtonPress(SaxtonHaleBase boss, int iButton)
 		TeleportEntity(boss.iClient, NULL_VECTOR, NULL_VECTOR, vecVel);
 		
 		SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
+		SetEntityFlags(boss.iClient, GetEntityFlags(boss.iClient) & ~FL_ONGROUND);
 		TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 		
 		g_flDashJumpCooldownWait[boss.iClient] += boss.GetPropFloat("DashJump", "Cooldown");

--- a/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
@@ -50,9 +50,10 @@ public void DashJump_OnButtonPress(SaxtonHaleBase boss, int iButton)
 		vecVel[1] = Cosine(DegToRad(vecAng[0])) * Sine(DegToRad(vecAng[1])) * boss.GetPropFloat("DashJump", "MaxForce");
 		vecVel[2] = (((-vecAng[0]) * 1.5) + 90.0) * 3.0;
 		
-		SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
-		
 		TeleportEntity(boss.iClient, NULL_VECTOR, NULL_VECTOR, vecVel);
+		
+		SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
+		TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 		
 		g_flDashJumpCooldownWait[boss.iClient] += boss.GetPropFloat("DashJump", "Cooldown");
 		boss.CallFunction("UpdateHudInfo", 0.0, boss.GetPropFloat("DashJump", "Cooldown") * 2);	//Update every frame for cooldown * 2

--- a/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
@@ -150,6 +150,8 @@ public void Lunge_OnButtonPress(SaxtonHaleBase boss, int iButton)
 		
 		TeleportEntity(boss.iClient, NULL_VECTOR, NULL_VECTOR, vecVelocity);
 		
+		SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
+		SetEntityFlags(boss.iClient, GetEntityFlags(boss.iClient) & ~FL_ONGROUND);
 		TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 	}
 }

--- a/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
@@ -149,6 +149,8 @@ public void Lunge_OnButtonPress(SaxtonHaleBase boss, int iButton)
 			vecVelocity[2] = 310.0;
 		
 		TeleportEntity(boss.iClient, NULL_VECTOR, NULL_VECTOR, vecVelocity);
+		
+		TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 	}
 }
 

--- a/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
@@ -59,6 +59,9 @@ public Action WallClimb_OnAttackCritical(SaxtonHaleBase boss, int iWeapon, bool 
 	vecVelocity[2] = boss.GetPropFloat("WallClimb", "MaxHeight");
 	
 	TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, vecVelocity);
+	
+	TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
+	
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_wallclimb.sp
@@ -60,6 +60,8 @@ public Action WallClimb_OnAttackCritical(SaxtonHaleBase boss, int iWeapon, bool 
 	
 	TeleportEntity(iClient, NULL_VECTOR, NULL_VECTOR, vecVelocity);
 	
+	SetEntProp(boss.iClient, Prop_Send, "m_bJumping", true);
+	SetEntityFlags(boss.iClient, GetEntityFlags(boss.iClient) & ~FL_ONGROUND);
 	TF2_AddCondition(boss.iClient, TFCond_BlastJumping);
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/vsh/base_boss.sp
+++ b/addons/sourcemod/scripting/vsh/base_boss.sp
@@ -61,6 +61,9 @@ public void SaxtonHaleBoss_OnThink(SaxtonHaleBase boss)
 	bool bGlow = (boss.flGlowTime == -1.0 || boss.flGlowTime >= GetGameTime());
 	SetEntProp(boss.iClient, Prop_Send, "m_bGlowEnabled", bGlow);
 	
+	if ((GetEntityFlags(boss.iClient) & FL_ONGROUND) && TF2_IsPlayerInCondition(boss.iClient, TFCond_BlastJumping))
+		TF2_RemoveCondition(boss.iClient, TFCond_BlastJumping);
+	
 	//Dont modify his speed during setup time or when taunting
 	if (boss.flSpeed >= 0.0 && GameRules_GetRoundState() != RoundState_Preround && !TF2_IsPlayerInCondition(boss.iClient, TFCond_Taunting))
 	{

--- a/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_filter.sp
@@ -15,6 +15,7 @@ enum TagsFilterType			//List of possible filters
 	TagsFilterType_FeignDeath,
 	TagsFilterType_VictimUber,
 	TagsFilterType_SelfDamage,
+	TagsFilterType_VictimCond,
 }
 
 enum struct TagsFilterStruct
@@ -28,7 +29,7 @@ enum struct TagsFilterStruct
 		
 		switch (this.nType)
 		{
-			case TagsFilterType_Cond, TagsFilterType_HitFromBehind, TagsFilterType_BackstabCount, TagsFilterType_DamageMaximum, TagsFilterType_DamageMinimum:
+			case TagsFilterType_Cond, TagsFilterType_HitFromBehind, TagsFilterType_BackstabCount, TagsFilterType_DamageMaximum, TagsFilterType_DamageMinimum, TagsFilterType_VictimCond:
 			{
 				//Get number from string
 				return !!StringToIntEx(sValue, this.nValue);
@@ -178,6 +179,11 @@ enum struct TagsFilterStruct
 				bool bSelf = (iVictim == iAttacker);
 				return (this.nValue ? bSelf : !bSelf);
 			}
+			case TagsFilterType_VictimCond:
+			{
+				int iVictim = tParams.GetInt("victim");
+				return TF2_IsPlayerInCondition(iVictim, this.nValue);
+			}
 		}
 		
 		return false;
@@ -261,6 +267,7 @@ TagsFilterType TagsFilter_GetType(const char[] sTarget)
 		mFilterType.SetValue("feigndeath", TagsFilterType_FeignDeath);
 		mFilterType.SetValue("victimuber", TagsFilterType_VictimUber);
 		mFilterType.SetValue("selfdamage", TagsFilterType_SelfDamage);
+		mFilterType.SetValue("victimcond", TagsFilterType_VictimCond);
 	}
 	
 	TagsFilterType nFilterType = TagsFilterType_Invalid;


### PR DESCRIPTION
This PR adds the blast jumping condition to bosses when they use the following abilities:
- Brave Jump
- Saxton Hale's Lunge
- Horseless Headless Horsemann Jr.'s Wall Climb
- Bonk Boy's Dash
...but purposefully not to:
- Jumper Modifier's Leap (because it's just jumping)
- Merasmus' Super Jump Spell (because it's a stock TF2 mechanic that's not as easy to modify)

...until they land, which in practice... doesn't actually do anything. But! The config is getting a new attackdamage filter, `victimcond`, which allows letting the Direct Hit and Reserve Shooter minicrit bosses using these abilities, as if they were blast jumping.