### PR TITLE
Remove trainyard map config

### DIFF
--- a/addons/sourcemod/configs/vsh/maps.cfg
+++ b/addons/sourcemod/configs/vsh/maps.cfg
@@ -232,11 +232,6 @@
 		{
 			"vsh_dome_radius_start"	"2250"
 		}
-		"vsh_trainyard"
-		{
-			"vsh_dome_centre"		"160 128 64"
-			"vsh_dome_radius_start"	"4000"
-		}
 		"vsh_tranquil"
 		{
 			"vsh_dome_radius_start"	"2750"


### PR DESCRIPTION
cp position in updated map will be epic.

also removed specified dome radius, can go with default value.