### PR TITLE
Pyroknight VSH (Sharpened Volcano Fragment adjustment)

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1107,10 +1107,27 @@
 		
 		"348"	//Sharpened Volcano Fragment
 		{
-			"desp"			"Sharpened Volcano Fragment: {positive}+200% afterburn damage bonus, {negative}minicrits instead of crits"
-			"attrib"		"71 ; 3.0"
+			"desp"			"Sharpened Volcano Fragment: {positive}+75 max health, +200% afterburn damage bonus, +150% damage bonus against burning enemies, {negative}minicrits instead of crits {negative}only medieval weapons can be equipped""
+			"attrib"		"26 ; 75.0 ; 71 ; 3.0 ; 795 ; 2.5"
 			"minicrit"		"1"
 			"crit"			"0"
+
+			"spawn"
+			{
+				"Tags_DestroyEntity"
+				{
+					"target"	"primary"
+					"attrib"	"2029"	//allowed_in_medieval_mode
+					"value"		"0.0"
+				}
+
+				"Tags_DestroyEntity"
+				{
+					"target"	"secondary"
+					"attrib"	"2029"	//allowed_in_medieval_mode
+					"value"		"0.0"
+				}
+			}
 		}
 		
 		"153"	//Homewrecker


### PR DESCRIPTION
Changes the Sharpened Volcano Fragment because it has the problem of competing with the Flamethrower.
Makes Pyro tankier with a stronger melee that could be boosted further at the cost of not being able to use primaries or secondaries.