### PR TITLE
zatoichi hit self on miss

### DIFF
--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -425,14 +425,14 @@
 						"damagetype"	"crit"			//Force crit
 						"damagetype"	"noknockback"	//Disable knockback
 					}
-					
+
 					"Tags_OnBackstab"	//Do backstab effects
 					{
 						"target"		"victim"
 					}
 				}
 			}
-			
+
 			"PDA2"
 			{
 				"takedamage"
@@ -441,13 +441,13 @@
 					{
 						"cond"			"4"		//Cloaked
 					}
-					
+
 					"params"
 					{
 						"multiply"		"0.4"	//Multiply damage by x0.4 if cloaked
 					}
 				}
-				
+
 				"takedamage"
 				{
 					"filter"
@@ -455,13 +455,13 @@
 						"cond"			"4"		//Cloaked
 						"attackweapon"	"melee"	//Is attacked from melee weapon?
 					}
-					
+
 					"Tags_SetEntProp"		//Reduce cloak meter
 					{
 						"target"		"client"
 						"type"			"float"
 						"prop"			"m_flCloakMeter"
-						
+
 						"math"			"multiply"	//Multiply current cloak by "value"
 						"value"			"0.1"
 					}
@@ -469,15 +469,16 @@
 			}
 		}
 	}
-	
+
 	"weapons"
 	{
 		// MULTI CLASS
-		
+
 		"357"	//Half-Zatoichi
 		{
 			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit"
-			
+			"attrib"		"204 ; 1.0"
+
 			"attackdamage"
 			{
 				"filter"
@@ -485,12 +486,12 @@
 					"victimuber"	"0"
 					"ignoreminions"	"1"
 				}
-				
+
 				"Tags_AddHealthBase"	//Add 50% of base health
 				{
 					"amount"		"0.5"
 				}
-				
+
 				"Tags_SetEntProp"		//Set bloody state
 				{
 					"target"		"melee"
@@ -498,7 +499,7 @@
 					"prop"			"m_bIsBloody"
 					"value"			"1"
 				}
-				
+
 				"Tags_SetEntProp"		//Set kill count
 				{
 					"target"		"client"
@@ -508,13 +509,13 @@
 				}
 			}
 		}
-		
+
 		"154"	//Pain Train
 		{
 			"desp"			"Pain Train: {positive}5x capture rate, {negative}+10% damage vulnerability from all sources"
 			"attrib"		"67 ; 1.0 ; 68 ; 4.0 ; 412 ; 1.1"
 		}
-		
+
 		"415"	//Reserve Shooter
 		{
 			"attackdamage"
@@ -523,7 +524,7 @@
 				{
 					"victimcond"		"81" // Blast jumping
 				}
-				
+
 				// Scuffed way of dealing minicrits
 				"Tags_AddCond"
 				{
@@ -532,53 +533,53 @@
 				}
 			}
 		}
-		
-		
+
+
 
 		// SCOUT
-		
+
 		"45"	//Force-A-Nature
 		{
 			"desp"			"Force-A-Nature: {negative}-50% slower reload time"
 			"attrib"		"96 ; 1.50"
 		}
-		
+
 		"1078"	//Festive Force-A-Nature
 		{
 			"prefab"		"45"
 		}
-		
+
 		"1103"	//Back Scatter
 		{
 			"desp"			"Back Scatter: {positive}Crits from behind and at close range"
 			"attrib"		"619 ; 0.0"
-			
+
 			"attackdamage"
 			{
 				"filter"
 				{
 					"hitfrombehind"		"512"
 				}
-				
+
 				"params"
 				{
 					"damagetype"		"crit"
 				}
 			}
 		}
-		
+
 		"772"	//Baby Face Blaster
 		{
 			"desp"			"Baby Face Blaster: {negative}Boost takes up to 400 damage to fully charge and is reset on stun"
 			"attrib"		"793 ; 1.0 ; 418 ; 0.0"		//Replacing boost meter with hype meter increases damage requirement for max speed to around 400
-			
+
 			"think"	//used to be from TF2_OnConditionAdded, but prob more easier if going for this way
 			{
 				"filter"
 				{
 					"cond"			"15"	//Dazed
 				}
-				
+
 				"Tags_SetEntProp"
 				{
 					"target"		"client"
@@ -586,7 +587,7 @@
 					"prop"			"m_flHypeMeter"
 					"value"			"0.0"
 				}
-				
+
 				"Tags_AddCond"
 				{
 					"cond"			"32"	//Speed boost

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -476,8 +476,8 @@
 
 		"357"	//Half-Zatoichi
 		{
-			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, {negative} hit self on miss"
-			"attrib"		"204 ; 1.0"
+			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, no Honorbound, {negative} hit self on miss, +100% damage to self"
+			"attrib"		"204 ; 1.0 ; 226 ; 0.0 ; 207 ; 2.0"
 
 			"attackdamage"
 			{

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -476,7 +476,7 @@
 
 		"357"	//Half-Zatoichi
 		{
-			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit"
+			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, {negative} hit self on miss"
 			"attrib"		"204 ; 1.0"
 
 			"attackdamage"

--- a/addons/sourcemod/configs/vsh/vsh.cfg
+++ b/addons/sourcemod/configs/vsh/vsh.cfg
@@ -476,7 +476,7 @@
 
 		"357"	//Half-Zatoichi
 		{
-			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, no Honorbound, {negative} hit self on miss, +100% damage to self"
+			"desp"			"Half-Zatoichi: {positive}Gain 50% of base health on hit, no Honorbound,{negative} hit self on miss, +100% damage to self"
 			"attrib"		"204 ; 1.0 ; 226 ; 0.0 ; 207 ; 2.0"
 
 			"attackdamage"


### PR DESCRIPTION
lol, lmao even
In case it is too much of a nerf (doubt) it can always be reverted
- hit self on miss
- no honorbound (honorbound self hit instakills)
- +100% self damage (makes miss 65dmg)