### PR TITLE
Fix some stuff

### DIFF
--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -71,6 +71,28 @@
 					}
 				}
 			}
+			"CBaseEntity::FVisible"
+			{
+				"offset"	"CBaseEntity::FVisible"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"entity"
+					{
+						"type"	"cbaseentity"
+					}
+					"mask"
+					{
+						"type"	"int"
+					}
+					"blocker"
+					{
+						"type"	"objectptr"
+					}
+				}				
+			}
 		}
 		"Offsets"
 		{
@@ -113,6 +135,13 @@
 			{
 				"linux"		"501"
 				"windows"	"494"
+			}
+			"CBaseEntity::FVisible"	
+			{
+				"windows"	"149"
+				"windows64"	"149"
+				"linux"		"149"
+				"linux64"	"149"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -128,6 +128,18 @@ enum
 	LAST_SHARED_COLLISION_GROUP
 };
 
+enum
+{
+	TF_COLLISIONGROUP_GRENADES = LAST_SHARED_COLLISION_GROUP,
+	TFCOLLISION_GROUP_OBJECT,
+	TFCOLLISION_GROUP_OBJECT_SOLIDTOPLAYERMOVEMENT,
+	TFCOLLISION_GROUP_COMBATOBJECT,
+	TFCOLLISION_GROUP_ROCKETS,		// Solid to players, but not player movement. ensures touch calls are originating from rocket
+	TFCOLLISION_GROUP_RESPAWNROOMS,
+	TFCOLLISION_GROUP_TANK,
+	TFCOLLISION_GROUP_ROCKET_BUT_NOT_WITH_OTHER_ROCKETS
+};
+
 // entity effects
 enum
 {
@@ -1011,6 +1023,10 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 	if (StrContains(sClassname, "tf_projectile_") == 0)
 	{
 		SDKHook(iEntity, SDKHook_StartTouchPost, Tags_OnProjectileTouch);
+	}
+	else if (strncmp(sClassname, "tf_weapon", 9) == 0)
+	{
+		SDK_FVisible(iEntity);
 	}
 	else if (strncmp(sClassname, "item_healthkit_", 15) == 0
 		|| strncmp(sClassname, "item_ammopack_", 14) == 0

--- a/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
@@ -127,6 +127,11 @@ public void Lunge_OnButtonPress(SaxtonHaleBase boss, int iButton)
 		TF2_AddCondition(boss.iClient, TFCond_HalloweenKartDash, -1.0);	// For animation
 		TF2_AddCondition(boss.iClient, TFCond_MegaHeal, -1.0);
 		
+		// Prevent the boss from swinging their melee
+		int iWeapon = GetPlayerWeaponSlot(boss.iClient, WeaponSlot_Melee);
+		if (iWeapon != INVALID_ENT_REFERENCE)
+			DelayNextWeaponAttack(iWeapon, 99999.0);
+		
 		GetClientEyeAngles(boss.iClient, g_vecLungeInitialAngles[boss.iClient]);
 		
 		// Restrict going heavily upwards/downwards
@@ -169,6 +174,12 @@ public void Lunge_OnThink(SaxtonHaleBase boss)
 				g_bLungeActive[boss.iClient] = false;
 				TF2_RemoveCondition(boss.iClient, TFCond_HalloweenKartDash);
 				TF2_RemoveCondition(boss.iClient, TFCond_MegaHeal);
+				
+				// Let the boss swing their melee again
+				int iWeapon = GetPlayerWeaponSlot(boss.iClient, WeaponSlot_Melee);
+				if (iWeapon != INVALID_ENT_REFERENCE)
+					DelayNextWeaponAttack(iWeapon, 0.0);
+				
 				return;
 			}
 		}

--- a/addons/sourcemod/scripting/vsh/abilities/ability_weapon_sentry.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_weapon_sentry.sp
@@ -79,7 +79,7 @@ public void WeaponSentry_OnThink(SaxtonHaleBase boss)
 				SetEntData(iSentry, FindSendPropInfo("CObjectSentrygun", "m_bServerOverridePlacement") + 28, true, 1);	//m_bForceQuickBuild
 			
 			if (GetEntPropFloat(iSentry, Prop_Send, "m_flModelScale") != 1.22)
-				SetEntPropFloat(iSentry, Prop_Send, "m_flModelScale", 1.22);
+				SetEntityModelScale(iSentry, 1.22);
 			
 			//m_iState: 0 is being carried or in the process of building, 1 is idle (can be either enabled or disabled), 2 is shooting at a target or being wrangled, 3 is in the process of upgrading
 			if (GetEntProp(iSentry, Prop_Send, "m_iState") > 0)

--- a/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_seeldier.sp
@@ -165,7 +165,7 @@ public void SeeldierMinion_OnSpawn(SaxtonHaleBase boss)
 	if (iWeapon > MaxClients)
 		SetEntPropEnt(boss.iClient, Prop_Send, "m_hActiveWeapon", iWeapon);
 	
-	SetEntPropFloat(boss.iClient, Prop_Send, "m_flModelScale", 0.75);
+	SetEntityModelScale(boss.iClient, 0.75);
 }
 
 public void SeeldierMinion_GetModel(SaxtonHaleBase boss, char[] sModel, int length)
