### PR TITLE
Yeti rework Electric boogaloo

### DIFF
--- a/addons/sourcemod/scripting/vsh/abilities/ability_rage_meteor.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_rage_meteor.sp
@@ -28,14 +28,14 @@ public void RageMeteor_Create(SaxtonHaleBase boss)
 	g_flNextRocketIn[boss.iClient] = 0.0;
 
 	boss.SetPropFloat("RageMeteor", "Damage", 15.0);
-	boss.SetPropFloat("RageMeteor", "Speed", 400.0);
+	boss.SetPropFloat("RageMeteor", "Speed", 300.0);
 	boss.SetPropFloat("RageMeteor", "SpawnRadius", 150.0);
-	boss.SetPropFloat("RageMeteor", "MinAngle", 25.0);
-	boss.SetPropFloat("RageMeteor", "FreezeTime", 0.5);
+	boss.SetPropFloat("RageMeteor", "MinAngle", 80.0);
+	boss.SetPropFloat("RageMeteor", "FreezeTime", 3.0);
 	boss.SetPropFloat("RageMeteor", "SpawnDelay", 0.094);
 	boss.SetPropFloat("RageMeteor", "SpawnDelaySuper", 0.077);
-	boss.SetPropInt("RageMeteor", "SpawnCount", 55);
-	boss.SetPropInt("RageMeteor", "SpawnCountSuper", 125);
+	boss.SetPropInt("RageMeteor", "SpawnCount", 25);
+	boss.SetPropInt("RageMeteor", "SpawnCountSuper", 65);
 }
 
 public void RageMeteor_OnRage(SaxtonHaleBase boss)
@@ -100,7 +100,7 @@ public Action RageMeteor_OnAttackDamage(SaxtonHaleBase boss, int victim, int &in
 					
 				}
 
-				TF2_StunPlayer(victim, flDuration, 1.0, TF_STUNFLAG_SLOWDOWN);
+				TF2_StunPlayer(victim, flDuration, 0.5, TF_STUNFLAG_SLOWDOWN);
 				
 				delete g_hFreezeTimer[victim];
 

--- a/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_yeti.sp
@@ -73,7 +73,7 @@ public void Yeti_GetBossInfo(SaxtonHaleBase boss, char[] sInfo, int length)
 	StrCat(sInfo, length, "\nRage");
 	StrCat(sInfo, length, "\n- Damage requirement: 3500");
 	StrCat(sInfo, length, "\n- Rains hail down on to players in front of you");
-	StrCat(sInfo, length, "\n- Players hit will get frozen for 1 second");
+	StrCat(sInfo, length, "\n- Players hit will get slowed for 3 second");
 	StrCat(sInfo, length, "\n- 200%% Rage: Increased projectile count and spawn rate");
 }
 


### PR DESCRIPTION
-nerfed health and rage frequency
-nerfed rage radius and spread
-nerfed rage damage
-increased freeze time but changed from hard stun to 50% slow [will reduce or increase % based on player feedback]
-reduced spawn count of rage to reflect the reduced radius
