### PR TITLE
Warrior's Spirit nerf

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -1596,8 +1596,9 @@
 		
 		"310"	//Warrior's Spirit
 		{
-			"desp"			"Warrior's Spirit: {positive}Gain 120 health on hit"
-			
+			"desp"			"Warrior's Spirit: {positive}Gain 75 health on hit, {positive}-15% less damage vulnerability"
+			"attrib" 		"412 ; 1.15"
+   
 			"attackdamage"
 			{
 				"filter"
@@ -1605,9 +1606,9 @@
 					"victimuber"	"0"
 				}
 				
-				"Tags_AddHealth"	//Add 120 health
+				"Tags_AddHealth"	//Add 75 health
 				{
-					"amount"		"120"
+					"amount"		"75"
 				}
 			}
 		}


### PR DESCRIPTION
Small adjustment before previous buff even went live, instead of healing 45 hp more, Warrior's Spirit should have softer damage vulnerability.