### PR TITLE
Eureka Effect taunt speed buff

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1721,8 +1721,8 @@
 		
 		"589"	//Eureka Effect
 		{
-			"desp"			"Eureka Effect: {negative}-50% damage penalty on telefrags"
-			
+			"desp"			"Eureka Effect: {positive}+25% faster taunt speed, {negative}-65% damage penalty on telefrags"
+			"attrib"		"201 ; 1.25"
 			"attackdamage"
 			{
 				"filter"
@@ -1734,7 +1734,7 @@
 				"params"
 				{
 					"passive"		"1"	
-					"multiply"		"0.5"
+					"multiply"		"0.35"
 				}
 			}
 		}


### PR DESCRIPTION
Decent taunt speed buff for Eureka Effect at the cost of even less telefrag damage to make it more reactive. Bosses move pretty fast, and usually have movement abilities, so by default, in ~2 seconds it takes for teleport to activate, they usually get you.
Since Eureka Effect already has significant downsides compared to other wrenches, I think it doesn't need more on top of it. Existence of dome ensures engineer can't run away too much, and this buff reduces teleport activation to ~1.5 seconds; it's not instant. It's true that engineer in general is very strong, but Eureka downsides mean that he'll likely build less sentries/spend more time looking for metal, it's purely defensive wrench that takes away your damage potential, which sounds like a decent trade-off. 

If telefrags become problematic again, damage can be tweaked further.