### PR TITLE
Degreaser change

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1002,9 +1002,19 @@
 		
 		"215"	// Degreaser
 		{
-			"desp"			"Degreaser: {positive}-33% less afterburn damage penalty"
-			"attrib"		"72 ; 0.67"
+			"desp"			"Degreaser: {positive}This weapon holsters 60% faster, {positive}-2 second airblast cooldown"
+			"attrib"		"199 ; 0.4"
+   
+   			"spawn"
+			{
+				"Tags_Airblast"
+				{
+					"override"		"pyro-primary-airblast"
+					"cooldown"		"10"
+				}
+			}
 		}
+
 		
 		"594"	//Phlogistinator
 		{


### PR DESCRIPTION
As other Flamethrowers are focused on getting damage from their primary fire or afterburn, the purpose of Degreaser is to be a combo weapon. Faster holster speed will help it to combo with secondaries or melees, and 2 second lower airblast cooldown will serve a support role. Removed slightly lower afterburn to use normal tf2 value to empathize combo playstyle.