### PR TITLE
Vaccinator buff

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1815,8 +1815,8 @@
 		
 		"998"	//Vaccinator
 		{
-			"desp"			"Vaccinator: {positive}+20% max overheal, -50% overheal decay rate"
-			"attrib"		"11 ; 1.20 ; 13 ; 1.50"
+			"desp"			"Vaccinator: {positive}+30% max overheal, -60% overheal decay rate"
+			"attrib"		"11 ; 1.30 ; 13 ; 1.60"
 		}
 		
 		"173"	//Vita-Saw


### PR DESCRIPTION
Not a long of thought behind this one, just making existing Vaccinator overheal effects stronger, since vaccinator doesn't do anything with melee damage. More overheal and slower overheal decay.