### PR TITLE
Fix damage taken still being incorrect in some cases

### DIFF
--- a/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
+++ b/addons/sourcemod/scripting/vsh/tags/tags_damage.sp
@@ -47,10 +47,13 @@ public Action TagsDamage_OnTakeDamageAlive(int victim, int &attacker, int &infli
 	TagsParams tParams = new TagsParams();
 	g_tOngoingParams.CopyData(tParams);
 	
-	// SDKHooks_TakeDamage only goes through OnTakeDamageAlive, so if we didn't already get our params info, do so now
+	// Some things only go through OnTakeDamageAlive, like SDKHooks_TakeDamage and fall damage from stomping (to the stomper, not the victim!) so if we didn't already get our params info, do so now
 	// ...also check if the last known damage wasn't done this frame, since some things call OnTakeDamage but not OnTakeDamageAlive
 	if (tParams.Size <= 0 || g_flLastFunctionCallTime != GetGameTime())
 		TagsDamage_CallFunctions(tParams, victim, attacker, inflictor, damage, damagetype, weapon, damagecustom);
+	
+	// We don't need this anymore
+	g_tOngoingParams.Clear();
 	
 	//Change damage values from params
 	Action action = Plugin_Continue;


### PR DESCRIPTION
Addresses #441, fixes tags-damage-parameters not being cleared if someone specifically deals modified damage then takes a different instance of unmodified damage that only goes through OnTakeDamageAlive and not OnTakeDamage on the same frame (such as an attacker dealing modified stomping damage then taking 0-1 damage from the stomp fall damage reduction).