### PR TITLE
Change Chargin' Targe resistance

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1253,10 +1253,21 @@
 				"Tags_AddCond"
 				{
 					"cond"			"26"	//...give a defense buff (with crit resistance) to the attacker...
-					"duration"		"6.0"	//...for 4 seconds.
+					"duration"		"6.0"	//...for 6 seconds.
 				}
 			}
-   		}
+			
+			"spawn"	//Called on spawn
+			{
+				"Tags_AddCond"
+				{
+					"delay"			"0.1"	//Must be in delay from spawn to make this work
+					
+					"cond"			"16"	//Minicrit
+					"duration"		"-1.0"	//Perma
+				}
+			}
+		}
 		
 		"1144"	//Festive Chargin' Targe
 		{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1246,17 +1246,8 @@
 		
 		"131"	//Chargin' Targe
 		{
-			"desp"			"Chargin' Targe: {positive}Gain a defense buff for 4 seconds on charge hit"
-			
-			"attackdamage" //When dealing damage with this weapon...
-			{				
-				"Tags_AddCond"
-				{
-					"cond"			"26"	//...give a defense buff (with crit resistance) to the attacker...
-					"duration"		"4.0"	//...for 4 seconds.
-				}
-			}
-			
+			"desp"			"Chargin' Targe: {positive}+15% damage resistance"
+			"attrib"		"412 ; 0.85"
 			"spawn"	//Called on spawn
 			{
 				"Tags_AddCond"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1246,19 +1246,17 @@
 		
 		"131"	//Chargin' Targe
 		{
-			"desp"			"Chargin' Targe: {positive}+15% damage resistance"
-			"attrib"		"412 ; 0.85"
-			"spawn"	//Called on spawn
-			{
+			"desp"			"Chargin' Targe: {positive}Gain a defense buff for 6 seconds on charge hit"
+			
+			"attackdamage" //When dealing damage with this weapon...
+			{				
 				"Tags_AddCond"
 				{
-					"delay"			"0.1"	//Must be in delay from spawn to make this work
-					
-					"cond"			"16"	//Minicrit
-					"duration"		"-1.0"	//Perma
+					"cond"			"26"	//...give a defense buff (with crit resistance) to the attacker...
+					"duration"		"6.0"	//...for 4 seconds.
 				}
 			}
-		}
+   		}
 		
 		"1144"	//Festive Chargin' Targe
 		{


### PR DESCRIPTION
Changes Chargin' Targe from active damage resistance you have to earn (requires minimum distance traveled + not hitting any teammates on impact) to passive 15%, to allow some interesting uses of Pain Train, Persian Persuader and Claidheamh Mòr. Will also allow Demoman to survive 1 hit without Booties or Eyelander. If new damage res proves to be problematic with certain bosses (50% fire + 15% general resistance against Pyro Car), fire damage resistance can be reduced.

As it is now, Chargin' Targe is outclassed by 2 other shields, I want Chargin' Targe to be the shield that enables some other less played weapons, as well as using it with popular choices, I suppose, there can never be enough damage resistance.