@@ -194,5 +194,5 @@ public Action SeeldierMinion_OnSoundPlayed(SaxtonHaleBase boss, int clients[MAXP
 
 public void SeeldierMinion_Destroy(SaxtonHaleBase boss)
 {
-	SetEntPropFloat(boss.iClient, Prop_Send, "m_flModelScale", 1.0);
+	SetEntityModelScale(boss.iClient, 1.0);
 }

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -174,8 +174,6 @@ void SDK_Init()
 	g_hHookFVisible = DHookCreateFromConf(hGameData, "CBaseEntity::FVisible");
 	if (g_hHookFVisible == null)
 		LogMessage("Failed to create hook: CBaseEntity::FVisible!");
-	else
-		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
 	
 	// This hook allows to allow/block medigun heals
 	Handle hHook = DHookCreateFromConf(hGameData, "CWeaponMedigun::AllowedToHealTarget");

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -4,6 +4,7 @@ static Handle g_hHookShouldTransmit;
 static Handle g_hHookGiveNamedItem;
 static Handle g_hHookBallImpact;
 static Handle g_hHookShouldBallTouch;
+static Handle g_hHookFVisible;
 static Handle g_hSDKGetMaxHealth;
 static Handle g_hSDKSendWeaponAnim;
 static Handle g_hSDKPlaySpecificSequence;
@@ -166,6 +167,13 @@ void SDK_Init()
 	g_hHookShouldBallTouch = DHookCreate(iOffset, HookType_Entity, ReturnType_Bool, ThisPointer_CBaseEntity);
 	if (g_hHookShouldBallTouch == null)
 		LogMessage("Failed to create hook: CTFStunBall::ApplyBallImpactEffectOnVictim!");
+	else
+		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
+	
+	iOffset = hGameData.GetOffset("CBaseEntity::FVisible");
+	g_hHookFVisible = DHookCreateFromConf(hGameData, "CBaseEntity::FVisible");
+	if (g_hHookFVisible == null)
+		LogMessage("Failed to create hook: CBaseEntity::FVisible!");
 	else
 		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
 	
@@ -394,6 +402,19 @@ public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hP
 	}
 	
 	return MRES_Ignored;
+}
+
+void SDK_FVisible(int iEntity)
+{
+	if (g_hHookFVisible != null)
+		DHookEntity(g_hHookFVisible, false, iEntity, _, Hook_FVisible);
+}
+
+MRESReturn Hook_FVisible(int iEntity, DHookReturn ret)
+{
+	// This might fix weapons sometimes not being given out to players
+	ret.Value = true;
+	return MRES_Supercede;
 }
 
 void SDK_SendWeaponAnim(int weapon, int anim)

--- a/addons/sourcemod/scripting/vsh/stocks.sp
+++ b/addons/sourcemod/scripting/vsh/stocks.sp
@@ -1121,3 +1121,20 @@ stock void ConstrainDistance(const float vecStart[3], float vecEnd[3], float flD
 	vecEnd[1] = ((vecEnd[1] - vecStart[1]) * flFactor) + vecStart[1];
 	vecEnd[2] = ((vecEnd[2] - vecStart[2]) * flFactor) + vecStart[2];
 }
+
+stock void SetEntityModelScale(int iEntity, float flScale, int iActivator = -1, int iCaller = -1)
+{
+	// SetModelScale errors out when using a float instead of a string, so it looks odd
+	char sScale[16];
+	FloatToString(flScale, sScale, sizeof(sScale));
+	
+	SetVariantString(sScale);
+	AcceptEntityInput(iEntity, "SetModelScale", iActivator, iCaller);
+}
+
+stock void DelayNextWeaponAttack(int iWeapon, float flDelay)
+{
+	float flNextAttack = GetGameTime() + flDelay;
+	SetEntPropFloat(iWeapon, Prop_Send, "m_flNextPrimaryAttack", flNextAttack);
+	SetEntPropFloat(iWeapon, Prop_Send, "m_flNextSecondaryAttack", flNextAttack);
+}


### PR DESCRIPTION
* Fixes aim target filter passing on friendly bosses (addresses #433)
* Prevents lunging bosses from attacking (addresses #434)
* Attempts to fix players sometimes either spawning without some weapons, or with the default weapons in slots that shouldn't behave that way (needs gamedata update)
* Fixes Vagineer's Sentry Gun and Seeldier Minion's model scaling not properly updating collision/hitboxes, meaning players shouldn't get stuck on them anymore (or at least as easily)
    * This might make Vagineer's Sentry Gun harder to place on displacements and slopes, beware!
* Adds TF2-specific collision groups, extending the collision group enum, even though they're unused by the gamemode at the moment