### PR TITLE
Dragon's fury airblast cooldown

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1016,21 +1016,7 @@
 				"block"				"pyro-primary-airblast"	//Phlogistinator don't have airblast
 			}
 		}
-		
-		"1178"	//Dragon's Fury
-		{
-			"desp"			"Dragon's Fury: {negative}+50% airblast cooldown"
-			
-			"spawn"
-			{
-				"Tags_Airblast"
-				{
-					"override"		"pyro-primary-airblast"
-					"cooldown"		"12"
-				}
-			}
-		}
-		
+
 		"1179"	//Thermal Thruster
 		{
 			"desp"			"Thermal Thruster: {positive}Stomping deals 1024 damage"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1026,7 +1026,7 @@
 				"Tags_Airblast"
 				{
 					"override"		"pyro-primary-airblast"
-					"cooldown"		"18"
+					"cooldown"		"12"
 				}
 			}
 		}


### PR DESCRIPTION
Dragon's Fury doesn't seem that much stronger to warrant 50% longer airblast cooldown, especially when it already uses pretty big number at base 