### PR TITLE
Flare Gun damage bonus

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1087,8 +1087,8 @@
 		
 		"39"	//Flare Gun
 		{
-			"desp"			"Flare Gun: {positive}+200% afterburn damage bonus"
-			"attrib"		"71 ; 3.0"
+			"desp"			"Flare Gun: {positive}+100% damage bonus"
+			"attrib"		"2 ; 2.0"
 		}
 		
 		"1081"	//Festive Flare Gun


### PR DESCRIPTION
Quite frankly, I don't think you can really buff Flare Gun in a meaningful way that won't change the functionality, aside from simply buffing damage. Flare Gun used to have +50% damage bonus in the past, but I'm not sure it really changed anything in how people choose Pyro secondary. I considered giving it less damage and faster projectile to make hitting enemies easier, but Manmelter already fills the niche of "Flaregun with faster projectile", so might as well make Flare Gun do what it does in base game better. Removed afterburn bonus since having both is overkill. 