### PR TITLE
Remove Battalions Resistance from Hales rage

### DIFF
--- a/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_hale.sp
@@ -130,7 +130,6 @@ public void SaxtonHale_Create(SaxtonHaleBase boss)
 	boss.SetPropFloat("RageAddCond", "RageCondSuperRageMultiplier", 2.0);
 	RageAddCond_AddCond(boss, TFCond_SpeedBuffAlly);	// Speed boost effect
 	RageAddCond_AddCond(boss, TFCond_MegaHeal);			// Knockback & stun immunity
-	RageAddCond_AddCond(boss, TFCond_DefenseBuffed);	// Battalion's Resistance
 
 	boss.CreateClass("Lunge");
 	


### PR DESCRIPTION
Hale is overperforming right now, and I feel like this is an appropriate nerf for him. It also makes the Kritzkrieg more usable now that it's not immediately shut down by rage.