### PR TITLE
Warrior's Spirit buff

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1609,7 +1609,7 @@
 		
 		"310"	//Warrior's Spirit
 		{
-			"desp"			"Warrior's Spirit: {positive}Gain 75 health on hit"
+			"desp"			"Warrior's Spirit: {positive}Gain 120 health on hit"
 			
 			"attackdamage"
 			{
@@ -1618,9 +1618,9 @@
 					"victimuber"	"0"
 				}
 				
-				"Tags_AddHealth"	//Add 75 health
+				"Tags_AddHealth"	//Add 120 health
 				{
-					"amount"		"75"
+					"amount"		"120"
 				}
 			}
 		}


### PR DESCRIPTION
Since Half-Zatoichi exists, and heals exactly 100, with demo's faster move speed and shields, I think it's fair if Warrior's Spirit heal was increased, on a slower class, with 30% damage vulnerability. If we take +30% damage taken into account, the healing results in 94 health per hit. I don't think damage bonus matters much on a melee of the slowest class in the game, though it's probably meant to be used exclusively with steak (which further increases damage taken...)