### PR TITLE
Fix a couple more things

### DIFF
--- a/addons/sourcemod/scripting/saxtonhale.sp
+++ b/addons/sourcemod/scripting/saxtonhale.sp
@@ -1585,7 +1585,7 @@ public Action Client_OnTakeDamageAlive(int victim, int &attacker, int &inflictor
 		{
 			int iBuilder = g_iTelefragBuilder;
 			if (iBuilder)
-				g_iPlayerAssistDamage[iBuilder] = RoundToNearest(damage);
+				g_iPlayerAssistDamage[iBuilder] += RoundToNearest(damage);
 		}
 	}
 	

--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -1,8 +1,10 @@
 static TagsParams g_tOngoingParams;
+static float g_flLastFunctionCallTime;
 
 void TagsDamage_Init()
 {
 	g_tOngoingParams = new TagsParams();
+	g_flLastFunctionCallTime = 0.0;
 }
 
 public Action TagsDamage_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
@@ -46,7 +48,8 @@ public Action TagsDamage_OnTakeDamageAlive(int victim, int &attacker, int &infli
 	g_tOngoingParams.CopyData(tParams);
 	
 	// SDKHooks_TakeDamage only goes through OnTakeDamageAlive, so if we didn't already get our params info, do so now
-	if (tParams.Size <= 0)
+	// ...also check if the last known damage wasn't done this frame, since some things call OnTakeDamage but not OnTakeDamageAlive
+	if (tParams.Size <= 0 || g_flLastFunctionCallTime != GetGameTime())
 		TagsDamage_CallFunctions(tParams, victim, attacker, inflictor, damage, damagetype, weapon, damagecustom);
 	
 	//Change damage values from params
@@ -83,13 +86,15 @@ public Action TagsDamage_OnTakeDamageAlive(int victim, int &attacker, int &infli
 		action = Plugin_Changed;
 	}
 	
-	g_tOngoingParams.Clear();
 	delete tParams;
 	return action;
 }
 
 void TagsDamage_CallFunctions(TagsParams tParams, int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, int damagecustom)
 {
+	g_tOngoingParams.Clear();
+	g_flLastFunctionCallTime = GetGameTime();
+	
 	tParams.SetInt("victim", victim);
 	tParams.SetInt("attacker", attacker);
 	tParams.SetInt("inflictor", inflictor);


### PR DESCRIPTION
* Fixes telefrags setting the teleport builder's assist damage to 8000, rather than adding 8000 to it
* Fixes modified damage dealt to a player that goes through OnTakeDamage, but not OnTakeDamageAlive, being stored and applied to the next instance of unmodified damage by any player, including bosses
    * Example: a boss hits a player wearing the Razorback, damage will be set to 1 and the victim will receive the bonked condition. Damage to bonked players goes through OnTakeDamage, but not OnTakeDamageAlive, which means the 1 damage will never be cleared when received by the victim, and will override the next damage anyone takes, from either team, as long as it's not modified by the config again.
        * This would be a lot more common if any boss could get the bonked condition, for example.