### PR TITLE
Buffalo Steak real damage resistance

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1571,7 +1571,7 @@
 				
 				"params"
 				{
-					"multiply"		"0.56"	//Multiply damage by 0.56 if under steak effect
+					"multiply"		"0.585"	//Multiply damage by 0.585 if under steak effect
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1561,6 +1561,7 @@
 		{
 			"desp"			"Buffalo Steak Sandvich: {positive}Gives +30% damage resistance"
 			"attrib" 		"798 ; 1.0"
+			
 			"takedamage"
 			{
 				"filter"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1571,7 +1571,7 @@
 				
 				"params"
 				{
-					"multiply"		"0.7"	//Multiply damage by 0.7 if under steak effect
+					"multiply"		"0.56"	//Multiply damage by 0.56 if under steak effect
 				}
 			}
 		}

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1560,7 +1560,7 @@
 		"311"	//Buffalo Steak Sandvich
 		{
 			"desp"			"Buffalo Steak Sandvich: {positive}Gives +30% damage resistance"
-			
+			"attrib" 		"798 ; 1.0"
 			"takedamage"
 			{
 				"filter"
@@ -1571,7 +1571,7 @@
 				
 				"params"
 				{
-					"multiply"		"0.585"	//Multiply damage by 0.585 if under steak effect
+					"multiply"		"0.7"	//Multiply damage by 0.7 if under steak effect
 				}
 			}
 		}


### PR DESCRIPTION
Since Buffalo Steak applies 20% damage vulnerability by default, VSH buff only results in -16% damage taken, which doesn't even help with damage threshold, you still die in 2 hits! This change applies real 30% damage resistance.