### PR TITLE
Updated dome damage for red team

### DIFF
--- a/addons/sourcemod/scripting/vsh/dome.sp
+++ b/addons/sourcemod/scripting/vsh/dome.sp
@@ -502,7 +502,7 @@ public Action Dome_TimerBleed(Handle hTimer)
 				else
 				{
 					//Calculate damage, the longer the player is outside of the dome, the more damage it deals
-					flDamage = Pow(2.0, g_flDomePlayerTime[iClient]);
+					flDamage = Pow(1.1, g_flDomePlayerTime[iClient]);
 				}
 				
 				if (flDamage < 1.0)


### PR DESCRIPTION
I feel like _dome_ is disproportionally harsher to red team compared to bosses, as it tends to accumulate, and does so very quickly. 7-9 seconds is the limit you can spend outside, maybe few seconds longer if you healed in-between ticks, while _dome_ becomes threatening to hale only in the last moments, when most people are usually dead.

This change should make walking outside _dome_ a bit more forgiving for red team, if before 7 seconds was enough to kill light classes, with this change it should take 15 seconds, 9 seconds could kill heavy before, now it will take 22 seconds. 
Re-entering the _dome_ will also deal less damage if you've already accumulated some, 100 damage after 10 seconds before, 12 damage after this change. Makes healing more effective to counteract the damage, too.

This change should allow red to stay outside 2–3 times longer on average, potentially being able to re-claim the point, or kill badly wounded Hale. Compared to average round time, it shouldn't increase round duration more than 5%. 