### PR TITLE
General QoL and small balance changes

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -2433,6 +2433,7 @@
 		"vsh_rps_enable"            "0"                 //Allow everyone use Rock Paper Scissors Taunt?
 		"vsh_blacklist_amount"		"2"					//How many bosses can a player blacklist? (0 disables this feature)
 		"vsh_top_score_outline"		"0"					//Should bosses see the top scoring player through walls via an outline?
+		"vsh_block_fake_hit_sound"	"1"					//Should melee hitsound desync be blocked by the gamemode?
 		
 		"vsh_boss_chance_saxton"    "0.30"              //% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)
 		"vsh_boss_chance_multi"     "0.15"              //% chance for next boss to be Multiple bosses (0.0 - 1.0)

--- a/addons/sourcemod/gamedata/vsh.txt
+++ b/addons/sourcemod/gamedata/vsh.txt
@@ -40,6 +40,12 @@
 				"linux"		"@_ZN16CObjectDispenser15CouldHealTargetEP11CBaseEntity"
 				"windows"	"\x55\x8B\xEC\x53\x56\x8B\x75\x08\x57\x8B\xF9\x8B\x87\x38\x01\x00\x00"
 			}
+			"CTFWeaponBaseMelee::DoSwingTraceInternal"
+			{
+  			  	"library"	"server"
+				"linux"		"@_ZN18CTFWeaponBaseMelee20DoSwingTraceInternalER10CGameTracebP10CUtlVectorIS0_10CUtlMemoryIS0_iEE"
+				"windows"	"\x53\x8B\xDC\x83\xEC\x08\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\x38\x05\x00\x00"
+			}
 		}
 		"Functions"
 		{
@@ -92,6 +98,28 @@
 						"type"	"objectptr"
 					}
 				}				
+			}
+			"CTFWeaponBaseMelee::DoSwingTraceInternal"
+			{
+				"signature"	"CTFWeaponBaseMelee::DoSwingTraceInternal"
+				"callconv"	"thiscall"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"trace"
+					{
+						"type"	"objectptr"
+					}
+					"bCleave"
+					{
+						"type"	"bool"
+					}
+					"pTargetTraceVector"
+					{
+						"type"	"vectorptr"
+					}
+				}
 			}
 		}
 		"Offsets"

--- a/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_dash_jump.sp
@@ -30,6 +30,13 @@ public void DashJump_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLengt
 		Format(sMessage, iLength, "%s\nDash charge: %d%%%%", sMessage, iCharge);
 }
 
+public void DashJump_OnArenaRoundStart(SaxtonHaleBase boss)
+{
+	float flTimeUntilMaxCharge = boss.GetPropFloat("DashJump", "Cooldown") * boss.GetPropFloat("DashJump", "MaxCharge");
+	g_flDashJumpCooldownWait[boss.iClient] = GetGameTime() + flTimeUntilMaxCharge;
+	boss.CallFunction("UpdateHudInfo", 0.0, flTimeUntilMaxCharge);	// Update every frame until dash charge maxes out
+}
+
 public void DashJump_OnButtonPress(SaxtonHaleBase boss, int iButton)
 {
 	if (iButton == IN_RELOAD && GameRules_GetRoundState() != RoundState_Preround && !TF2_IsPlayerInCondition(boss.iClient, TFCond_Dazed))

--- a/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
+++ b/addons/sourcemod/scripting/vsh/abilities/ability_lunge.sp
@@ -42,6 +42,13 @@ public void Lunge_GetHudInfo(SaxtonHaleBase boss, char[] sMessage, int iLength, 
 	}
 }
 
+public void Lunge_OnArenaRoundStart(SaxtonHaleBase boss)
+{
+	float flTimeUntilMaxCharge = boss.GetPropFloat("Lunge", "Cooldown");
+	g_flLungeCooldownWait[boss.iClient] = GetGameTime() + flTimeUntilMaxCharge;
+	boss.CallFunction("UpdateHudInfo", 0.0, flTimeUntilMaxCharge);	// Update every frame until charge maxes out
+}
+
 static bool CanLunge(SaxtonHaleBase boss)
 {
 	return !TF2_IsPlayerInCondition(boss.iClient, TFCond_Dazed) &&

--- a/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
+++ b/addons/sourcemod/scripting/vsh/bosses/boss_pyrocar.sp
@@ -288,7 +288,7 @@ public Action PyroCar_OnAttackDamageAlive(SaxtonHaleBase boss, int victim, int &
 			}
 		}
 		
-		g_hPyrocarHealTimer[victim] = CreateTimer(0.6, Timer_RemoveLessHealing, GetClientSerial(victim));
+		g_hPyrocarHealTimer[victim] = CreateTimer(1.0, Timer_RemoveLessHealing, GetClientSerial(victim));
 	}
 	
 	if (g_flPyrocarGasCharge[boss.iClient] <= g_iMaxGasPassers * g_flGasMinCharge)

