### PR TITLE
Scotsman's Skullcutter melee range

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1399,7 +1399,12 @@
 		{
 			"prefab"		"132"
 		}
-		
+
+		"172"	//Scotsman's Skullcutter
+		{
+			"desp"			"Scotsman's Skullcutter: {positive}+40% melee range"
+			"attrib"		"264 ; 1.4"
+  		
 		"404"	//Persian Persuader
 		{
 			"desp"			"Persian Persuader: {positive}Able to wall climb"


### PR DESCRIPTION
Scotsman's Skullcutter has pretty significant downside of lower move speed on use, and higher damage doesn't matter as much in vsh where damage thresholds don't exist for bosses (but it's still good!). Experimental buff for melee range that increases the reach from 72 HU to 100 HU. Skullcutter is pretty long weapon visually, longer melee reach can potentially be interesting to play around for demo using it as opposed to buffing damage further.