### PR TITLE
Detonator push force

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1098,8 +1098,8 @@
 		
 		"351"	//Detonator
 		{
-			"desp"			"Detonator: {positive}+200% afterburn damage bonus"
-			"attrib"		"71 ; 3.0"
+			"desp"			"Detonator: {positive}+150% self damage push force"
+			"attrib"		"58 ; 2.5"
 		}
 		
 		"593"	//Third Degree


### PR DESCRIPTION
Bringing back old attribute Detonator used to have in VSH before Rewrite, super detonator jumps! Removed afterburn damage bonus to make it a pure movement tool