--- a/addons/sourcemod/scripting/vsh/custommelee.sp
+++ b/addons/sourcemod/scripting/vsh/custommelee.sp
@@ -1,0 +1,152 @@
+#pragma semicolon 1
+#pragma newdecls required
+
+enum struct MeleeData
+{
+	int iEntity;
+	float flMeleeRange;
+	float flMeleeBounds;
+}
+
+static ArrayList g_aMeleeSavedData;
+static bool g_bGlobalNextSound[MAXPLAYERS + 1];
+
+void CustomMelee_Init()
+{
+	g_aMeleeSavedData = new ArrayList(sizeof(MeleeData));
+}
+
+void CustomMelee_OnMapStart()
+{
+	g_aMeleeSavedData.Clear();
+}
+
+void CustomMelee_OnEntityDestroyed(int iEntity)
+{
+	int iIndex = g_aMeleeSavedData.FindValue(iEntity);
+	if (iIndex != -1)
+		g_aMeleeSavedData.Erase(iIndex);
+}
+
+void CustomMelee_OnPluginEnd()
+{
+	int iEntity = INVALID_ENT_REFERENCE;
+	while ((iEntity = FindEntityByClassname(iEntity, "tf_weap*")) != INVALID_ENT_REFERENCE)
+	{
+		int iIndex = g_aMeleeSavedData.FindValue(iEntity);
+		if (iIndex != -1)
+			RestoreMeleeData(iEntity);
+	}
+}
+
+Action CustomMelee_OnSoundHook(int clients[MAXPLAYERS], int &numClients, int &entity, int &channel)
+{
+	if (channel == SNDCHAN_STATIC && entity > 0 && entity <= MaxClients)
+	{
+		// Play the server-sided sound to the client
+		if (g_bGlobalNextSound[entity])
+		{
+			g_bGlobalNextSound[entity] = false;
+
+			clients[numClients] = entity;
+			numClients++;
+			return Plugin_Changed;
+		}
+	}
+	
+	return Plugin_Continue;
+}
+
+void CustomMelee_CalcIsAttackCritical(int iWeapon, const char[] sClassname)
+{
+	if (!g_ConfigConvar.LookupBool("vsh_block_fake_hit_sound"))
+		return;
+	
+	int iOwner = GetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity");
+	if (iOwner <= 0 || iOwner > MaxClients)
+		return;
+	
+	if (TF2_GetItemInSlot(iOwner, TFWeaponSlot_Melee) != iWeapon)
+		return;
+	
+	// Ignore spy knives with this logic for now
+	if (StrEqual(sClassname, "tf_weapon_knife"))
+		return;
+	
+	SaveMeleeData(iWeapon);
+}
+
+void CustomMelee_DoSwingTracePre(int iWeapon)
+{
+	if (!g_ConfigConvar.LookupBool("vsh_block_fake_hit_sound"))
+		return;
+	
+	RestoreMeleeData(iWeapon);
+}
+
+void CustomMelee_DoSwingTracePost(int iWeapon, bool bHit)
+{
+	if (!g_ConfigConvar.LookupBool("vsh_block_fake_hit_sound"))
+		return;
+	
+	int iIndex = g_aMeleeSavedData.FindValue(iWeapon);
+	if (iIndex == -1)
+		return;
+	
+	TF2Attrib_SetByName(iWeapon, "melee bounds multiplier", 0.0);
+	TF2Attrib_SetByName(iWeapon, "melee range multiplier", 0.0);
+	
+	if (bHit)
+	{
+		// Play the server-sided sound to the client
+		int iOwner = GetEntPropEnt(iWeapon, Prop_Send, "m_hOwnerEntity");
+		if (iOwner > 0 && iOwner <= MaxClients)
+		{
+			char sClassname[64];
+			GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+			if (!StrEqual(sClassname, "tf_weapon_knife"))
+				g_bGlobalNextSound[iOwner] = true;
+		}
+	}
+}
+
+static void SaveMeleeData(int iWeapon)
+{
+	float flBounds = TF2Attrib_HookValueFloat(1.0, "melee_bounds_multiplier", iWeapon);
+	float flRange = TF2Attrib_HookValueFloat(1.0, "melee_range_multiplier", iWeapon);
+	
+	int iIndex = g_aMeleeSavedData.FindValue(iWeapon);
+	if (flBounds > 0.0 || flRange > 0.0 || iIndex == -1)
+	{
+		MeleeData data;
+		data.iEntity = iWeapon;
+		data.flMeleeBounds = flBounds;
+		data.flMeleeRange = flRange;
+		
+		if (iIndex != -1)
+			g_aMeleeSavedData.SetArray(iIndex, data);
+		else
+			g_aMeleeSavedData.PushArray(data);
+	}
+
+	TF2Attrib_SetByName(iWeapon, "melee bounds multiplier", 0.0);
+	TF2Attrib_SetByName(iWeapon, "melee range multiplier", 0.0);
+}
+
+static void RestoreMeleeData(int iWeapon)
+{
+	int iIndex = g_aMeleeSavedData.FindValue(iWeapon);
+	if (iIndex == -1)
+		return;
+	
+	MeleeData data;
+	g_aMeleeSavedData.GetArray(iIndex, data, sizeof(data));
+	
+	if (data.flMeleeBounds > 0.0)
+		TF2Attrib_SetByName(iWeapon, "melee bounds multiplier", data.flMeleeBounds);
+	
+	if (data.flMeleeRange > 0.0)
+		TF2Attrib_SetByName(iWeapon, "melee range multiplier", data.flMeleeRange);
+	
+	g_aMeleeSavedData.Erase(iIndex);
+}

--- a/addons/sourcemod/scripting/vsh/event.sp
+++ b/addons/sourcemod/scripting/vsh/event.sp
@@ -206,12 +206,14 @@ public void Event_RoundArenaStart(Event event, const char[] sName, bool bDontBro
 		}
 	}
 	
-	//Refresh boss health from player count
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
 		SaxtonHaleBase boss = SaxtonHaleBase(iClient);
 		if (boss.bValid)
 		{
+			boss.CallFunction("OnArenaRoundStart");
+			
+			//Refresh boss health from player count
 			int iHealth = boss.CallFunction("CalculateMaxHealth");
 			boss.iMaxHealth = iHealth;
 			boss.iHealth = iHealth;

--- a/addons/sourcemod/scripting/vsh/menu.sp
+++ b/addons/sourcemod/scripting/vsh/menu.sp
@@ -37,10 +37,11 @@ void Menu_Init()
 	Format(buffer, sizeof(buffer), "%s \nKirillian - Several boss model addition", buffer);
 	Format(buffer, sizeof(buffer), "%s \nSediSocks - Announcer model", buffer);
 	Format(buffer, sizeof(buffer), "%s \nArtvin & Crusty - Modified Saxton Hale model", buffer);
+	Format(buffer, sizeof(buffer), "%s \nArtvin - Melee hitsound desync fix", buffer);
 	Format(buffer, sizeof(buffer), "%s \nsarysa - Modified Yeti concept", buffer);
 	Format(buffer, sizeof(buffer), "%s \nAlex Turtle & Chillax - Original Rewrite test subjects", buffer);
 	Format(buffer, sizeof(buffer), "%s \nwo - Test subject", buffer);
-	Format(buffer, sizeof(buffer), "%s \nRedSun - Host community!", buffer);
+	Format(buffer, sizeof(buffer), "%s \nRed Sun - Host community!", buffer);
 	g_hMenuCredits.SetTitle(buffer);
 	g_hMenuCredits.AddItem("back", "<- Back");
 	

--- a/addons/sourcemod/scripting/vsh/sdk.sp
+++ b/addons/sourcemod/scripting/vsh/sdk.sp
@@ -191,6 +191,18 @@ void SDK_Init()
 	else
 		DHookEnableDetour(hHook, true, Hook_CouldHealTarget);
 	
+	hHook = DHookCreateFromConf(hGameData, "CTFWeaponBaseMelee::DoSwingTraceInternal");
+	if (hHook == null)
+	{
+		LogMessage("Failed to create hook: CTFWeaponBaseMelee::DoSwingTraceInternal!");
+	}
+	else
+	{
+		DHookEnableDetour(hHook, false, Hook_DoSwingTraceInternalPre);
+		DHookEnableDetour(hHook, true, Hook_DoSwingTraceInternalPost);
+	}
+		
+	
 	delete hHook;
 	delete hGameData;
 	
@@ -399,6 +411,18 @@ public MRESReturn Hook_CouldHealTarget(int iDispenser, Handle hReturn, Handle hP
 		return MRES_Supercede;
 	}
 	
+	return MRES_Ignored;
+}
+
+MRESReturn Hook_DoSwingTraceInternalPre(int iEntity, DHookReturn ret, Handle hParams)
+{
+	CustomMelee_DoSwingTracePre(iEntity);
+	return MRES_Ignored;
+}
+
+MRESReturn Hook_DoSwingTraceInternalPost(int iEntity, DHookReturn ret, Handle hParams)
+{
+	CustomMelee_DoSwingTracePost(iEntity, ret.Value);
 	return MRES_Ignored;
 }
 


### PR DESCRIPTION
- Added `vsh_block_fake_hit_sound`, ported from FF2 Rewrite, which stops clientside melee hitsound desync (it doesn't do anything beside that). Requires gamedata update.
- Added the `OnArenaRoundStart` boss function, which is pretty self-explanatory.
- Saxton Hale's Lunge and Bonk Boy's Dash now start uncharged, to match other movement-heavy abilities, addresses #443.
- Pyrocar's antiheal on flamethrower hit now takes slightly longer to wear off (from 0.6 to 1 second).
- Added some basic blacklist data gathering stuff.